### PR TITLE
docs(spec): v1.0 Object-Relational Foundation design

### DIFF
--- a/docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md
+++ b/docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md
@@ -1,0 +1,462 @@
+# Ziba v1.0 — Object-Relational Foundation
+
+**Status**: Approved 2026-05-10
+**Owner**: @francescogiannicola
+**Supersedes**: the earlier "v1.0 plugin system + web app" idea — both
+deferred. Plugins go to v1.x once the object model gives them
+something interesting to manipulate; web port stays on the roadmap as
+its own multi-phase project.
+
+## 1. Goal
+
+Turn Ziba from "Obsidian with extras" into an **Anytype-class object
+graph**: every note can declare itself as a typed object with typed
+relations to other objects. The graph view becomes the primary surface
+where the constellation of types and relations is visible at a glance;
+inside a note, a side panel surfaces the object's properties and
+inverse relations so navigation is bidirectional everywhere, not only
+in a backlinks panel.
+
+The goal is qualitative, not quantitative: after v1.0, opening a note
+about a person should immediately tell you "12 books authored, 4
+projects involved, 3 ideas attributed" — without writing a query, and
+without leaving the editor.
+
+## 2. Non-goals
+
+- **Not a hard schema enforcement**. Schemas are documentation +
+  editor affordance, not a validator that refuses to save. Markdown
+  files stay editable in any tool; an out-of-spec value renders as
+  best-effort, not as an error.
+- **Not a Notion/Anytype clone of the database UI**. Tables / boards /
+  calendar already exist; v1.0 adds type filters on top, not a new
+  database engine.
+- **Not a plugin system**. Plugins are deferred to v1.x and will be
+  built on top of this foundation (typed relations + schemas are what
+  makes plugins useful in the first place).
+- **Not a web port**. Electron-only stays through v1.0. The web port
+  is its own roadmap item; this design avoids choices that would lock
+  us out of porting later (e.g. nothing here requires native modules
+  beyond what's already there).
+- **Not a renderer rewrite**. The Tiptap editor, the Database view,
+  the global graph keep their current architecture. v1.0 *extends*
+  them; it doesn't replace them.
+
+## 3. Data model
+
+### 3.1 Frontmatter shape
+
+A typed object is a markdown note that declares `type:` and (optionally)
+`relations:` in frontmatter:
+
+```yaml
+---
+type: book
+title: The Hobbit
+year: 1937
+isbn: 978-0-261-10334-4
+relations:
+  author: [[Tolkien]]
+  in_series: [[Middle-earth Legendarium]]
+  next_in_series: [[The Lord of the Rings]]
+---
+
+Body markdown stays as today. Generic [[wikilink]]s in the body remain
+backward-compatible — they're recorded as untyped relations
+(`kind = ''`, the sentinel; see SQL schema in §4.1).
+```
+
+Three rules:
+
+1. `type` is a **string slug** (kebab-case). Convention: singular noun
+   (`book`, not `books`). Missing `type:` = untyped note (works as
+   today).
+2. `relations:` is a **map** from `kind` (string slug) to wikilink or
+   list of wikilinks. Multi-target = list. Single = scalar.
+3. Property keys other than `type` / `relations` follow the existing
+   PropertyEditor conventions — they're regular typed properties
+   indexed by the v0.3 typed-property index.
+
+### 3.2 Schema files
+
+A vault carries its type definitions in `.ziba/schema/<type>.yml`. The
+file is human-editable, version-controllable (the `.ziba/` dir can be
+git-tracked if the user wants), and feeds editor autocomplete + the
+sidebar TypesSection counts. Example:
+
+```yaml
+# .ziba/schema/book.yml
+id: book
+label: Libro
+icon: 📖
+color: "#6366f1"           # used by the sidebar pill + graph node + hull
+properties:
+  title: { type: text, required: true }
+  year: { type: number }
+  isbn: { type: text }
+relations:
+  author:        { target: person, multiple: false, label: "Autore" }
+  in_series:     { target: series, multiple: false, label: "Serie" }
+  next_in_series: { target: book,   multiple: false, label: "Volume successivo" }
+inverse:
+  cited_by:      { reverse_of: cites }   # auto-derived from any note that cites this one
+```
+
+The schema is **soft**: editor autocomplete uses it, the database view
+uses it for column suggestions, the graph uses `color` and `icon`, but
+the indexer never refuses a save that diverges. Drift is recoverable —
+delete the schema file, regenerate from the seed.
+
+### 3.3 First-party seeded types
+
+Ziba ships with seven built-in schemas in `packages/core/src/seed-schemas/`:
+
+| Type | Use case | Common relations |
+|---|---|---|
+| `note` | the default catch-all (for notes the user hasn't typed) | (none) |
+| `person` | people, authors, contacts | `works_at`, `knows`, `partner_of` |
+| `book` | books, papers, articles | `author`, `in_series` |
+| `project` | active work, initiatives | `owner`, `member`, `blocks`, `blocked_by` |
+| `idea` | freeform notes | `inspired_by`, `related_to` |
+| `daily` | daily log entries | `worked_on`, `met_with`, `read` |
+| `meeting` | meeting notes | `attended_by`, `for_project`, `outcome_of` |
+
+On first vault open, if `.ziba/schema/` is empty, Ziba copies the seed
+schemas into it. The user can then edit, add, or remove freely. On a
+vault that already has schemas, the seed step is a no-op.
+
+## 4. Indexing
+
+### 4.1 New SQLite tables
+
+The existing `wikilinks` table is **replaced** by a `relations` table
+that subsumes it (kind=NULL = generic body wikilink). A second new
+table caches the schema for fast `types:list` queries.
+
+```sql
+-- Replaces `wikilinks`. The legacy `wikilinks` table is dropped on
+-- first open of a v1.0 vault — index is a cache, no data loss.
+--
+-- `kind` is NOT NULL with a sentinel empty string for generic body
+-- wikilinks. SQLite PRIMARY KEY requires column references (not
+-- expressions like COALESCE), so we encode "untyped" as '' rather
+-- than NULL. The renderer / query layer maps '' ↔ undefined.
+CREATE TABLE IF NOT EXISTS relations (
+  source_path  TEXT NOT NULL,
+  kind         TEXT NOT NULL DEFAULT '',  -- '' = generic body wikilink
+  target_title TEXT NOT NULL,             -- raw, before resolution
+  target_path  TEXT,                       -- NULL = broken link
+  PRIMARY KEY (source_path, kind, target_title)
+);
+CREATE INDEX relations_target_idx ON relations (target_path, kind);
+CREATE INDEX relations_kind_idx   ON relations (kind) WHERE kind <> '';
+
+-- Caches the schemas read from `.ziba/schema/*.yml` on vault open.
+CREATE TABLE IF NOT EXISTS object_types (
+  id          TEXT PRIMARY KEY,
+  label       TEXT NOT NULL,
+  icon        TEXT,
+  color       TEXT,
+  schema_json TEXT NOT NULL,          -- full YAML serialized as JSON
+  mtime       INTEGER NOT NULL
+);
+```
+
+### 4.2 Indexer pipeline
+
+`packages/core/src/markdown/relations.ts` (new module):
+
+- `extractRelations(frontmatter): RelationEntry[]`
+  - Reads `frontmatter.relations` (object | undefined).
+  - For each `(kind, value)` pair: if `value` is a wikilink scalar →
+    one entry with that kind+target; if list → one entry per item.
+  - Returns `[]` when `relations` is missing or malformed.
+- `extractBodyWikilinks(body): RelationEntry[]`
+  - Reuses the existing wikilink scanner; emits entries with
+    `kind = ''` (the SQL sentinel).
+- `extractAllRelations(note): RelationEntry[]`
+  - Combination of the two; called by the indexer instead of the
+    legacy `extractWikilinks`.
+
+The adapter exposes a single `replaceRelations(sourcePath, rels[])`
+method (mirror of `replaceTags`). The save pipeline becomes:
+
+1. Parse frontmatter + body.
+2. Replace properties (existing).
+3. Replace tags (existing).
+4. Replace relations (new — supersedes wikilinks).
+5. Replace FTS (existing).
+
+Type extraction is trivial: read `frontmatter.type` if it's a string
+matching `^[a-z][a-z0-9-]*$`, otherwise null. The type isn't denormalised
+into its own table column — it's a regular property already indexed
+by the v0.3 property index. Lookup of "all books" is
+`SELECT path FROM note_properties WHERE prop_key = 'type' AND text_value = 'book'`.
+
+### 4.3 Query API extensions
+
+In `packages/core/src/query/`:
+
+- `getRelations({ source, kind? })` → entries originating from `source`,
+  optionally filtered by kind.
+- `getReverseRelations({ target, kind? })` → entries pointing AT `target`.
+  Drives the "Cited by" / "Inverse" panel.
+- `getTypeCounts()` → `[{ type, count }]`. Drives sidebar
+  TypesSection.
+- `runDatabaseQuery({ filters, where: { type? } })` — the existing API
+  is extended with a `type` shortcut (sugar for an `eq` filter on the
+  `type` property). Optional, kept for ergonomics.
+- `getFullGraph()` (existing) extended to include each node's `type`
+  and `color` (when known) and each edge's `kind` (nullable).
+
+## 5. UI surfaces
+
+### 5.1 Right pane — adaptive object panel
+
+Today: `<BacklinksPanel>` and `<MiniGraph>` are two right-pane tabs.
+
+v1.0: when the active note has a `type:`, the Backlinks tab is replaced
+by a wider **Object panel** with three sections:
+
+```
+TYPE
+  📖 Book
+
+PROPERTIES
+  title  The Hobbit
+  year   1937
+  isbn   978-...
+
+RELATIONS
+  Autore           [Tolkien]
+  Volume successivo [LOTR]
+
+INVERSE
+  Cited by (3)     [Note about Middle-earth] [+2]
+  Bookshelf        [me]
+```
+
+Untyped notes keep today's plain backlinks panel — backward-compat.
+The toggle is automatic (driven by `type` presence), no new
+preferences.
+
+### 5.2 Sidebar — TypesSection
+
+Above `<TagsSection>`, a new section listing types with counts:
+
+```
+TYPES
+  📝 Note     234
+  📖 Book      12
+  👤 Person     8
+
+TAGS
+  #urgent      9
+  ...
+```
+
+Click a type → file tree filters to that type (mirror of the existing
+selectedTag behaviour, factored as `selectedTypeOrTag`). The two
+filters are mutually exclusive in v1.0 (selecting a type clears the
+tag and vice versa); union is a v1.1 follow-up.
+
+### 5.3 Database view — type dropdown
+
+Header gets a `Type: [▼ Tutti]` dropdown. Selecting a type:
+
+- Adds an implicit `type = <selected>` filter (no chip in the
+  FilterBar — it's the page-level filter).
+- Pre-populates the **column suggestions** with the schema's property
+  keys + the union of relation kinds (e.g. "author", "in_series" for
+  Book).
+
+### 5.4 Editor — inline type indicator + relation slash entry
+
+Two small affordances:
+
+1. **Wikilink type icon (decoration)**: `[[Tolkien]]` renders with the
+   target's type icon prefix when known: `👤 Tolkien`. Pure render-time
+   decoration — markdown on disk is unchanged.
+2. **Slash menu `/relation`**: opens a small popup (kind picker +
+   wikilink autocomplete) and writes a new entry into `frontmatter.relations`
+   without the user touching YAML. Power users keep editing the
+   PropertyEditor or the YAML directly.
+
+The PropertyEditor already supports adding new frontmatter properties;
+v1.0 extends it with a "Add relation" affordance that produces a
+`kind: target` row instead of a scalar property.
+
+## 6. Constellation graph
+
+Extends the existing `<GlobalGraph>` (force-directed, pan/zoom, search)
+with four changes — none of them rewrites the layout engine.
+
+### 6.1 Cluster bias forces
+
+In `apps/desktop/src/components/MiniGraph/layout.ts` add a new term to
+the per-tick force sum: nodes of the same type pull each other
+together with weight `CLUSTER_STRENGTH = 0.3` (tunable in
+`graph-tuning.ts`). The result: visually distinct clusters per type,
+emerging naturally from the same simulator that already runs.
+
+### 6.2 Constellation hulls overlay
+
+For each type with ≥ 3 visible nodes, compute a **convex hull**
+polygon and render it as a semi-transparent SVG `<path>` underneath
+the nodes, filled with the type's color. Recomputed once per
+simulator tick (cheap — O(n log n) per hull). Toggleable via header
+("Mostra cluster"). Off by default — opt-in for the "Anytype vibe".
+
+### 6.3 Edge styling per kind
+
+- `kind = ''` (generic body wikilink): thin grey edge, no label.
+- `kind = '<something>'`: edge color from the relation's kind palette
+  (deterministic hash → HSL hue, consistent across renders), label on
+  hover.
+- Header dropdown "Filtra relazioni" — multi-select per relation kind,
+  hides everything else.
+
+### 6.4 Type filter chips
+
+Header gets a chip row: `📖 Book / 👤 Person / 💡 Idea / Tutti`.
+Single-select for v1.0 (multi-select is a follow-up). Hidden types
+fade their nodes + edges to 10% opacity (rather than removing —
+keeps the layout stable).
+
+### 6.5 Legend
+
+Top-right floating panel shows the active types and their colors. If
+relation-kind filtering is on, also shows the active kinds.
+
+## 7. Migration
+
+**Zero-effort by design**: the SQLite index is a cache, the markdown
+files are the source of truth.
+
+Migration steps on first open of a v1.0 build against an existing
+vault:
+
+1. Schema version bumps from N → N+1. Detected via
+   `PRAGMA user_version`.
+2. Drop tables that changed shape (`wikilinks` → `relations`).
+3. Re-run `SCHEMA_SQL` (recreates `relations`, `object_types`, leaves
+   `notes`, `note_properties`, `tags`, `notes_fts` untouched — they
+   didn't change).
+4. Trigger the existing `reindexVault()` flow, which now extracts
+   relations alongside everything else.
+5. Copy the seed schemas into `<vault>/.ziba/schema/` if the dir is
+   empty.
+
+The user sees: a slightly longer first open ("Reindicizzazione…"
+toast), then everything works. No data loss possible — the index is
+derivable.
+
+A "skip rebuild" path runs when the user has an entirely fresh vault
+(no notes); seed copy still happens.
+
+## 8. Phasing
+
+Five PRs, each on its own branch, each green (typecheck + lint + tests)
+before merging the next.
+
+### Phase 1 — Schema + indexer
+
+- New: `packages/core/src/markdown/relations.ts` (extractor),
+  `packages/core/src/seed-schemas/` (7 yaml files), schema yaml loader
+  in `packages/core/src/types/schema.ts`.
+- IPC: `types:list`, `relations:bySource`, `relations:byTarget`.
+- SQLite: schema bump, `relations` + `object_types` tables, drop
+  `wikilinks`.
+- Adapter: `replaceRelations`, `getRelations`, `getReverseRelations`,
+  `getTypeCounts`. `getBacklinks` reads from `relations` (compat).
+- Tests: extractor unit tests (parse YAML edge cases, malformed
+  values, list vs scalar, broken targets), adapter integration tests
+  (replace / query roundtrip), seed copy on first open.
+- No UI changes yet — the underpinning works headless.
+
+### Phase 2 — Right-pane object panel + sidebar TypesSection
+
+- New: `apps/desktop/src/components/ObjectPanel/` (replaces
+  BacklinksPanel for typed notes; both live behind the same right-pane
+  slot, switched by `currentNote.type`).
+- New: `apps/desktop/src/components/Sidebar/TypesSection.tsx` (mirror
+  of TagsSection).
+- Stores: `useTagsStore` generalises to `useTaxonomyStore` covering
+  selected type OR tag; the two filters are mutually exclusive.
+- Tests: object-panel rendering for typed/untyped, sidebar
+  type-counts integration, mutual-exclusion filter behaviour.
+
+### Phase 3 — Editor decoration + slash relation + PropertyEditor
+
+- Wikilink decoration with type icon — extension to the Wikilink
+  Tiptap node (read type from a small in-memory cache populated by
+  the vault store; no IPC per render).
+- Slash menu entry `↗ Aggiungi relazione` — opens a popover (kind
+  picker + wikilink autocomplete) and writes into
+  `frontmatter.relations`.
+- PropertyEditor: "Aggiungi proprietà" dropdown gains an "Aggiungi
+  relazione" branch.
+- Tests: decoration with cached / uncached type, slash entry persists
+  through markdown roundtrip, PropertyEditor relation editing.
+
+### Phase 4 — Database view type filter
+
+- DatabaseView header: type dropdown driven by `useTaxonomyStore`.
+- ColumnPicker: schema-aware suggestions (when type filter is set,
+  surface the schema's property + relation keys at the top of the
+  picker).
+- Tests: dropdown updates query state, schema-driven suggestion
+  ordering.
+
+### Phase 5 — Constellation graph
+
+- Layout engine: cluster bias forces, hull computation per type.
+- Render: hulls underneath, edge color per kind, legend, type chips,
+  relation-kind filter dropdown.
+- Tuning constants in `graph-tuning.ts`.
+- Tests: cluster-bias smoke (synthetic graph with two types ends with
+  separable clusters), hull computation against known input,
+  edge-color determinism.
+
+## 9. Risks + open questions
+
+- **Seed schema bikeshed**. The seven seed types are opinionated.
+  Mitigation: each schema yaml is one file, easy to delete; an
+  `INFO.md` in `.ziba/schema/` explains how to extend.
+- **Wikilink decoration cost**. Per-render lookup of "what type is
+  this target" must come from a renderer-side cache, not IPC. The
+  vault store already has the full notes list; we extend it with a
+  `pathToType` map updated on watcher events. Bounded cost.
+- **Relation autocomplete UX**. Picking the right kind from a flat
+  list of every kind across all schemas is bad at scale. v1.0
+  suggests kinds based on the **current note's type** first
+  (schema-relevant), then the long tail.
+- **Backward-incompat sense check**. Vaults built on v0.x have no
+  `type:` and no `relations:`. v1.0 must keep them perfectly usable.
+  Done: untyped notes flow through the legacy backlinks panel.
+
+## 10. Success criteria
+
+After v1.0 ships:
+
+1. Opening a typed note shows a populated object panel with
+   relations + inverse relations within 100ms (cached).
+2. Sidebar shows type counts that match `SELECT type, COUNT(*)` over
+   `note_properties`.
+3. The graph view, with cluster overlay on, makes types visually
+   distinct at a glance for a vault of 200+ notes mixing 5+ types.
+4. A user upgrading from v0.x sees no data loss and no functional
+   regression on their existing untyped notes.
+5. Seven seed schemas exist in a fresh vault and a contributor can
+   add an eighth (`movie.yml`) without touching code.
+
+## 11. Sequencing notes for the plan
+
+Each phase produces tests against pure modules first (extractor,
+schema loader, query helpers), then renderer wiring, then visual
+polish. Phase 5 is intentionally last because it depends on
+Phase 1's data shape (relation kinds, type colors).
+
+The local dir rename `Desktop/YC/synapsium` → `Desktop/YC/ziba` is
+**not** part of v1.0 — it's an environment housekeeping task that
+can happen any time, independent of the codebase.


### PR DESCRIPTION
## Summary

Design doc for v1.0. Pivots from "plugin system + web port" to an **Anytype-class object graph**:

- Typed objects via frontmatter (`type:` + `relations:`)
- Schema files in `.ziba/schema/<type>.yml` (7 first-party seeds)
- SQL: replaces `wikilinks` table with a unified `relations` table (kind='' = legacy body wikilink)
- Adaptive right-pane: object panel for typed notes, backlinks for untyped (backward compat)
- Sidebar: TypesSection above TagsSection
- Database view: type dropdown + schema-driven column suggestions
- Editor: wikilink decoration with type icon + slash menu relation entry
- **Constellation graph**: cluster bias forces, convex-hull overlays per type, edge color per relation kind, type/kind filters
- Zero-effort migration (cache rebuild)
- 5-phase plan, each phase its own PR

## Test plan

This is a design doc (no code). Sign-off required:

- [ ] Reviewer agrees with the data-model choice (frontmatter, kind='' sentinel, schema yamls)
- [ ] Reviewer agrees with the 5-phase split
- [ ] Reviewer agrees with the constellation-graph approach (cluster bias, hulls)

After merge: invoke `writing-plans` skill to produce the per-phase implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)