### PR TITLE
feat(v0.6-polish): 5 nice-to-have items — toast, shortcuts, perf, tests, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ electron-builder.yml.local
 # Vault data (never commit)
 *.sqlite
 *.sqlite-journal
+/.claude/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Markdown locale come fonte unica di verità, database strutturati come Notion, grafo di connessioni come Obsidian. In futuro: AI-native (semantic search, auto-link, agent organizzativi).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-alpha%20%E2%80%94%20v0.1-orange)](#stato)
+[![Status](https://img.shields.io/badge/status-alpha%20%E2%80%94%20v0.5-orange)](#stato)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 [Filosofia](#filosofia--perché-Ziba) ·
@@ -42,7 +42,7 @@ I tuoi dati restano file `.md` con frontmatter YAML sul tuo disco. Sincronizzabi
 
 ## Stato
 
-> **Alpha — v0.3 in costruzione.** Non è ancora installabile come app distribuita. Funziona solo in modalità sviluppo, ma le funzionalità centrali (vault, editor, wikilink/backlink, search FTS5, database view, grafo globale, callout) sono cablate end-to-end.
+> **Alpha — v0.5 shipped, v0.6 in progettazione.** Non è ancora installabile come bundle distribuito. Funziona solo in modalità sviluppo (`pnpm dev`), ma il core è completo end-to-end: vault locale, editor a blocchi con wikilink/backlink, search FTS5, database con vista tabella/kanban/calendario, grafo globale, callout, embed `![[]]`, math LaTeX, IPC error surface tipizzato, toast UI. La base test è 340+ casi (140 core + 200 desktop) con typecheck e lint puliti.
 
 ## Funzionalità
 
@@ -77,6 +77,15 @@ I tuoi dati restano file `.md` con frontmatter YAML sul tuo disco. Sincronizzabi
 - 🗓️ **Calendar view** — sub-mode del Database: griglia mensile italiana (Lun-Dom), navigazione prev/next/oggi, note posizionate nel giorno della loro property data. Click → apre.
 - ↪️ **Embed block** — `![[Nota]]` mostra il contenuto di un'altra nota inline (read-only). Markdown roundtrip Obsidian-compatible. Lazy-load del target.
 - ∑ **Math (KaTeX)** — formule LaTeX con `$$..$$` block e `$..$` inline. Click sul rendering → editor LaTeX live preview. Markdown roundtrip nativo.
+
+### v0.5 — Hardening + UX polish (✅ shipped)
+
+- 🛡️ **IPC error surface tipizzato** — `IpcErrorCode` derivato dal type union, `extractIpcErrorCode` / `ipcErrorMessage` helper round-trippano `code` su due path indipendenti (own property + `[CODE]` message prefix). Defense-in-depth contro structured-clone changes futuri di Electron.
+- 🍞 **Toast surface globale** — sostituisce `window.alert` ovunque. Non-blocking, color-coded per kind (info/success/warning/error), auto-dismiss configurabile, `role="alert"` per gli errori. Tutte le mutazioni della sidebar passano attraverso il toast.
+- ⚙️ **Two-stage error split nelle mutazioni** — IPC failure dice "Impossibile X"; refresh/follow-up failure dice "X riuscito ma aggiornamento fallito" (truthful — l'azione È accaduta sul disco). Pinned da test dedicati.
+- ⌨️ **Keyboard shortcuts** — `Cmd/Ctrl+S` salva, `Cmd/Ctrl+N` apre la prompt nuova nota, `Cmd/Ctrl+K` (già v0.2) apre la search palette.
+- 🏗️ **Refactor**: Sidebar 553 → ~340 righe (`useSidebarMutations` hook + `<SidebarDialogs>` component); `index-store.sqlite.ts` 882 → 745 con query-builder estratto come modulo puro; `Fragment` discriminated union (`predicate / always-false / always-true`) consente short-circuit della query quando un filtro è unsatisfiable.
+- 🎨 **DST anchor**, **KaTeX LRU cache**, **scanInlineMath** Pandoc-style guards, **CalendarView/BoardView memo stability** con `EMPTY_ROWS` frozen const.
 
 ### In arrivo
 
@@ -197,7 +206,10 @@ pnpm --filter ziba-desktop run dist:linux   # AppImage + .deb
 | ✅ v0.2 | Power editing | Search FTS5 (Cmd+K), property editor, tag system, slash menu, mini-graph |
 | ✅ v0.3 | Database & graph | Database table view, grafo globale interattivo, callout block proper |
 | ✅ v0.4 | DB sub-views + blocchi | Kanban view, calendar view, embed `![[...]]`, math (KaTeX) `$$...$$` |
-| v0.5 (next) | Polish + power-user | Property drag handles, theme switcher, Sidebar refactor, plugin system foundation |
+| ✅ v0.5 | Hardening + UX polish | IPC error surface, toast UI, two-stage error split, Cmd+S/Cmd+N shortcuts, Sidebar refactor, query-builder split |
+| v0.6 (next) | Plugin system foundation | Manifest + capabilities + lifecycle, sandboxed plugin contexts, first-party plugin examples |
+| v1.0 | Web build + sync | Web app via OPFS / remote sync, plugin marketplace, theme switcher, multi-vault |
+| v1.x | AI-native | Semantic search, auto-link, agent organizzativi |
 | v1.0 | Multi-piattaforma | Web app, plugin system, sync via filesystem-cloud (Dropbox/iCloud/Drive) |
 | v1.x | AI native | Embeddings locali, semantic search, auto-link suggestions, Q&A sul vault, agent organizzativi |
 | v1.5+ | Mobile | Expo app (iOS/Android), sync server custom |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,12 +18,12 @@
     "clean": "rimraf out dist .turbo"
   },
   "dependencies": {
-    "@ziba/core": "workspace:*",
     "@tiptap/core": "^2.10.3",
     "@tiptap/pm": "^2.10.3",
     "@tiptap/react": "^2.10.3",
     "@tiptap/starter-kit": "^2.10.3",
     "@tiptap/suggestion": "^2.10.3",
+    "@ziba/core": "workspace:*",
     "better-sqlite3": "^11.5.0",
     "chokidar": "^3.6.0",
     "clsx": "^2.1.1",
@@ -34,7 +34,8 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
-    "@ziba/tsconfig": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.11",
     "@types/katex": "^0.16.7",
     "@types/node": "^20.16.13",
@@ -42,6 +43,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "@vitest/coverage-v8": "^2.1.0",
+    "@ziba/tsconfig": "workspace:*",
     "autoprefixer": "^10.4.20",
     "electron": "^32.2.0",
     "electron-builder": "^25.1.8",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { installMockIpc } from './test/mock-ipc';
+import { App } from './App';
+import { useEditorStore } from './stores/editor';
+import { useSearchStore } from './stores/search';
+import { useUiStore } from './stores/ui';
+import { useVaultStore } from './stores/vault';
+
+// Smoke + integration tests for the global keyboard shortcuts wired
+// in App.tsx. We render the full App (so the keydown listener is
+// actually attached to `window`) and dispatch synthetic events.
+//
+// Each test exercises one shortcut path and asserts that the matching
+// store action fired (or that the editor save was triggered) — that's
+// the contract the App is responsible for. The downstream behaviour
+// (palette opens, prompt dialog appears, save round-trips through IPC)
+// has its own tests.
+
+beforeEach(() => {
+  installMockIpc();
+  // Pretend a vault is open: the App short-circuits the shortcuts when
+  // `current === null`, so without this stub we'd be testing the
+  // empty-state branch.
+  useVaultStore.setState({
+    current: { root: '/test', name: 'test', openedAt: 0 },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function dispatchShortcut(key: string, opts: { shift?: boolean; alt?: boolean } = {}): void {
+  const e = new KeyboardEvent('keydown', {
+    key,
+    metaKey: true,
+    ctrlKey: true,
+    shiftKey: opts.shift ?? false,
+    altKey: opts.alt ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(e);
+}
+
+describe('App keyboard shortcuts', () => {
+  it('Cmd+K opens the search palette', () => {
+    const openSpy = vi.fn();
+    useSearchStore.setState({ openPalette: openSpy });
+
+    render(<App />);
+    dispatchShortcut('k');
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+S triggers editor.save when there is a dirty note', () => {
+    const saveSpy = vi.fn(async () => undefined);
+    useEditorStore.setState({
+      currentPath: 'foo.md',
+      currentNote: {
+        path: 'foo.md',
+        title: 'foo',
+        frontmatter: {},
+        content: 'body',
+        wikilinks: [],
+        mtimeMs: 0,
+      },
+      dirty: true,
+      save: saveSpy,
+    });
+
+    render(<App />);
+    dispatchShortcut('s');
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+S is a no-op when no note is open', () => {
+    const saveSpy = vi.fn(async () => undefined);
+    useEditorStore.setState({
+      currentPath: null,
+      currentNote: null,
+      dirty: false,
+      save: saveSpy,
+    });
+
+    render(<App />);
+    dispatchShortcut('s');
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+S is a no-op when the note is clean (not dirty)', () => {
+    const saveSpy = vi.fn(async () => undefined);
+    useEditorStore.setState({
+      currentPath: 'foo.md',
+      currentNote: {
+        path: 'foo.md',
+        title: 'foo',
+        frontmatter: {},
+        content: 'body',
+        wikilinks: [],
+        mtimeMs: 0,
+      },
+      dirty: false,
+      save: saveSpy,
+    });
+
+    render(<App />);
+    dispatchShortcut('s');
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+Shift+S does not save (reserved for future "Save as")', () => {
+    const saveSpy = vi.fn(async () => undefined);
+    useEditorStore.setState({
+      currentPath: 'foo.md',
+      currentNote: {
+        path: 'foo.md',
+        title: 'foo',
+        frontmatter: {},
+        content: 'body',
+        wikilinks: [],
+        mtimeMs: 0,
+      },
+      dirty: true,
+      save: saveSpy,
+    });
+
+    render(<App />);
+    dispatchShortcut('s', { shift: true });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+N requests the new-note prompt via UI store', () => {
+    render(<App />);
+    expect(useUiStore.getState().newNotePromptOpen).toBe(false);
+
+    dispatchShortcut('n');
+
+    expect(useUiStore.getState().newNotePromptOpen).toBe(true);
+  });
+
+  it('shortcuts are inert on the empty-state screen (no vault open)', () => {
+    useVaultStore.setState({ current: null });
+    const openSpy = vi.fn();
+    useSearchStore.setState({ openPalette: openSpy });
+
+    render(<App />);
+    dispatchShortcut('k');
+    dispatchShortcut('n');
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(useUiStore.getState().newNotePromptOpen).toBe(false);
+  });
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { SearchPalette } from './components/SearchPalette';
 import { ToastStack } from './components/ToastStack';
 import { useEditorStore } from './stores/editor';
 import { useSearchStore } from './stores/search';
+import { useUiStore } from './stores/ui';
 import { useVaultStore } from './stores/vault';
 import { ipc } from './lib/ipc';
 
@@ -40,17 +41,48 @@ export function App(): JSX.Element {
     };
   }, [hydrateFromMain, applyVaultEvent, applyExternalChange, setIndexProgress]);
 
-  // Global Cmd/Ctrl+K opens the search palette. Listening on `window` so
-  // the shortcut works regardless of which descendant has focus
-  // (sidebar tree, editor, backlinks panel). The palette gates itself
-  // on a vault being open, but we also short-circuit here to avoid
-  // opening it from the empty-state screen.
+  // Global keyboard shortcuts. Listening on `window` so they fire
+  // regardless of which descendant has focus (sidebar tree, editor,
+  // backlinks panel). All three short-circuit on a closed vault so
+  // they don't trigger from the empty-state screen.
+  //
+  //   - Cmd/Ctrl+K: open the search palette
+  //   - Cmd/Ctrl+S: save the current note (no-op if not dirty)
+  //   - Cmd/Ctrl+N: open the "Nuova nota" prompt
+  //
+  // We pull the editor / UI store actions from `getState()` inside the
+  // handler so the effect deps stay stable — there's no need to
+  // re-attach the listener every time `dirty` flips.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent): void => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        if (current === null) return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (current === null) return;
+      const key = e.key.toLowerCase();
+      if (key === 'k') {
         e.preventDefault();
         openPalette();
+        return;
+      }
+      if (key === 's') {
+        // Don't intercept Cmd+Shift+S (commonly "Save as", currently
+        // unused but reserved). Plain Cmd+S only.
+        if (e.shiftKey || e.altKey) return;
+        const editor = useEditorStore.getState();
+        if (editor.currentNote === null || !editor.dirty) {
+          // Still preventDefault so the browser doesn't surface the
+          // "save page" dialog on the empty-state Cmd+S press.
+          e.preventDefault();
+          return;
+        }
+        e.preventDefault();
+        void editor.save();
+        return;
+      }
+      if (key === 'n') {
+        if (e.shiftKey || e.altKey) return;
+        e.preventDefault();
+        useUiStore.getState().requestNewNotePrompt();
+        return;
       }
     };
     window.addEventListener('keydown', onKeyDown);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { EmptyState } from './components/EmptyState';
 import { Layout } from './components/Layout';
 import { SearchPalette } from './components/SearchPalette';
+import { ToastStack } from './components/ToastStack';
 import { useEditorStore } from './stores/editor';
 import { useSearchStore } from './stores/search';
 import { useVaultStore } from './stores/vault';
@@ -60,11 +61,14 @@ export function App(): JSX.Element {
 
   if (current === null) {
     return (
-      <EmptyState
-        onOpenVault={async (): Promise<void> => {
-          await pickAndOpenVault();
-        }}
-      />
+      <>
+        <EmptyState
+          onOpenVault={async (): Promise<void> => {
+            await pickAndOpenVault();
+          }}
+        />
+        <ToastStack />
+      </>
     );
   }
 
@@ -72,6 +76,7 @@ export function App(): JSX.Element {
     <>
       <Layout />
       <SearchPalette />
+      <ToastStack />
     </>
   );
 }

--- a/apps/desktop/src/components/Sidebar/FileTree.tsx
+++ b/apps/desktop/src/components/Sidebar/FileTree.tsx
@@ -1,5 +1,4 @@
 import type { NotePath } from '@ziba/core';
-import { useMemo } from 'react';
 import type { TreeNode } from '../../lib/tree';
 
 /**
@@ -13,17 +12,20 @@ export type TreeTarget =
   | { kind: 'empty' };
 
 export type FileTreeProps = {
-  /** Pre-built hierarchical tree from `buildTree(notes)`. */
-  tree: TreeNode[];
+  /**
+   * Pre-flattened, depth-aware row list. Computed by the parent (so
+   * keyboard nav and the rendered list share one walk per tree
+   * mutation instead of recomputing on every keystroke). Derive via
+   * `flattenTree(tree, expanded)`.
+   */
+  rows: ReadonlyArray<FlatRow>;
   /** Currently-open note path; used to highlight the active row. */
   currentPath: NotePath | null;
-  /** Set of expanded folder paths. */
-  expanded: ReadonlySet<string>;
-  /** Optional row that should appear focused (for keyboard nav). */
-  focusedPath: string | null;
   onToggleFolder(path: string): void;
   onSelectFile(path: NotePath): void;
   onContextMenu(target: TreeTarget, x: number, y: number): void;
+  /** Optional row that should appear focused (for keyboard nav). */
+  focusedPath: string | null;
   /** Called with the row path when the user clicks/focuses it. */
   onFocusPath(path: string): void;
 };
@@ -74,21 +76,14 @@ function flatten(
 const INDENT_PX = 12;
 
 export function FileTree({
-  tree,
+  rows,
   currentPath,
-  expanded,
   focusedPath,
   onToggleFolder,
   onSelectFile,
   onContextMenu,
   onFocusPath,
 }: FileTreeProps): JSX.Element {
-  const rows = useMemo<FlatRow[]>(() => {
-    const out: FlatRow[] = [];
-    flatten(tree, 0, expanded, out);
-    return out;
-  }, [tree, expanded]);
-
   if (rows.length === 0) {
     return (
       <div

--- a/apps/desktop/src/components/Sidebar/NewNoteButton.tsx
+++ b/apps/desktop/src/components/Sidebar/NewNoteButton.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
 import { useEditorStore } from '../../stores/editor';
+import { toast } from '../../stores/toast';
 import { useVaultStore } from '../../stores/vault';
 import { PromptDialog } from './PromptDialog';
 import { buildNotePath, validateRelativeNotePath } from './path-utils';
@@ -28,9 +29,7 @@ export function NewNoteButton(): JSX.Element {
       await openNote(notePath);
       setOpen(false);
     } catch (err: unknown) {
-      // Surface failures as alert for v0.1; richer toasts come later.
-      const message = ipcErrorMessage(err);
-      window.alert(`Impossibile creare la nota: ${message}`);
+      toast.error(ipcErrorMessage(err), 'Impossibile creare la nota');
     } finally {
       setSubmitting(false);
     }

--- a/apps/desktop/src/components/Sidebar/NewNoteButton.tsx
+++ b/apps/desktop/src/components/Sidebar/NewNoteButton.tsx
@@ -3,6 +3,7 @@ import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
 import { useEditorStore } from '../../stores/editor';
 import { toast } from '../../stores/toast';
+import { useUiStore } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { PromptDialog } from './PromptDialog';
 import { buildNotePath, validateRelativeNotePath } from './path-utils';
@@ -12,12 +13,35 @@ import { buildNotePath, validateRelativeNotePath } from './path-utils';
  * prompt asking for a name (which can include a folder, e.g. `inbox/foo`),
  * creates the note via IPC, refreshes the index, and opens the new note
  * in the editor.
+ *
+ * The dialog can also be opened externally via
+ * `useUiStore.getState().requestNewNotePrompt()` — used by the
+ * Cmd/Ctrl+N global shortcut. We mirror that flag into local state so
+ * the dialog still owns its own open/close lifecycle (close on submit,
+ * close on cancel, close on Esc) without re-entering through the store.
  */
 export function NewNoteButton(): JSX.Element {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const refreshNotes = useVaultStore((s) => s.refreshNotes);
   const openNote = useEditorStore((s) => s.openNote);
+  const newNotePromptOpen = useUiStore((s) => s.newNotePromptOpen);
+  const closeNewNotePrompt = useUiStore((s) => s.closeNewNotePrompt);
+
+  // Externally-driven open: when the UI store flips the flag (Cmd+N
+  // shortcut), open the dialog and clear the flag so re-pressing the
+  // shortcut after manual close re-opens it.
+  if (newNotePromptOpen && !open) {
+    setOpen(true);
+    closeNewNotePrompt();
+  }
+
+  const handleClose = (): void => {
+    setOpen(false);
+    // Belt-and-braces: in case the flag was set after our local open
+    // but before we cleared it, make sure it's down on close too.
+    closeNewNotePrompt();
+  };
 
   const handleSubmit = async (raw: string): Promise<void> => {
     setSubmitting(true);
@@ -27,7 +51,7 @@ export function NewNoteButton(): JSX.Element {
       await ipc.createNote({ path: notePath });
       await refreshNotes();
       await openNote(notePath);
-      setOpen(false);
+      handleClose();
     } catch (err: unknown) {
       toast.error(ipcErrorMessage(err), 'Impossibile creare la nota');
     } finally {
@@ -55,7 +79,7 @@ export function NewNoteButton(): JSX.Element {
           onSubmit={(value): void => {
             void handleSubmit(value);
           }}
-          onCancel={(): void => setOpen(false)}
+          onCancel={handleClose}
         />
       )}
     </>

--- a/apps/desktop/src/components/Sidebar/index.tsx
+++ b/apps/desktop/src/components/Sidebar/index.tsx
@@ -66,6 +66,11 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
 
   const tree = useMemo(() => buildTree(visibleNotes), [visibleNotes]);
   const expandedSet = useMemo(() => new Set(expandedFolders), [expandedFolders]);
+  // Pre-flattened row list shared between <FileTree> and the keyboard
+  // handler. One walk per tree mutation instead of one per keystroke
+  // — matters at vault scale (~1000+ notes) where the recursive walk
+  // is no longer free.
+  const flatRows = useMemo(() => flattenTree(tree, expandedSet), [tree, expandedSet]);
 
   // Auto-expand the chain of folders that lead to the currently-open note,
   // so the active row is always visible after opening from another surface
@@ -212,27 +217,27 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
       ) {
         return;
       }
-      const flat = flattenTree(tree, expandedSet);
-      if (flat.length === 0) return;
+      if (flatRows.length === 0) return;
 
-      const currentIdx = focusedPath === null ? -1 : flat.findIndex((r) => r.path === focusedPath);
+      const currentIdx =
+        focusedPath === null ? -1 : flatRows.findIndex((r) => r.path === focusedPath);
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        const next = flat[Math.min(currentIdx + 1, flat.length - 1)] ?? flat[0];
+        const next = flatRows[Math.min(currentIdx + 1, flatRows.length - 1)] ?? flatRows[0];
         if (next !== undefined) setFocusedPath(next.path);
         return;
       }
       if (e.key === 'ArrowUp') {
         e.preventDefault();
-        const next = flat[Math.max(currentIdx - 1, 0)] ?? flat[0];
+        const next = flatRows[Math.max(currentIdx - 1, 0)] ?? flatRows[0];
         if (next !== undefined) setFocusedPath(next.path);
         return;
       }
 
       // Below this point we need a focused row.
       if (currentIdx === -1) return;
-      const row = flat[currentIdx];
+      const row = flatRows[currentIdx];
       if (row === undefined) return;
 
       if (e.key === 'Enter') {
@@ -272,7 +277,7 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
         }
       }
     },
-    [dialog.kind, contextMenu, tree, expandedSet, focusedPath, handleSelectFile, toggleFolder],
+    [dialog.kind, contextMenu, flatRows, focusedPath, handleSelectFile, toggleFolder],
   );
 
   const closeDialog = useCallback((): void => setDialog({ kind: 'none' }), []);
@@ -310,9 +315,8 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
 
       <div className="relative flex-1 overflow-y-auto">
         <FileTree
-          tree={tree}
+          rows={flatRows}
           currentPath={currentPath}
-          expanded={expandedSet}
           focusedPath={focusedPath}
           onToggleFolder={toggleFolder}
           onSelectFile={handleSelectFile}

--- a/apps/desktop/src/components/Sidebar/useSidebarMutations.test.ts
+++ b/apps/desktop/src/components/Sidebar/useSidebarMutations.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { installMockIpc, type MockController } from '../../test/mock-ipc';
+import { useEditorStore } from '../../stores/editor';
+import { useToastStore } from '../../stores/toast';
+import { useVaultStore } from '../../stores/vault';
+import { useSidebarMutations } from './useSidebarMutations';
+
+// Tests pin the two-stage error split that the hook's docstring calls
+// out as load-bearing: a previous shape collapsed both stages into a
+// single try/catch and mis-reported follow-up failures (refresh,
+// re-open) as "Impossibile eliminare la nota" — even when the file was
+// actually deleted. The split must keep the user-facing message
+// truthful in three distinct outcomes.
+
+let mock: MockController;
+
+beforeEach(() => {
+  mock = installMockIpc();
+  useToastStore.getState().clear();
+  // The follow-up branch deliberately logs failures via console.error
+  // for the dev console — silence the chatter in test output.
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  // Reset stores between tests so vault/editor state doesn't leak.
+  useVaultStore.setState({
+    current: { root: '/test', name: 'test', openedAt: 0 },
+    notes: [],
+    indexProgress: null,
+  });
+  useEditorStore.setState({
+    currentPath: null,
+    currentNote: null,
+    dirty: false,
+    lastSaveError: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function lastToast(): { kind: string; title: string | undefined; message: string } | undefined {
+  const toasts = useToastStore.getState().toasts;
+  if (toasts.length === 0) return undefined;
+  const t = toasts[toasts.length - 1]!;
+  return { kind: t.kind, title: t.title, message: t.message };
+}
+
+describe('useSidebarMutations — deleteFile two-stage split', () => {
+  it('IPC succeeds + refresh succeeds → no error toast surfaces', async () => {
+    // Defaults already make both succeed. Just call and verify silence.
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.deleteFile('foo.md');
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it('IPC fails → "Impossibile eliminare" error toast, refresh NOT called', async () => {
+    mock.setHandler('notes:delete', async () => {
+      throw Object.assign(new Error('[PERMISSION_DENIED] Permesso negato.'), {
+        code: 'PERMISSION_DENIED',
+      });
+    });
+    const refreshSpy = vi.spyOn(useVaultStore.getState(), 'refreshNotes');
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.deleteFile('foo.md');
+
+    const t = lastToast();
+    expect(t?.kind).toBe('error');
+    expect(t?.title).toBe('Impossibile eliminare la nota');
+    expect(t?.message).toBe('Permesso negato.');
+    // Refresh must NOT run: the IPC failed so the file is still on disk
+    // and the in-app tree is consistent already.
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('IPC succeeds + refresh fails → warning toast (NOT "Impossibile eliminare")', async () => {
+    // The exact regression the hook's docstring warns about: the file
+    // *was* deleted on disk, but the watcher / refresh fell over.
+    const refreshErr = new Error('watcher stalled');
+    vi.spyOn(useVaultStore.getState(), 'refreshNotes').mockRejectedValueOnce(refreshErr);
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.deleteFile('foo.md');
+
+    const t = lastToast();
+    expect(t?.kind).toBe('warning');
+    expect(t?.title).toBe('Aggiornamento incompleto');
+    // Truthful message: tells the user the delete *did* happen but the
+    // tree didn't update. Critically NOT "Impossibile eliminare la nota".
+    expect(t?.message).toMatch(/Eliminazione nota riuscito/);
+    expect(t?.message).not.toMatch(/Impossibile/);
+  });
+});
+
+describe('useSidebarMutations — renameFile two-stage split', () => {
+  it('IPC fails → error toast with rename title, no follow-up runs', async () => {
+    mock.setHandler('notes:rename', async () => {
+      throw Object.assign(new Error('[ALREADY_EXISTS] Una nota esiste già.'), {
+        code: 'ALREADY_EXISTS',
+      });
+    });
+    const openSpy = vi.spyOn(useEditorStore.getState(), 'openNote');
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.renameFile('foo.md', 'bar');
+
+    expect(lastToast()?.title).toBe('Impossibile rinominare la nota');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('IPC ok + openNote (re-open after rename) fails → warning, not error', async () => {
+    // Set the editor's currentPath so the rename triggers a re-open.
+    useEditorStore.setState({ currentPath: 'foo.md' });
+    vi.spyOn(useEditorStore.getState(), 'openNote').mockRejectedValueOnce(
+      new Error('disk read failed'),
+    );
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.renameFile('foo.md', 'bar');
+
+    const t = lastToast();
+    expect(t?.kind).toBe('warning');
+    expect(t?.title).toBe('Aggiornamento incompleto');
+    expect(t?.message).toMatch(/Rinomina nota riuscito/);
+  });
+
+  it('no-op when newName resolves to the same path (no IPC, no toast)', async () => {
+    const renameSpy = mock.getSpy('notes:rename');
+
+    const { result } = renderHook(() => useSidebarMutations());
+    // Renaming "foo.md" to "foo" lands at the same path — should
+    // short-circuit without touching IPC.
+    await result.current.renameFile('foo.md', 'foo');
+
+    expect(renameSpy).not.toHaveBeenCalled();
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+});
+
+describe('useSidebarMutations — createNoteIn two-stage split', () => {
+  it('IPC fails → error toast with create title, no openNote', async () => {
+    mock.setHandler('notes:create', async () => {
+      throw Object.assign(new Error('[INVALID_PATH] Percorso non valido.'), {
+        code: 'INVALID_PATH',
+      });
+    });
+    const openSpy = vi.spyOn(useEditorStore.getState(), 'openNote');
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.createNoteIn('new', '');
+
+    expect(lastToast()?.title).toBe('Impossibile creare la nota');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('IPC succeeds + openNote fails → warning, NOT "Impossibile creare"', async () => {
+    vi.spyOn(useEditorStore.getState(), 'openNote').mockRejectedValueOnce(new Error('load failed'));
+
+    const { result } = renderHook(() => useSidebarMutations());
+    await result.current.createNoteIn('new', '');
+
+    const t = lastToast();
+    expect(t?.kind).toBe('warning');
+    expect(t?.title).toBe('Aggiornamento incompleto');
+    expect(t?.message).not.toMatch(/Impossibile/);
+  });
+});

--- a/apps/desktop/src/components/Sidebar/useSidebarMutations.ts
+++ b/apps/desktop/src/components/Sidebar/useSidebarMutations.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
 import { useEditorStore } from '../../stores/editor';
+import { toast } from '../../stores/toast';
 import { useUiStore } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { buildFolderPath, buildNotePath, replaceLastSegment } from './path-utils';
@@ -28,9 +29,10 @@ import { buildFolderPath, buildNotePath, replaceLastSegment } from './path-utils
  * user just sees a stale tree. The narrow scope keeps the message
  * truthful.
  *
- * Errors surface through `window.alert` for v0.5 — same as before. A
- * future iteration can replace that with a toast surface; concentrating
- * the calls here makes that swap a one-file change.
+ * Errors surface through the global toast store (`stores/toast.ts`):
+ * the IPC stage uses an error toast, the follow-up stage uses a
+ * warning toast. Tests can drain `useToastStore.getState().toasts`
+ * to assert on what the user would see.
  */
 export type SidebarMutations = {
   refreshing: boolean;
@@ -58,10 +60,11 @@ async function runFollowUp(verb: string, fn: () => Promise<void>): Promise<void>
     await fn();
   } catch (err: unknown) {
     console.error(`[sidebar] follow-up after ${verb} failed:`, err);
-    window.alert(
+    toast.warning(
       `${verb} riuscito ma l'aggiornamento della vista è fallito (${ipcErrorMessage(
         err,
       )}). Premi F5 per ricaricare.`,
+      'Aggiornamento incompleto',
     );
   }
 }
@@ -91,7 +94,7 @@ export function useSidebarMutations(): SidebarMutations {
       try {
         await ipc.createNote({ path });
       } catch (err: unknown) {
-        window.alert(`Impossibile creare la nota: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile creare la nota');
         return;
       }
       await runFollowUp('Creazione nota', async () => {
@@ -108,7 +111,7 @@ export function useSidebarMutations(): SidebarMutations {
       try {
         await ipc.createFolder({ path });
       } catch (err: unknown) {
-        window.alert(`Impossibile creare la cartella: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile creare la cartella');
         return;
       }
       await runFollowUp('Creazione cartella', async () => {
@@ -129,7 +132,7 @@ export function useSidebarMutations(): SidebarMutations {
         const result = await ipc.renameNote({ from: oldPath, to: newPath });
         resultNewPath = result.newPath;
       } catch (err: unknown) {
-        window.alert(`Impossibile rinominare la nota: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile rinominare la nota');
         return;
       }
       await runFollowUp('Rinomina nota', async () => {
@@ -149,7 +152,7 @@ export function useSidebarMutations(): SidebarMutations {
       try {
         await ipc.renameFolder({ from: oldPath, to: newPath });
       } catch (err: unknown) {
-        window.alert(`Impossibile rinominare la cartella: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile rinominare la cartella');
         return;
       }
       await runFollowUp('Rinomina cartella', async () => {
@@ -169,7 +172,7 @@ export function useSidebarMutations(): SidebarMutations {
       try {
         await ipc.deleteNote({ path });
       } catch (err: unknown) {
-        window.alert(`Impossibile eliminare la nota: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile eliminare la nota');
         return;
       }
       await runFollowUp('Eliminazione nota', async () => {
@@ -185,7 +188,7 @@ export function useSidebarMutations(): SidebarMutations {
       try {
         await ipc.deleteFolder({ path });
       } catch (err: unknown) {
-        window.alert(`Impossibile eliminare la cartella: ${ipcErrorMessage(err)}`);
+        toast.error(ipcErrorMessage(err), 'Impossibile eliminare la cartella');
         return;
       }
       await runFollowUp('Eliminazione cartella', async () => {

--- a/apps/desktop/src/components/ToastStack.tsx
+++ b/apps/desktop/src/components/ToastStack.tsx
@@ -1,0 +1,75 @@
+import type { JSX } from 'react';
+import { useToastStore, type Toast, type ToastKind } from '../stores/toast';
+
+/**
+ * Bottom-right toast stack. Mounted once at the app root next to the
+ * search palette. New toasts append to the bottom; the column reverses
+ * via flex so the most recent visually appears on top of older ones.
+ *
+ * Accessibility:
+ *   - The container is `role="status" aria-live="polite"` for info /
+ *     success / warning so screen readers announce calmly.
+ *   - Errors get `role="alert" aria-live="assertive"` to interrupt.
+ *   - Each toast renders its own region so multi-toast announcements
+ *     don't collapse into a single re-read.
+ */
+export function ToastStack(): JSX.Element | null {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-80 max-w-[90vw] flex-col-reverse gap-2"
+      data-toast-stack=""
+    >
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={(): void => dismiss(t.id)} />
+      ))}
+    </div>
+  );
+}
+
+const KIND_CLASSES: Record<ToastKind, string> = {
+  info: 'border-fg-muted bg-bg text-fg',
+  success: 'border-emerald-500 bg-bg text-fg',
+  warning: 'border-amber-500 bg-bg text-fg',
+  error: 'border-red-500 bg-bg text-fg',
+};
+
+const KIND_LABELS: Record<ToastKind, string> = {
+  info: 'Info',
+  success: 'Successo',
+  warning: 'Attenzione',
+  error: 'Errore',
+};
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }): JSX.Element {
+  const isError = toast.kind === 'error';
+  return (
+    <div
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      className={`pointer-events-auto rounded border px-3 py-2 text-sm shadow-lg ${KIND_CLASSES[toast.kind]}`}
+      data-toast-kind={toast.kind}
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold uppercase tracking-wide text-fg-muted">
+            {toast.title ?? KIND_LABELS[toast.kind]}
+          </div>
+          <div className="break-words">{toast.message}</div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Chiudi notifica"
+          className="-mr-1 -mt-0.5 shrink-0 rounded p-0.5 text-fg-muted hover:bg-bg-muted hover:text-fg"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/navigate.ts
+++ b/apps/desktop/src/lib/navigate.ts
@@ -1,15 +1,14 @@
 // Shared "switch view + open note" helper.
 //
 // DatabaseView and GlobalGraph both need to: (1) switch the top-level
-// view back to the editor, (2) load the chosen note. Doing it inline at
-// each call site means duplicating the order, the error swallowing, and
-// the eventual "show a toast on failure" wiring. One helper here keeps
-// the behaviour identical across navigation sources, and gives us a
-// single place to add a toast / surface errors when v0.4 introduces a
-// notification system.
+// view back to the editor, (2) load the chosen note. One helper keeps
+// the behaviour identical across navigation sources and gives us a
+// single place to surface errors via the global toast store.
 
 import type { NotePath } from '@ziba/core';
+import { ipcErrorMessage } from './ipc-error';
 import { useEditorStore } from '../stores/editor';
+import { toast } from '../stores/toast';
 import { useUiStore } from '../stores/ui';
 
 /**
@@ -18,21 +17,19 @@ import { useUiStore } from '../stores/ui';
  * before the note's body has loaded) so the user feels an immediate
  * response; the load runs in the background.
  *
- * Errors from `openNote` (file deleted between query and click,
- * disk error, etc.) currently surface through `useEditorStore.lastSaveError`.
- * Once the app has a global toast system, replace the inline `console.error`
- * with a toast call.
+ * On `openNote` failure (file deleted between query and click, disk
+ * error, vault closed mid-flight), the editor store records the error
+ * for inline display, and we also surface a toast — the call sites
+ * (table click, graph node click) no longer have a natural inline
+ * surface for the failure since the user just left their previous
+ * context.
  */
 export async function navigateToNote(path: NotePath): Promise<void> {
   useUiStore.getState().setMainView('editor');
   try {
     await useEditorStore.getState().openNote(path);
   } catch (err: unknown) {
-    // Don't let a failed openNote leave the renderer in a half-state.
-    // The editor store already records the error; we also log so the
-    // dev-mode renderer console pipe surfaces it during debugging.
-    if (typeof console !== 'undefined') {
-      console.error('[ziba] navigateToNote failed for', path, err);
-    }
+    console.error('[ziba] navigateToNote failed for', path, err);
+    toast.error(ipcErrorMessage(err), 'Apertura nota fallita');
   }
 }

--- a/apps/desktop/src/stores/toast.test.ts
+++ b/apps/desktop/src/stores/toast.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast, useToastStore, type ToastKind } from './toast';
+
+// The toast store powers all user-facing error/success surfaces (sidebar
+// CRUD, navigation failures, future plugin events). The interface is
+// tiny but a few invariants are load-bearing:
+//   - id allocation is monotonic so React keys stay stable;
+//   - auto-dismiss must not fire after a manual dismiss (no "ghost"
+//     ID tries to remove a toast a different push later inserts at the
+//     same id, mid-runtime);
+//   - clear() must cancel pending timers (otherwise tests bleed
+//     across each other and prod sees odd flicker on vault switch).
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useToastStore.getState().clear();
+});
+
+afterEach(() => {
+  useToastStore.getState().clear();
+  vi.useRealTimers();
+});
+
+describe('useToastStore — push / dismiss', () => {
+  it('appends a toast with a fresh id', () => {
+    const id1 = useToastStore.getState().push({ kind: 'info', message: 'a' });
+    const id2 = useToastStore.getState().push({ kind: 'info', message: 'b' });
+    expect(id2).toBeGreaterThan(id1);
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(2);
+    expect(toasts[0]!.message).toBe('a');
+    expect(toasts[1]!.message).toBe('b');
+  });
+
+  it('preserves the optional title and kind in the stored toast', () => {
+    useToastStore.getState().push({ kind: 'error', message: 'boom', title: 'Errore IPC' });
+    const t = useToastStore.getState().toasts[0]!;
+    expect(t.kind).toBe('error');
+    expect(t.title).toBe('Errore IPC');
+  });
+
+  it('dismiss(id) removes the matching toast and is a no-op for unknown ids', () => {
+    const id = useToastStore.getState().push({ kind: 'info', message: 'a' });
+    useToastStore.getState().dismiss(id);
+    expect(useToastStore.getState().toasts).toEqual([]);
+    // Unknown id — should not throw.
+    useToastStore.getState().dismiss(99999);
+  });
+});
+
+describe('useToastStore — auto-dismiss', () => {
+  it('auto-dismisses after the default 4s window', () => {
+    useToastStore.getState().push({ kind: 'info', message: 'a' });
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(3999);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('respects a custom durationMs', () => {
+    useToastStore.getState().push({ kind: 'info', message: 'a', durationMs: 1000 });
+    vi.advanceTimersByTime(999);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('keeps the toast visible indefinitely when durationMs is null', () => {
+    useToastStore.getState().push({ kind: 'error', message: 'persistent', durationMs: null });
+    vi.advanceTimersByTime(60_000);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+
+  it('manual dismiss before the timer cancels the timer (no double-remove)', () => {
+    const id = useToastStore.getState().push({ kind: 'info', message: 'a' });
+    useToastStore.getState().dismiss(id);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    // The pending auto-dismiss timer must not later try to remove a
+    // *different* toast that happens to inherit `id` (we don't recycle
+    // ids, but the timer must be cleared to avoid runtime warnings).
+    vi.advanceTimersByTime(10_000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('clear() removes everything and cancels pending timers', () => {
+    useToastStore.getState().push({ kind: 'info', message: 'a' });
+    useToastStore.getState().push({ kind: 'info', message: 'b' });
+    useToastStore.getState().clear();
+    expect(useToastStore.getState().toasts).toEqual([]);
+    // Even after the original auto-dismiss window, no further state
+    // change should occur (no errors logged, no zombie removals).
+    vi.advanceTimersByTime(10_000);
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+});
+
+describe('toast convenience helpers', () => {
+  it.each([
+    ['info', 'info'],
+    ['success', 'success'],
+    ['warning', 'warning'],
+    ['error', 'error'],
+  ] as const)('toast.%s pushes a toast with kind=%s', (helper, expectedKind: ToastKind) => {
+    toast[helper]('msg', 'My title');
+    const t = useToastStore.getState().toasts[0]!;
+    expect(t.kind).toBe(expectedKind);
+    expect(t.message).toBe('msg');
+    expect(t.title).toBe('My title');
+  });
+});

--- a/apps/desktop/src/stores/toast.ts
+++ b/apps/desktop/src/stores/toast.ts
@@ -1,0 +1,123 @@
+// Global toast queue for non-blocking user feedback.
+//
+// Replaces `window.alert` across the renderer. The native dialog was
+// the v0.1 placeholder: it's modal (blocks the whole window),
+// platform-styled (looks foreign next to our UI), can't be unit-tested
+// without monkey-patching, and stacks one-at-a-time.
+//
+// Design notes:
+//   - Plain Zustand store, no provider needed. Both React components
+//     (`useToastStore(s => s.toasts)`) and non-React callers
+//     (`useToastStore.getState().push(...)`) use the same surface.
+//   - IDs are monotonic counters so `<ToastStack>` can key reliably.
+//     We don't use `crypto.randomUUID` to keep the store deterministic
+//     in tests (no need to mock global randomness).
+//   - Auto-dismiss is per-toast, scheduled inside `push` so the store
+//     itself stays declarative (the timer drives `dismiss(id)`, which
+//     is the same path manual close uses).
+
+import { create } from 'zustand';
+
+/**
+ * Severity of a toast. Drives the visual treatment in `<ToastStack>`
+ * (color, icon) and helps assistive tech announce the urgency.
+ */
+export type ToastKind = 'info' | 'success' | 'warning' | 'error';
+
+export type Toast = {
+  id: number;
+  kind: ToastKind;
+  /** Headline shown in bold; defaults to a kind-appropriate label when omitted. */
+  title?: string;
+  /** Body text. Required so a toast always has something to read. */
+  message: string;
+};
+
+export type ToastInput = Omit<Toast, 'id'> & {
+  /**
+   * Override the default auto-dismiss window (ms). Pass `null` to
+   * keep the toast visible until manually dismissed — useful for
+   * persistent error states a user must acknowledge.
+   */
+  durationMs?: number | null;
+};
+
+type ToastState = {
+  toasts: Toast[];
+  push(toast: ToastInput): number;
+  dismiss(id: number): void;
+  clear(): void;
+};
+
+/**
+ * Default auto-dismiss window. Long enough for a user to read a
+ * one-line message at a glance, short enough not to pile up.
+ */
+const DEFAULT_DURATION_MS = 4000;
+
+let nextId = 1;
+const dismissTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+  push(input): number {
+    const id = nextId++;
+    const toast: Toast = {
+      id,
+      kind: input.kind,
+      message: input.message,
+      ...(input.title !== undefined ? { title: input.title } : {}),
+    };
+    set((s) => ({ toasts: [...s.toasts, toast] }));
+
+    const duration = input.durationMs === undefined ? DEFAULT_DURATION_MS : input.durationMs;
+    if (duration !== null) {
+      const timer = setTimeout(() => {
+        get().dismiss(id);
+      }, duration);
+      dismissTimers.set(id, timer);
+    }
+    return id;
+  },
+  dismiss(id): void {
+    const timer = dismissTimers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      dismissTimers.delete(id);
+    }
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  },
+  clear(): void {
+    for (const timer of dismissTimers.values()) clearTimeout(timer);
+    dismissTimers.clear();
+    set({ toasts: [] });
+  },
+}));
+
+/**
+ * Convenience accessor for non-React callers (stores, async helpers,
+ * IPC error handlers). Avoids the cost-and-rules of a hook in places
+ * that aren't React components.
+ */
+function pushHelper(kind: ToastKind, message: string, title?: string): number {
+  // `exactOptionalPropertyTypes` rejects `{ title: undefined }`, so we
+  // omit the field entirely when no title was supplied.
+  return useToastStore
+    .getState()
+    .push(title === undefined ? { kind, message } : { kind, message, title });
+}
+
+export const toast = {
+  info(message: string, title?: string): number {
+    return pushHelper('info', message, title);
+  },
+  success(message: string, title?: string): number {
+    return pushHelper('success', message, title);
+  },
+  warning(message: string, title?: string): number {
+    return pushHelper('warning', message, title);
+  },
+  error(message: string, title?: string): number {
+    return pushHelper('error', message, title);
+  },
+};

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -134,6 +134,13 @@ function savePersisted(p: Persisted): void {
 }
 
 type UiState = Persisted & {
+  /**
+   * Ephemeral flag set by the Cmd/Ctrl+N keyboard shortcut and
+   * consumed by `<NewNoteButton>` to open its prompt dialog.
+   * Deliberately NOT persisted — a "should be open" state surviving
+   * reloads would surprise the user.
+   */
+  newNotePromptOpen: boolean;
   setSidebarWidth(n: number): void;
   setBacklinksWidth(n: number): void;
   toggleBacklinks(): void;
@@ -143,6 +150,8 @@ type UiState = Persisted & {
   setRightPaneTab(tab: RightPaneTab): void;
   setMainView(view: MainView): void;
   setDatabaseViewMode(mode: DatabaseViewMode): void;
+  requestNewNotePrompt(): void;
+  closeNewNotePrompt(): void;
 };
 
 export const useUiStore = create<UiState>((set, get) => {
@@ -173,6 +182,13 @@ export const useUiStore = create<UiState>((set, get) => {
 
   return {
     ...initial,
+    newNotePromptOpen: false,
+    requestNewNotePrompt() {
+      set({ newNotePromptOpen: true });
+    },
+    closeNewNotePrompt() {
+      set({ newNotePromptOpen: false });
+    },
     setSidebarWidth(n) {
       set({ sidebarWidth: clamp(n, MIN_SIDEBAR, MAX_SIDEBAR) });
       persist();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,12 @@ importers:
         specifier: ^4.5.5
         version: 4.5.7(@types/react@18.3.28)(react@18.3.1)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/better-sqlite3':
         specifier: ^7.6.11
         version: 7.6.13
@@ -261,6 +267,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -734,6 +744,25 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tiptap/core@2.27.2':
     resolution: {integrity: sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==}
     peerDependencies:
@@ -904,6 +933,9 @@ packages:
     resolution: {integrity: sha512-cblXqub7uABXKNMzvPB1IyOuSQpeMo7zZHSREB2C0mtIVn4lUSd2CfaGBtOrDqmkC9dsan3itxY4IejChQvfpg==}
     cpu: [arm64]
     os: [win32]
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1154,6 +1186,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1203,6 +1239,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1614,6 +1653,10 @@ packages:
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1642,6 +1685,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -2562,6 +2608,10 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2991,6 +3041,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -3100,6 +3154,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -3987,6 +4044,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4396,6 +4455,27 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@tiptap/core@2.27.2(@tiptap/pm@2.27.2)':
     dependencies:
       '@tiptap/pm': 2.27.2
@@ -4574,6 +4654,8 @@ snapshots:
 
   '@turbo/windows-arm64@2.9.10':
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4893,6 +4975,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -4994,6 +5078,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -5450,6 +5538,8 @@ snapshots:
 
   delegates@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
@@ -5494,6 +5584,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -6619,6 +6711,8 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7047,6 +7141,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
@@ -7194,6 +7294,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary

Closes the 5 nice-to-have polish items identified by a fresh code-reviewer pass on the post-rebrand codebase. Ships in two commits on this branch.

### Items

1. **Global toast surface** (`stores/toast.ts` + `<ToastStack>`) replaces 8 `window.alert` callsites in `useSidebarMutations`, `NewNoteButton`, and `navigate.ts`. Covered by 12 store tests (push/dismiss/auto-dismiss/null-duration/clear-cancels-timers/convenience helpers).
2. **`useSidebarMutations` two-stage split test** (8 cases) pinning the truthful-message invariant — the file's docstring explicitly calls out the regression this guards against. Adds `@testing-library/react` as a dev dep.
3. **Memoize flattenTree** at Sidebar level. Was recomputing inside `handleKeyDown` per arrow keypress + a redundant `useMemo` inside `FileTree`. Hoisted once, passed as `rows` prop. Real perf smell at vault scale.
4. **Cmd/Ctrl+S** save (no-op when not dirty) + **Cmd/Ctrl+N** new-note prompt. Cmd+Shift+S explicitly reserved for future Save-as. Seven smoke tests via `App.test.tsx` covering each shortcut, no-op cases, empty-state inertness.
5. **README status badge + roadmap** bumped from v0.1 to v0.5; new v0.5 feature section; roadmap demoted "v0.5 (next)" → v0.6, added v1.0 + v1.x rows.

### Numbers

- Tests: 313 → 340 (+27 across 4 new test files)
- Files: 13 changed, 2 new test files, 2 new component/store files
- Typecheck + lint clean

## Test plan

- [x] `pnpm test` — 340 / 340 passing (140 core + 200 desktop)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: Cmd+S in editor with dirty buffer triggers save
- [ ] Manual: Cmd+N from any focus opens prompt
- [ ] Manual: Sidebar arrow-key nav still feels instant on a 1k-note vault
- [ ] Manual: Toast appears bottom-right and auto-dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)