### PR TITLE
docs(plan): v1.0 phase 1 implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-10-v1.0-phase1-schema-indexer.md
+++ b/docs/superpowers/plans/2026-05-10-v1.0-phase1-schema-indexer.md
@@ -1,0 +1,685 @@
+# Ziba v1.0 Phase 1 — Schema + Indexer + Relations Table
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the headless foundation of v1.0 — typed object schemas, typed relations between notes, SQLite migration, IPC plumbing — so subsequent phases (object panel, sidebar TypesSection, database type filter, constellation graph) plug into a working data layer. No UI changes in this phase.
+
+**Architecture:** YAML schema files in `<vault>/.ziba/schema/<type>.yml` (mirrored into `object_types` SQLite cache on vault open). Frontmatter `type:` + `relations:` extracted by a pure module in `@ziba/core`, persisted via a unified `relations` SQL table that replaces the legacy `wikilinks` table (kind=`''` sentinel for backward-compat with body wikilinks). Seven first-party seed schemas copied into a fresh vault on first open. New IPC channels for the renderer to query relations and types.
+
+**Tech Stack:** TypeScript, `js-yaml` (new core dep), `better-sqlite3` (existing), Vitest, Electron IPC.
+
+**Branch:** `feat/v1.0-phase1-schema-indexer`. One commit per task. PR at the end against `main`.
+
+---
+
+### Task 0: Branch off main
+
+**Files:** none
+
+- [ ] **Step 1: Sync main**
+
+```
+git checkout main
+git pull --ff-only
+```
+
+Expected: `Already up to date.` or fast-forward to latest.
+
+- [ ] **Step 2: Create branch**
+
+```
+git checkout -b feat/v1.0-phase1-schema-indexer
+```
+
+Expected: `Switched to a new branch 'feat/v1.0-phase1-schema-indexer'`.
+
+---
+
+### Task 1: Add `js-yaml` to `@ziba/core` + schema TypeScript types
+
+**Files:**
+- Modify: `packages/core/package.json` (deps)
+- Create: `packages/core/src/types/schema.ts`
+- Modify: `packages/core/src/types/index.ts` (re-exports)
+
+- [ ] **Step 1: Add `js-yaml` dependency**
+
+```
+pnpm --filter @ziba/core add js-yaml
+pnpm --filter @ziba/core add -D @types/js-yaml
+```
+
+Expected: both add cleanly, `pnpm-lock.yaml` updated.
+
+- [ ] **Step 2: Write the schema types file**
+
+Create `packages/core/src/types/schema.ts` with:
+- `PropertySpec` (type, required?, label?)
+- `RelationSpec` (target, multiple?, label?)
+- `InverseRelationSpec` (reverse_of, label?)
+- `ObjectTypeSchema` (id, label, icon?, color?, properties, relations, inverse)
+- `SchemaParseResult` discriminated union (ok | errors)
+- `TYPE_SLUG_RE = /^[a-z][a-z0-9-]*$/`
+
+Each type carries a JSDoc comment explaining purpose and constraints. The schema model is "soft" — the indexer never refuses a save that diverges; the editor surfaces drift as a warning.
+
+- [ ] **Step 3: Re-export from the types barrel**
+
+Modify `packages/core/src/types/index.ts` — append `export * from './schema';`.
+
+- [ ] **Step 4: Verify it compiles**
+
+```
+pnpm typecheck
+```
+
+Expected: 3/3 successful.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/package.json pnpm-lock.yaml packages/core/src/types/schema.ts packages/core/src/types/index.ts
+git commit -m "feat(core): schema types + js-yaml dep (v1.0 phase 1)"
+```
+
+---
+
+### Task 2: Schema YAML parser with validation
+
+**Files:**
+- Modify: `packages/core/src/types/schema.ts` (add parser)
+- Create: `packages/core/src/types/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/types/schema.test.ts` with 7 cases:
+
+1. **happy path minimal** — `{ id, label, properties.title { type, required }, relations.author { target } }` → `result.ok === true`, default-empty `inverse: {}`.
+2. **icon + color preserved** when valid `#RRGGBB`.
+3. **malformed YAML** → `errors[0]` matches `/yaml/i`.
+4. **missing `id`** → errors contains `'id is required'`.
+5. **invalid slug `id`** (e.g. `"Book Title!"`) → errors mention "slug".
+6. **missing `label`** → errors contains `'label is required'`.
+7. **unknown property type** (e.g. `type: not-a-type`) → errors mention "property type".
+8. **all errors at once** — empty `id` + empty `label` returns BOTH errors, not just the first.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+pnpm --filter @ziba/core test schema.test.ts
+```
+
+Expected: FAIL — `parseSchemaYaml` is not exported.
+
+- [ ] **Step 3: Implement the parser**
+
+Append `parseSchemaYaml(content: string): SchemaParseResult` to `packages/core/src/types/schema.ts`. Implementation:
+
+1. `js-yaml`.`load(content)` inside try/catch; on `YAMLException` return `{ ok: false, errors: ['yaml parse error: ...'] }`.
+2. Validate the root is a non-array mapping.
+3. Accumulate errors for each section: id (slug-regex), label (non-empty), icon (string if present), color (matches `^#[0-9a-fA-F]{6}$` if present), properties (mapping of mappings), relations (mapping of mappings with `target` required), inverse (mapping of mappings with `reverse_of` required).
+4. `ALLOWED_PROPERTY_TYPES` is the existing `PropertyType` union: `'text' | 'number' | 'boolean' | 'date' | 'url' | 'string-array'`.
+5. Return all errors; if none, build the schema with optional fields conditionally set to satisfy `exactOptionalPropertyTypes: true`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```
+pnpm --filter @ziba/core test schema.test.ts
+```
+
+Expected: 8 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/types/schema.ts packages/core/src/types/schema.test.ts
+git commit -m "feat(core): parseSchemaYaml + 8-case validator (v1.0 phase 1)"
+```
+
+---
+
+### Task 3: Seven first-party seed schemas
+
+**Files:**
+- Create: `packages/core/src/seed-schemas/index.ts`
+- Modify: `packages/core/src/index.ts` (export `SEED_SCHEMAS`)
+- Test: `packages/core/src/seed-schemas/index.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/seed-schemas/index.test.ts`:
+
+1. `SEED_SCHEMA_IDS` equals the canonical seven: `['note', 'person', 'book', 'project', 'idea', 'daily', 'meeting']`.
+2. Each `SEED_SCHEMAS[id]` parses cleanly via `parseSchemaYaml` and `result.schema.id === id`.
+3. Each seed has both `icon` and a valid `#RRGGBB` `color`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+pnpm --filter @ziba/core test seed-schemas
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the seed schemas module**
+
+Create `packages/core/src/seed-schemas/index.ts`:
+
+- `SeedSchemaId` union of the 7 ids.
+- `SEED_SCHEMA_IDS: ReadonlyArray<SeedSchemaId>` in canonical order.
+- 7 raw YAML string constants (NOTE, PERSON, BOOK, PROJECT, IDEA, DAILY, MEETING) following the schema documented in §3.3 of the design doc. Each must include `id`, `label`, `icon`, `color`, `properties: {}` (or with entries), `relations: {}` (or with entries), `inverse: {}` (or with entries).
+- `SEED_SCHEMAS: Record<SeedSchemaId, string>` mapping id → YAML string.
+
+Reference colors from the design doc:
+- note `#71717a`, person `#f97316`, book `#6366f1`, project `#10b981`, idea `#eab308`, daily `#06b6d4`, meeting `#a855f7`.
+
+Reference relations from the design doc Table in §3.3.
+
+- [ ] **Step 4: Re-export from the package barrel**
+
+Modify `packages/core/src/index.ts` — append `export { SEED_SCHEMAS, SEED_SCHEMA_IDS, type SeedSchemaId } from './seed-schemas';`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```
+pnpm --filter @ziba/core test seed-schemas
+```
+
+Expected: 3 tests passed.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/seed-schemas/ packages/core/src/index.ts
+git commit -m "feat(core): 7 first-party seed schemas (v1.0 phase 1)"
+```
+
+---
+
+### Task 4: Relations extractor (frontmatter + body)
+
+**Files:**
+- Create: `packages/core/src/markdown/relations.ts`
+- Modify: `packages/core/src/markdown/index.ts` (re-export)
+- Test: `packages/core/src/markdown/relations.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/markdown/relations.test.ts` covering:
+
+**`extractType`**:
+- Valid slugs (`'book'`, `'multi-word-type'`) → returned.
+- Missing / non-string / array / null → `null`.
+- Slug regex failures (`'Book'` capital, `'book title'` space, `'1book'` leading digit, `''` empty) → `null`.
+
+**`extractFrontmatterRelations`**:
+- Scalar wikilink: `{ relations: { author: '[[Tolkien]]' } }` → `[{ kind: 'author', targetTitle: 'Tolkien' }]`.
+- List of wikilinks: `{ relations: { knows: ['[[Alice]]', '[[Bob]]'] } }` → 2 entries with same kind.
+- Heading ref stripped: `'[[Foo#section]]'` → `targetTitle: 'Foo'`.
+- Pipe alias: `'[[Tolkien|J.R.R.]]'` → `targetTitle: 'Tolkien'` (LHS).
+- Skips non-wikilink values silently (`'plain string'`, numeric, mixed list).
+- `{}` → `[]`. `{ relations: 'oops' }` → `[]`. `{ relations: ['nope'] }` → `[]`.
+
+**`extractBodyRelations`**:
+- `'See [[Foo]] and [[Bar|alias]] for context.'` → 2 entries with `kind: ''`.
+- Code-block exclusion is delegated to the existing `extractWikilinks` (verify by mixing inline `\`[[InCode]]\`` and a fenced block — only out-of-code links emit).
+- Empty body → `[]`.
+
+**`extractAllRelations`**:
+- Combines frontmatter + body, in that order.
+- De-duplicates per `(kind, targetTitle)` — body+frontmatter same `kind` and target = one entry; body wikilink with `kind: ''` and frontmatter `cites` with same target = TWO entries (different kinds).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+pnpm --filter @ziba/core test relations
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the extractor**
+
+Create `packages/core/src/markdown/relations.ts`:
+
+- Export `RelationEntry = { kind: string; targetTitle: string }`.
+- `parseWikilinkValue(raw: string): string | null` — regex `^\[\[([^\]]+)\]\]$` on the trimmed value, then strip pipe alias (LHS of `|`) and heading ref (LHS of `#`). Returns `null` for non-wikilink strings or empty inner.
+- `extractType(frontmatter)` — checks string + `TYPE_SLUG_RE`.
+- `extractFrontmatterRelations(frontmatter)` — iterates `Object.entries(rels)`, accepts scalar string or list, calls `parseWikilinkValue`, skips silently on parse failure.
+- `extractBodyRelations(body)` — calls existing `extractWikilinks` and maps to `{ kind: '', targetTitle }`.
+- `extractAllRelations({ frontmatter, content })` — uses a `Set<string>` keyed on `${kind}\x00${targetTitle}` to de-dup; processes frontmatter first, then body.
+
+- [ ] **Step 4: Re-export from the markdown barrel**
+
+Modify `packages/core/src/markdown/index.ts` — append `export * from './relations';`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```
+pnpm --filter @ziba/core test relations
+```
+
+Expected: ~16 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/markdown/relations.ts packages/core/src/markdown/relations.test.ts packages/core/src/markdown/index.ts
+git commit -m "feat(core): extractAllRelations + extractType (v1.0 phase 1)"
+```
+
+---
+
+### Task 5: SQLite schema bump + adapter interface extension
+
+**Files:**
+- Modify: `packages/core/src/index-store/schema.ts`
+- Modify: `packages/core/src/adapters/index-store.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Bump SCHEMA_SQL with new tables + drop legacy wikilinks**
+
+Edit `packages/core/src/index-store/schema.ts`:
+
+1. **Remove** the existing `wikilinks` `CREATE TABLE` block from `SCHEMA_SQL`.
+2. **Add** in its place: `relations` table (PK `(source_path, kind, target_title)` with `kind TEXT NOT NULL DEFAULT ''`, plus `target_path TEXT` nullable; indexes `relations_target_idx (target_path, kind)` and partial `relations_kind_idx (kind) WHERE kind <> ''`).
+3. **Add** `object_types` table (PK `id`, columns `label`, `icon` (NULL ok), `color` (NULL ok), `schema_json TEXT NOT NULL`, `mtime INTEGER NOT NULL`).
+4. Append after `SCHEMA_SQL`:
+   - `EXPECTED_USER_VERSION = 2` (with JSDoc explaining the bump and the bump rules).
+   - `MIGRATION_DROP_SQL` — `DROP TABLE IF EXISTS` for: `wikilinks`, `relations`, `object_types`, `notes_fts`, `note_properties`, `tags`, `notes`. Plus a JSDoc explaining that all these are cache-only and rebuild from disk on the next reindex.
+
+- [ ] **Step 2: Extend the IndexStoreAdapter interface**
+
+Edit `packages/core/src/adapters/index-store.ts`:
+
+1. Import `RelationEntry` from `../markdown/relations` and `ObjectTypeSchema` from `../types/schema`.
+2. Add and export two row types:
+   - `RelationRow = { sourcePath, kind, targetTitle, targetPath }` (camelCase mirror of the SQL row).
+   - `ObjectTypeRow = { id, label, icon: string|null, color: string|null, schema: ObjectTypeSchema, mtimeMs: number }`.
+3. Add to the `IndexStoreAdapter` interface (alongside existing methods like `replaceTags`):
+   - `replaceRelations(sourcePath, relations: RelationEntry[]): Promise<void>`
+   - `getRelations({ sourcePath, kind? }): Promise<RelationRow[]>`
+   - `getReverseRelations({ targetPath, kind? }): Promise<RelationRow[]>`
+   - `listObjectTypes(): Promise<ObjectTypeRow[]>`
+   - `upsertObjectType(row: ObjectTypeRow): Promise<void>`
+   - `deleteObjectType(id: string): Promise<void>`
+4. **Do NOT remove** the existing `replaceWikilinks` method yet — Task 7 swaps callers; we drop it as a follow-up in a later phase (or in Task 7 if it's only one call site).
+
+- [ ] **Step 3: Re-export from the package barrel**
+
+Edit `packages/core/src/index.ts` — append:
+
+- `export type { RelationEntry } from './markdown/relations';`
+- `export type { RelationRow, ObjectTypeRow } from './adapters/index-store';`
+- `export { EXPECTED_USER_VERSION, MIGRATION_DROP_SQL } from './index-store/schema';`
+
+- [ ] **Step 4: Verify @ziba/core builds**
+
+```
+pnpm --filter @ziba/core build
+```
+
+Expected: clean build. The desktop app may not yet typecheck (Task 6 fixes that) — don't run the whole repo typecheck here.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/index-store/schema.ts packages/core/src/adapters/index-store.ts packages/core/src/index.ts
+git commit -m "feat(core): SQLite schema v2 + adapter relations interface (v1.0 phase 1)"
+```
+
+---
+
+### Task 6: SQLite adapter — relations + migration
+
+**Files:**
+- Modify: `apps/desktop/electron/adapters/index-store.sqlite.ts`
+
+- [ ] **Step 1: Add migration on open**
+
+Update the imports at the top of `index-store.sqlite.ts` to also pull in `EXPECTED_USER_VERSION`, `MIGRATION_DROP_SQL`, `ObjectTypeRow`, `RelationEntry`, `RelationRow` from `@ziba/core`.
+
+In the opener (find `db.exec(SCHEMA_SQL)`), insert RIGHT AFTER:
+
+```
+const versionRow = db.prepare('PRAGMA user_version').get() as { user_version: number };
+if (versionRow.user_version < EXPECTED_USER_VERSION) {
+  db.exec(MIGRATION_DROP_SQL);
+  db.exec(SCHEMA_SQL);
+  db.exec(`PRAGMA user_version = ${EXPECTED_USER_VERSION}`);
+}
+```
+
+(Why drop everything? Index is a cache. The reindex pipeline rebuilds notes/properties/tags/fts on the next open. Cheap and clean.)
+
+- [ ] **Step 2: Replace wikilinks prepared statements with relations equivalents**
+
+Find the prepared-statement construction block (`s = { upsertNote: ..., ... }`). Replace `wikilinks`-touching statements:
+
+- `deleteWikilinksFor` → `deleteRelationsFor: db.prepare('DELETE FROM relations WHERE source_path = ?')`.
+- `insertWikilink` → `insertRelation: db.prepare(\`INSERT INTO relations (source_path, kind, target_title, target_path) VALUES (?, ?, ?, ?) ON CONFLICT (source_path, kind, target_title) DO UPDATE SET target_path = excluded.target_path\`)`.
+- `getBacklinks` → reads `relations` `WHERE target_path = ?` ordered by `(kind, source_path)`. Same shape as before; UI layers don't change.
+- Add: `getRelationsBySource`, `getRelationsBySourceAndKind`, `getReverseRelations`, `getReverseRelationsByKind`. Each `SELECT source_path, kind, target_title, target_path FROM relations WHERE ...`.
+- `clearWikilinks` → `clearRelations: db.prepare('DELETE FROM relations')`.
+- Keep `resolveTitle` (it queries `notes`, not `wikilinks` — unchanged).
+- Add `upsertObjectType`, `deleteObjectType`, `listObjectTypes` prepared statements (full SQL in the design doc §4.1; standard ON CONFLICT upsert).
+
+- [ ] **Step 3: Update the `clear()` method**
+
+In the existing `clear()` method, replace `s.clearWikilinks.run()` with `s.clearRelations.run()`. Other table clears stay.
+
+- [ ] **Step 4: Implement the new adapter methods**
+
+Append inside `SqliteIndexStore`:
+
+1. `replaceRelations(sourcePath, relations)` — wraps a transaction: `deleteRelationsFor.run(src)` then `insertRelation.run(src, r.kind, r.targetTitle, null)` for each entry. `target_path` is left NULL by the indexer (resolution is a separate concern; for Phase 1 the renderer queries with `target_title` joins or accepts unresolved).
+2. `getRelations({ sourcePath, kind? })` — branches on kind presence; returns rows mapped through a small helper.
+3. `getReverseRelations({ targetPath, kind? })` — symmetric.
+4. `listObjectTypes()` — selects all, maps `schema_json` → `JSON.parse(...)` into `schema`.
+5. `upsertObjectType(row)` — runs the upsert prepared statement with `JSON.stringify(row.schema)`.
+6. `deleteObjectType(id)` — runs the delete.
+
+Add a module-level helper `rowToRelation(r) → RelationRow` next to the existing `sqliteRowToDetected` / `groupRowToValue`.
+
+- [ ] **Step 5: Verify typecheck**
+
+```
+pnpm typecheck
+```
+
+Expected: 3/3 successful. If the existing `replaceWikilinks` is still on the interface and SQLite-side, leave both for now — Task 7 swaps callers, then we can decide whether to drop the old method.
+
+- [ ] **Step 6: Commit**
+
+```
+git add apps/desktop/electron/adapters/index-store.sqlite.ts
+git commit -m "feat(desktop): SQLite relations + object_types + v2 migration (v1.0 phase 1)"
+```
+
+---
+
+### Task 7: Indexer pipeline — replace `replaceWikilinks` calls with `replaceRelations`
+
+**Files:**
+- Modify: `apps/desktop/electron/ipc/notes.ts` (and any other indexer call sites)
+- Possibly modify: `packages/core/src/adapters/index-store.ts` (drop `replaceWikilinks` if no callers remain)
+
+- [ ] **Step 1: Locate the indexer call sites**
+
+```
+grep -rn "replaceWikilinks\|extractWikilinks" apps/desktop/electron/ packages/core/src/
+```
+
+- [ ] **Step 2: Replace each call**
+
+For each occurrence in indexer code (typically in `apps/desktop/electron/ipc/notes.ts` save flow + initial reindex pass):
+
+Replace:
+
+```
+const wikilinks = extractWikilinks(note.content);
+await indexStore.replaceWikilinks(note.path, wikilinks);
+```
+
+With:
+
+```
+import { extractAllRelations } from '@ziba/core';
+// ...
+const relations = extractAllRelations({
+  frontmatter: note.frontmatter,
+  content: note.content,
+});
+await indexStore.replaceRelations(note.path, relations);
+```
+
+After all call sites are updated, `grep -rn replaceWikilinks` should return 0 hits across `apps/`. If so, remove the method from the `IndexStoreAdapter` interface AND from `SqliteIndexStore` (its prepared statements were already swapped in Task 6, so the implementation stub will be empty / dead).
+
+- [ ] **Step 3: Run typecheck**
+
+```
+pnpm typecheck
+```
+
+Expected: 3/3 successful.
+
+- [ ] **Step 4: Run the full test suite**
+
+```
+pnpm test
+```
+
+Expected: all green. Existing tests don't touch wikilinks directly (they test FTS, properties, tags); their pass means nothing broke.
+
+- [ ] **Step 5: Commit**
+
+```
+git add apps/desktop/electron/ipc/notes.ts packages/core/src/adapters/index-store.ts apps/desktop/electron/adapters/index-store.sqlite.ts
+git commit -m "feat(desktop): indexer calls extractAllRelations / replaceRelations (v1.0 phase 1)"
+```
+
+---
+
+### Task 8: IPC channels for relations + types
+
+**Files:**
+- Modify: `apps/desktop/shared/ipc.ts`
+- Create: `apps/desktop/electron/ipc/types.ts`
+- Modify: `apps/desktop/electron/ipc/index.ts`
+- Modify: `apps/desktop/src/lib/ipc.ts`
+
+- [ ] **Step 1: Extend `IpcChannels` + request/response types**
+
+In `apps/desktop/shared/ipc.ts`:
+
+1. Add to `IpcChannels` `as const`:
+   - `listObjectTypes: 'types:list'`
+   - `upsertObjectType: 'types:upsert'`
+   - `deleteObjectType: 'types:delete'`
+   - `getRelationsBySource: 'relations:bySource'`
+   - `getRelationsByTarget: 'relations:byTarget'`
+2. Re-export `ObjectTypeRow` and `RelationRow` from `@ziba/core` (they cross the IPC boundary).
+3. Add request types in `IpcRequests`:
+   - `[IpcChannels.listObjectTypes]: void`
+   - `[IpcChannels.upsertObjectType]: { row: ObjectTypeRow }`
+   - `[IpcChannels.deleteObjectType]: { id: string }`
+   - `[IpcChannels.getRelationsBySource]: { sourcePath: NotePath; kind?: string }`
+   - `[IpcChannels.getRelationsByTarget]: { targetPath: NotePath; kind?: string }`
+4. Add response types in `IpcResponses`:
+   - `[IpcChannels.listObjectTypes]: ObjectTypeRow[]`
+   - `[IpcChannels.upsertObjectType]: void`
+   - `[IpcChannels.deleteObjectType]: void`
+   - `[IpcChannels.getRelationsBySource]: RelationRow[]`
+   - `[IpcChannels.getRelationsByTarget]: RelationRow[]`
+
+- [ ] **Step 2: Create the handler module**
+
+Create `apps/desktop/electron/ipc/types.ts`:
+
+- 5 functions: `listObjectTypes`, `upsertObjectType`, `deleteObjectType`, `getRelationsBySource`, `getRelationsByTarget`.
+- Each is a thin pass-through to the `IndexStoreAdapter` accessed through the existing `getIndexStore()` (or whatever pattern `apps/desktop/electron/state.ts` exposes — copy the import shape from `apps/desktop/electron/ipc/links.ts`).
+- If no vault is open, throw `new IpcError('NO_VAULT', 'Nessun vault aperto.')` (matches existing handlers).
+
+- [ ] **Step 3: Register handlers**
+
+In `apps/desktop/electron/ipc/index.ts`:
+
+1. Import the 5 handler functions.
+2. Inside the registration block, add 5 `handle(IpcChannels.X, (args) => handlerX(args))` calls. For `listObjectTypes` use the void-args form `() => listObjectTypesHandler()`.
+
+- [ ] **Step 4: Add renderer client methods**
+
+In `apps/desktop/src/lib/ipc.ts`:
+
+1. Update the `import type { ... } from '../../shared/ipc';` to also import `ObjectTypeRow` and `RelationRow`.
+2. Append 5 methods to the `ipc` object: `listObjectTypes()`, `upsertObjectType(args)`, `deleteObjectType(args)`, `getRelationsBySource(args)`, `getRelationsByTarget(args)`. Each is a one-line `return api().invoke(IpcChannels.X, args);`.
+
+- [ ] **Step 5: Verify typecheck**
+
+```
+pnpm typecheck
+```
+
+Expected: 3/3 successful.
+
+- [ ] **Step 6: Commit**
+
+```
+git add apps/desktop/shared/ipc.ts apps/desktop/electron/ipc/types.ts apps/desktop/electron/ipc/index.ts apps/desktop/src/lib/ipc.ts
+git commit -m "feat(ipc): channels for object types + typed relations (v1.0 phase 1)"
+```
+
+---
+
+### Task 9: Schema loader + seed bootstrap on vault open
+
+**Files:**
+- Create: `apps/desktop/electron/schema-loader.ts`
+- Modify: `apps/desktop/electron/ipc/vault.ts`
+
+- [ ] **Step 1: Write the schema loader**
+
+Create `apps/desktop/electron/schema-loader.ts` exporting `bootstrapSchemas(vaultRoot, store): Promise<{ loaded: number }>`.
+
+Two private helpers:
+
+1. `ensureSeedSchemas(vaultRoot)`: `mkdir -p <vault>/.ziba/schema/`. Read directory; if there are no `.yml` / `.yaml` files, write each `SEED_SCHEMAS[id]` to `<dir>/<id>.yml`. **Never overwrite** existing files — the user owns this directory.
+2. `loadSchemasIntoStore(vaultRoot, store)`: read every `.yml` / `.yaml`; for each, read content + stat for `mtimeMs`; `parseSchemaYaml`; on parse failure log to `console.error` and skip; on success build an `ObjectTypeRow` and `await store.upsertObjectType(row)`. Return the count loaded.
+
+The public `bootstrapSchemas` calls them in order. Idempotent — safe to call on every open.
+
+Imports: `INDEX_DIR_NAME`, `SEED_SCHEMAS`, `SEED_SCHEMA_IDS`, `parseSchemaYaml`, `IndexStoreAdapter`, `ObjectTypeRow` — all from `@ziba/core`.
+
+- [ ] **Step 2: Wire the bootstrap into `openVault`**
+
+In `apps/desktop/electron/ipc/vault.ts`, find where the index store is initialized inside the `openVault` handler. After init, before returning to the renderer, add:
+
+```
+import { bootstrapSchemas } from '../schema-loader';
+// inside openVault:
+await bootstrapSchemas(vaultRoot, store);
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+```
+pnpm typecheck
+```
+
+Expected: 3/3 successful.
+
+- [ ] **Step 4: Commit**
+
+```
+git add apps/desktop/electron/schema-loader.ts apps/desktop/electron/ipc/vault.ts
+git commit -m "feat(desktop): schema loader + seed bootstrap on openVault (v1.0 phase 1)"
+```
+
+---
+
+### Task 10: Adapter integration test (in-memory SQLite)
+
+**Files:**
+- Create: `apps/desktop/electron/adapters/index-store-relations.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/electron/adapters/index-store-relations.test.ts`. Uses `better-sqlite3` `:memory:` so we exercise real prepared statements.
+
+Setup with `beforeEach`: open `:memory:`, run `PRAGMAS`, run `SCHEMA_SQL`, set `user_version = EXPECTED_USER_VERSION`. `afterEach`: close.
+
+Test cases:
+
+1. **typed relation round-trip** — INSERT `('src/a.md', 'author', 'Tolkien', 'src/people/tolkien.md')`, SELECT WHERE `target_path = 'src/people/tolkien.md'` returns one row matching.
+2. **`''` sentinel for body wikilinks** — INSERT with `kind = ''`, SELECT WHERE `kind = ''` returns it. Partial index `kind <> ''` MUST not block this insert.
+3. **replace-by-source via tx** — pre-insert old, run a transaction that deletes by source then inserts new, verify only the new row remains.
+4. **PK uniqueness** — duplicate `(source, kind, target)` throws `UNIQUE`. Same source + target with different `kind` does NOT throw (different rows).
+5. **migration drops legacy `wikilinks`** — manually `CREATE TABLE wikilinks (...)`, set `user_version = 1`, run `MIGRATION_DROP_SQL` + `SCHEMA_SQL` + bump version. Verify `wikilinks` is gone, `relations` exists and is empty.
+6. **object_types upsert + list** — upsert two rows, list returns ordered by id. Re-upsert one with new label updates in place.
+
+- [ ] **Step 2: Run the tests**
+
+```
+pnpm --filter ziba-desktop test electron/adapters/index-store-relations.test.ts
+```
+
+Expected: 6 tests passing.
+
+- [ ] **Step 3: Commit**
+
+```
+git add apps/desktop/electron/adapters/index-store-relations.test.ts
+git commit -m "test(desktop): adapter relations round-trip + migration coverage (v1.0 phase 1)"
+```
+
+---
+
+### Task 11: Final verification + open PR
+
+**Files:** none new
+
+- [ ] **Step 1: Run the entire suite**
+
+```
+cd /Users/francescogiannicola/Desktop/YC/synapsium
+pnpm typecheck && pnpm test && pnpm lint
+```
+
+Expected: typecheck clean (3/3), 360+ tests passing (was 340 → +~25 from this phase), lint clean.
+
+- [ ] **Step 2: Push the branch**
+
+```
+git push -u origin feat/v1.0-phase1-schema-indexer
+```
+
+- [ ] **Step 3: Open the PR**
+
+Use `gh pr create --base main --head feat/v1.0-phase1-schema-indexer --title "feat(v1.0 phase 1): schema + indexer + relations table"` with a body that summarizes:
+
+- @ziba/core schema TypeScript types + YAML parser (8 validator cases)
+- 7 first-party seed schemas (note, person, book, project, idea, daily, meeting)
+- `extractType` + `extractAllRelations` pure extractors with 16+ unit tests
+- SQLite schema bump to v2: drops legacy `wikilinks`, introduces unified `relations` (`kind=''` sentinel) + `object_types`. One-shot migration via `PRAGMA user_version` mismatch — index is a cache, no data loss.
+- Adapter interface extended: 6 new methods. SQLite implementation in `index-store.sqlite.ts`.
+- `getBacklinks` reads from `relations` (kind-agnostic) — preserves v0.x behaviour.
+- Indexer pipeline calls `extractAllRelations` + `replaceRelations`.
+- 5 IPC channels.
+- Schema loader + seed bootstrap on `openVault`.
+- Adapter integration tests use in-memory SQLite — first time we exercise real prepared statements in tests.
+
+Test plan in the body:
+- typecheck / test / lint clean
+- Manual: open existing v0.x vault → no data loss, backlinks still work
+- Manual: open empty vault → 7 seed YAMLs created
+- Manual: a note with `type: book` and `relations: { author: [[Tolkien]] }` → `getRelationsBySource({ sourcePath })` returns the entry
+
+- [ ] **Step 4: Mark the plan complete**
+
+Phase 1 is done. Subsequent phases (2-5 from the design doc) build on top: object panel, sidebar TypesSection, database type filter, constellation graph.
+
+---
+
+## Self-review
+
+**Spec coverage** (Phase 1 requirements from `docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md` §8):
+
+- ✅ `relations.ts` extractor → Task 4
+- ✅ schema yaml loader in `types/schema.ts` → Tasks 1-2
+- ✅ 7 seed YAML strings → Task 3
+- ✅ IPC channels (`types:list`, `relations:bySource`, `relations:byTarget`, plus 2 admin channels) → Task 8
+- ✅ SQLite schema bump → Task 5
+- ✅ `relations` + `object_types` tables → Task 5 + 6
+- ✅ Drop `wikilinks` table → Task 5 (`MIGRATION_DROP_SQL`) + Task 6 (migration trigger)
+- ✅ Adapter methods (`replaceRelations`, `getRelations`, `getReverseRelations`) → Task 5 + 6
+- ✅ `getBacklinks` reroute via relations → Task 6
+- ✅ Adapter integration tests → Task 10
+- ✅ Seed copy on first open → Task 9
+- ✅ No UI changes — verified, no renderer components touched
+
+**Placeholder scan**: no TBDs, no "implement later", every step has either a runnable command, a code-shape description, or a concrete file edit.
+
+**Type consistency**:
+- `RelationEntry = { kind, targetTitle }` defined in Task 4, consumed by `replaceRelations` in Task 5+6.
+- `RelationRow = { sourcePath, kind, targetTitle, targetPath }` defined in Task 5, returned by `getRelations` / `getReverseRelations` and propagated through IPC in Task 8.
+- `ObjectTypeRow = { id, label, icon, color, schema, mtimeMs }` defined in Task 5, written by Task 9's loader, returned by Task 6's `listObjectTypes`, propagated through IPC in Task 8.
+- `EXPECTED_USER_VERSION = 2` defined in Task 5, used in Task 6 migration check and Task 10 test setup.


### PR DESCRIPTION
11-task TDD plan for Phase 1 (schema types + YAML parser + 7 seed schemas + relations extractor + SQLite v2 migration + adapter methods + IPC channels + schema bootstrap + integration tests). Each task self-contained with bite-sized steps. Self-review confirms full spec coverage from `docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md`.

Implementation will follow on `feat/v1.0-phase1-schema-indexer` after this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)