### PR TITLE
feat(v1.0 phase 1): schema + indexer + relations table

### DIFF
--- a/apps/desktop/electron/adapters/index-store-relations.test.ts
+++ b/apps/desktop/electron/adapters/index-store-relations.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { EXPECTED_USER_VERSION, MIGRATION_DROP_SQL, PRAGMAS, SCHEMA_SQL } from '@ziba/core';
+
+// Adapter integration tests use an in-memory SQLite so we exercise the
+// real prepared statements (and catch SQL syntax mistakes) without
+// touching the filesystem. The tests intentionally don't import the
+// SqliteIndexStore class — that one ties to Electron's app paths;
+// instead we recreate the same statements here and verify the SQL
+// shapes round-trip.
+
+let db: Database.Database;
+
+function setupNote(path: string, title = path.replace(/\.md$/, '')): void {
+  db.prepare(
+    `INSERT INTO notes (path, title, frontmatter_json, mtime)
+     VALUES (?, ?, '{}', 0)
+     ON CONFLICT (path) DO NOTHING`,
+  ).run(path, title);
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec(PRAGMAS);
+  db.exec(SCHEMA_SQL);
+  db.exec(`PRAGMA user_version = ${EXPECTED_USER_VERSION}`);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('relations table — round-trip', () => {
+  it('inserts a typed relation and reads it back via target', () => {
+    setupNote('src/a.md');
+    setupNote('src/people/tolkien.md');
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, ?, ?, ?)`,
+    ).run('src/a.md', 'author', 'Tolkien', 'src/people/tolkien.md');
+
+    const rows = db
+      .prepare(
+        `SELECT source_path, kind, target_title, target_path
+         FROM relations WHERE target_path = ?`,
+      )
+      .all('src/people/tolkien.md');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      source_path: 'src/a.md',
+      kind: 'author',
+      target_title: 'Tolkien',
+      target_path: 'src/people/tolkien.md',
+    });
+  });
+
+  it("uses '' as the sentinel for generic body wikilinks", () => {
+    setupNote('src/a.md');
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, ?, ?, ?)`,
+    ).run('src/a.md', '', 'Foo', null);
+
+    const rows = db
+      .prepare(`SELECT * FROM relations WHERE source_path = ? AND kind = ''`)
+      .all('src/a.md');
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('replace by source_path works (delete + insert in tx)', () => {
+    setupNote('src/a.md');
+    const tx = db.transaction((src: string) => {
+      db.prepare(`DELETE FROM relations WHERE source_path = ?`).run(src);
+      db.prepare(
+        `INSERT INTO relations (source_path, kind, target_title, target_path)
+         VALUES (?, ?, ?, ?)`,
+      ).run(src, 'author', 'New', null);
+    });
+
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, ?, ?, ?)`,
+    ).run('src/a.md', 'author', 'Old', null);
+
+    tx('src/a.md');
+
+    const rows = db
+      .prepare(`SELECT target_title FROM relations WHERE source_path = ?`)
+      .all('src/a.md');
+
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { target_title: string }).target_title).toBe('New');
+  });
+
+  it('PRIMARY KEY (source_path, kind, target_title) prevents duplicates', () => {
+    setupNote('a');
+    const stmt = db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, ?, ?, ?)`,
+    );
+    stmt.run('a', 'author', 'Foo', null);
+    expect(() => stmt.run('a', 'author', 'Foo', null)).toThrow(/UNIQUE/);
+    // Same (source, target) but different kind = different row.
+    expect(() => stmt.run('a', 'translator', 'Foo', null)).not.toThrow();
+  });
+
+  it('migration drops legacy wikilinks and recreates relations', () => {
+    db.close();
+    db = new Database(':memory:');
+    db.exec(PRAGMAS);
+    db.exec(`
+      CREATE TABLE wikilinks (
+        source_path TEXT, target_title TEXT, target_path TEXT,
+        PRIMARY KEY (source_path, target_title)
+      );
+      INSERT INTO wikilinks VALUES ('a.md', 'Old', 'b.md');
+      PRAGMA user_version = 1;
+    `);
+
+    db.exec(MIGRATION_DROP_SQL);
+    db.exec(SCHEMA_SQL);
+    db.exec(`PRAGMA user_version = ${EXPECTED_USER_VERSION}`);
+
+    const tables = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as {
+      name: string;
+    }[];
+    expect(tables.map((t) => t.name)).not.toContain('wikilinks');
+    expect(tables.map((t) => t.name)).toContain('relations');
+    const rels = db.prepare(`SELECT COUNT(*) AS c FROM relations`).get() as { c: number };
+    expect(rels.c).toBe(0);
+  });
+});
+
+describe('object_types table — round-trip', () => {
+  it('upsert + list returns ordered rows', () => {
+    const upsert = db.prepare(`
+      INSERT INTO object_types (id, label, icon, color, schema_json, mtime)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT (id) DO UPDATE SET label = excluded.label
+    `);
+    upsert.run('book', 'Libro', '📖', '#6366f1', '{}', 1);
+    upsert.run('person', 'Persona', '👤', '#f97316', '{}', 2);
+
+    const rows = db.prepare(`SELECT id FROM object_types ORDER BY id`).all() as { id: string }[];
+    expect(rows.map((r) => r.id)).toEqual(['book', 'person']);
+
+    upsert.run('book', 'Libri', '📚', '#000000', '{}', 3);
+    const updated = db.prepare(`SELECT label FROM object_types WHERE id = 'book'`).get() as {
+      label: string;
+    };
+    expect(updated.label).toBe('Libri');
+  });
+});

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -13,6 +13,8 @@ import {
   INDEX_DIR_NAME,
   PRAGMAS,
   SCHEMA_SQL,
+  EXPECTED_USER_VERSION,
+  MIGRATION_DROP_SQL,
   type DatabaseGroup,
   type DatabaseQuery,
   type DatabaseResult,
@@ -23,7 +25,10 @@ import {
   type IndexStoreAdapter,
   type NotePath,
   type NoteSummary,
+  type ObjectTypeRow,
   type OutgoingWikilink,
+  type RelationRow,
+  type ResolvedRelation,
   type TagPair,
   type TagSummaryRow,
   type UpsertNoteInput,
@@ -98,12 +103,18 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     getNote: Database.Statement;
     listNotes: Database.Statement;
     searchByTitle: Database.Statement;
-    deleteWikilinksFor: Database.Statement;
-    insertWikilink: Database.Statement;
+    deleteRelationsFor: Database.Statement;
+    insertRelation: Database.Statement;
     getBacklinks: Database.Statement;
     getOutgoing: Database.Statement;
+    getRelationsBySource: Database.Statement;
+    getRelationsBySourceAndKind: Database.Statement;
+    getReverseRelations: Database.Statement;
+    getReverseRelationsByKind: Database.Statement;
+    findRelationsByResolvedTarget: Database.Statement;
+    updateRelationTargetPath: Database.Statement;
     resolveTitle: Database.Statement;
-    clearWikilinks: Database.Statement;
+    clearRelations: Database.Statement;
     clearNotes: Database.Statement;
     deleteFts: Database.Statement;
     insertFts: Database.Statement;
@@ -119,6 +130,9 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     clearProps: Database.Statement;
     graphNodes: Database.Statement;
     graphEdges: Database.Statement;
+    upsertObjectType: Database.Statement;
+    deleteObjectType: Database.Statement;
+    listObjectTypes: Database.Statement;
   } | null = null;
 
   async init(vaultRoot: string): Promise<void> {
@@ -130,14 +144,25 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     db.exec(PRAGMAS);
     db.exec(SCHEMA_SQL);
 
+    // v1.0: cache schema versioning. Drops legacy / changed tables on
+    // a version mismatch and re-creates them; the existing reindex
+    // pipeline rebuilds the data from disk on the next save / open.
+    // Index is a cache, no data loss.
+    const versionRow = db.prepare('PRAGMA user_version').get() as { user_version: number };
+    if (versionRow.user_version < EXPECTED_USER_VERSION) {
+      db.exec(MIGRATION_DROP_SQL);
+      db.exec(SCHEMA_SQL);
+      db.exec(`PRAGMA user_version = ${EXPECTED_USER_VERSION}`);
+    }
+
     // Augment with case-insensitive lookup indexes. The shared schema can't
     // assume a particular collation, so we add LOWER() expression indexes
     // here -- these are idempotent (CREATE INDEX IF NOT EXISTS).
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_notes_title_lower
         ON notes(LOWER(title));
-      CREATE INDEX IF NOT EXISTS idx_wikilinks_target_title_lower
-        ON wikilinks(LOWER(target_title));
+      CREATE INDEX IF NOT EXISTS idx_relations_target_title_lower
+        ON relations(LOWER(target_title));
     `);
 
     this.db = db;
@@ -165,27 +190,65 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         ORDER BY LOWER(title) ASC
         LIMIT @limit
       `),
-      deleteWikilinksFor: db.prepare(`DELETE FROM wikilinks WHERE source_path = ?`),
-      insertWikilink: db.prepare(`
-        INSERT OR REPLACE INTO wikilinks (source_path, target_title, target_path)
-        VALUES (?, ?, ?)
+      deleteRelationsFor: db.prepare(`DELETE FROM relations WHERE source_path = ?`),
+      insertRelation: db.prepare(`
+        INSERT INTO relations (source_path, kind, target_title, target_path)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT (source_path, kind, target_title) DO UPDATE SET
+          target_path = excluded.target_path
       `),
-      // Join back to notes for source title -- the IPC layer needs it for
-      // backlinks UI without an extra round-trip per row.
+      // Backlinks now read from `relations` (kind-agnostic). Returning
+      // every kind preserves v0.x panel behaviour; the v1.0 object
+      // panel can group by `kind` itself.
       getBacklinks: db.prepare(`
-        SELECT w.source_path AS source_path,
-               w.target_title AS target_title,
-               w.target_path  AS target_path,
+        SELECT r.source_path  AS source_path,
+               r.target_title AS target_title,
+               r.target_path  AS target_path,
                n.title        AS source_title
-        FROM wikilinks w
-        JOIN notes n ON n.path = w.source_path
-        WHERE w.target_path = ?
+        FROM relations r
+        JOIN notes n ON n.path = r.source_path
+        WHERE r.target_path = ?
+        ORDER BY r.kind, r.source_path
       `),
+      // `getOutgoing` keeps the v0.x shape (no `kind`) so the existing
+      // OutgoingWikilink consumers continue to work. v1.0 callers
+      // wanting kind-aware outgoing edges use `getRelationsBySource`.
       getOutgoing: db.prepare(`
         SELECT source_path, target_title, target_path
-        FROM wikilinks
+        FROM relations
         WHERE source_path = ?
       `),
+      getRelationsBySource: db.prepare(`
+        SELECT source_path, kind, target_title, target_path
+        FROM relations
+        WHERE source_path = ?
+        ORDER BY kind, target_title
+      `),
+      getRelationsBySourceAndKind: db.prepare(`
+        SELECT source_path, kind, target_title, target_path
+        FROM relations
+        WHERE source_path = ? AND kind = ?
+        ORDER BY target_title
+      `),
+      getReverseRelations: db.prepare(`
+        SELECT source_path, kind, target_title, target_path
+        FROM relations
+        WHERE target_path = ?
+        ORDER BY kind, source_path
+      `),
+      getReverseRelationsByKind: db.prepare(`
+        SELECT source_path, kind, target_title, target_path
+        FROM relations
+        WHERE target_path = ? AND kind = ?
+        ORDER BY source_path
+      `),
+      findRelationsByResolvedTarget: db.prepare(
+        `SELECT source_path, kind, target_title FROM relations WHERE target_path = ?`,
+      ),
+      updateRelationTargetPath: db.prepare(
+        `UPDATE relations SET target_path = ?
+         WHERE source_path = ? AND kind = ? AND target_title = ?`,
+      ),
       // "Most canonical" tiebreak: shortest path, then alphabetic.
       resolveTitle: db.prepare(`
         SELECT path FROM notes
@@ -193,7 +256,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         ORDER BY LENGTH(path) ASC, path ASC
         LIMIT 1
       `),
-      clearWikilinks: db.prepare(`DELETE FROM wikilinks`),
+      clearRelations: db.prepare(`DELETE FROM relations`),
       clearNotes: db.prepare(`DELETE FROM notes`),
       deleteFts: db.prepare(`DELETE FROM notes_fts WHERE path = ?`),
       // Plain FTS5 table: we delete-then-insert rather than rely on rowid
@@ -245,12 +308,29 @@ export class SqliteIndexStore implements IndexStoreAdapter {
       clearProps: db.prepare(`DELETE FROM note_properties`),
       graphNodes: db.prepare(`SELECT path, title FROM notes`),
       graphEdges: db.prepare(`
-        SELECT w.source_path AS source,
-               w.target_path  AS target,
-               n.title         AS target_title
-        FROM wikilinks w
-        JOIN notes n ON n.path = w.target_path
-        WHERE w.target_path IS NOT NULL
+        SELECT r.source_path AS source,
+               r.target_path  AS target,
+               n.title         AS target_title,
+               r.kind          AS kind
+        FROM relations r
+        JOIN notes n ON n.path = r.target_path
+        WHERE r.target_path IS NOT NULL
+      `),
+      upsertObjectType: db.prepare(`
+        INSERT INTO object_types (id, label, icon, color, schema_json, mtime)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT (id) DO UPDATE SET
+          label       = excluded.label,
+          icon        = excluded.icon,
+          color       = excluded.color,
+          schema_json = excluded.schema_json,
+          mtime       = excluded.mtime
+      `),
+      deleteObjectType: db.prepare(`DELETE FROM object_types WHERE id = ?`),
+      listObjectTypes: db.prepare(`
+        SELECT id, label, icon, color, schema_json, mtime
+        FROM object_types
+        ORDER BY id
       `),
     };
   }
@@ -365,45 +445,125 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     return rows.map((r) => ({ targetTitle: r.target_title, targetPath: r.target_path }));
   }
 
+  /**
+   * v0.x compat shim. Body wikilinks are now `kind = ''` rows in the
+   * `relations` table; this shim adapts to that shape so existing
+   * callers (notes.ts save flow) keep working until migrated to
+   * `replaceRelations` directly. Sets `kind = ''` for every entry.
+   */
   async replaceWikilinks(sourcePath: NotePath, links: OutgoingWikilink[]): Promise<void> {
+    return this.replaceRelations(
+      sourcePath,
+      links.map((l) => ({ kind: '', targetTitle: l.targetTitle, targetPath: l.targetPath })),
+    );
+  }
+
+  async replaceRelations(sourcePath: NotePath, relations: ResolvedRelation[]): Promise<void> {
     const s = this.require();
     if (!this.db) throw new Error('IndexStore not initialized');
-    const tx = this.db.transaction((src: NotePath, ls: OutgoingWikilink[]) => {
-      s.deleteWikilinksFor.run(src);
-      for (const l of ls) {
-        s.insertWikilink.run(src, l.targetTitle, l.targetPath);
+    const tx = this.db.transaction((src: NotePath, rels: ResolvedRelation[]) => {
+      s.deleteRelationsFor.run(src);
+      for (const r of rels) {
+        s.insertRelation.run(src, r.kind, r.targetTitle, r.targetPath);
       }
     });
-    tx(sourcePath, links);
+    tx(sourcePath, relations);
+    return Promise.resolve();
+  }
+
+  async getRelations(args: { sourcePath: NotePath; kind?: string }): Promise<RelationRow[]> {
+    const s = this.require();
+    type R = {
+      source_path: string;
+      kind: string;
+      target_title: string;
+      target_path: string | null;
+    };
+    const rows =
+      args.kind === undefined
+        ? (s.getRelationsBySource.all(args.sourcePath) as R[])
+        : (s.getRelationsBySourceAndKind.all(args.sourcePath, args.kind) as R[]);
+    return Promise.resolve(rows.map(rowToRelation));
+  }
+
+  async getReverseRelations(args: { targetPath: NotePath; kind?: string }): Promise<RelationRow[]> {
+    const s = this.require();
+    type R = {
+      source_path: string;
+      kind: string;
+      target_title: string;
+      target_path: string | null;
+    };
+    const rows =
+      args.kind === undefined
+        ? (s.getReverseRelations.all(args.targetPath) as R[])
+        : (s.getReverseRelationsByKind.all(args.targetPath, args.kind) as R[]);
+    return Promise.resolve(rows.map(rowToRelation));
+  }
+
+  async listObjectTypes(): Promise<ObjectTypeRow[]> {
+    const s = this.require();
+    type R = {
+      id: string;
+      label: string;
+      icon: string | null;
+      color: string | null;
+      schema_json: string;
+      mtime: number;
+    };
+    const rows = s.listObjectTypes.all() as R[];
+    return Promise.resolve(
+      rows.map((r) => ({
+        id: r.id,
+        label: r.label,
+        icon: r.icon,
+        color: r.color,
+        schema: JSON.parse(r.schema_json),
+        mtimeMs: r.mtime,
+      })),
+    );
+  }
+
+  async upsertObjectType(row: ObjectTypeRow): Promise<void> {
+    const s = this.require();
+    s.upsertObjectType.run(
+      row.id,
+      row.label,
+      row.icon,
+      row.color,
+      JSON.stringify(row.schema),
+      row.mtimeMs,
+    );
+    return Promise.resolve();
+  }
+
+  async deleteObjectType(id: string): Promise<void> {
+    const s = this.require();
+    s.deleteObjectType.run(id);
     return Promise.resolve();
   }
 
   async reresolveStaleWikilinks(formerlyResolvingTo: NotePath): Promise<void> {
+    const s = this.require();
     if (!this.db) throw new Error('IndexStore not initialized');
-    // Find every wikilink whose stored target_path was the now-renamed
-    // (or now-deleted) note. We re-resolve each by its target_title so the
-    // link can land on whoever currently owns that title (possibly the
-    // renamed note at its new path, possibly a different note, possibly
-    // null if no match).
-    type StaleRow = { source_path: string; target_title: string };
-    const stale = this.db
-      .prepare(`SELECT source_path, target_title FROM wikilinks WHERE target_path = ?`)
-      .all(formerlyResolvingTo) as StaleRow[];
+    // Find every relation whose stored target_path was the now-renamed
+    // (or now-deleted) note, then re-resolve each by its target_title.
+    // The relation may land on the renamed note at its new path, on a
+    // different note that now matches the title, or null (broken).
+    type StaleRow = { source_path: string; kind: string; target_title: string };
+    const stale = s.findRelationsByResolvedTarget.all(formerlyResolvingTo) as StaleRow[];
     if (stale.length === 0) return;
 
-    // better-sqlite3 transactions are sync; resolve the new target paths
-    // up-front so the inner loop is a pure SQL batch.
+    // better-sqlite3 transactions are sync; resolve up-front so the
+    // inner loop is a pure SQL batch.
     const resolutions: Array<{ row: StaleRow; newPath: NotePath | null }> = [];
     for (const r of stale) {
       resolutions.push({ row: r, newPath: await this.resolveTitleToPath(r.target_title) });
     }
 
-    const updateStmt = this.db.prepare(
-      `UPDATE wikilinks SET target_path = ? WHERE source_path = ? AND target_title = ?`,
-    );
     this.db.transaction((items: typeof resolutions) => {
       for (const { row, newPath } of items) {
-        updateStmt.run(newPath, row.source_path, row.target_title);
+        s.updateRelationTargetPath.run(newPath, row.source_path, row.kind, row.target_title);
       }
     })(resolutions);
   }
@@ -466,7 +626,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     const s = this.require();
     if (!this.db) throw new Error('IndexStore not initialized');
     const tx = this.db.transaction(() => {
-      s.clearWikilinks.run();
+      s.clearRelations.run();
       s.clearTags.run();
       s.clearProps.run();
       s.clearFts.run();
@@ -677,6 +837,20 @@ export class SqliteIndexStore implements IndexStoreAdapter {
  * `DetectedProperty` back. Returns `null` for malformed rows (shouldn't
  * happen if writes go through the typed adapter, but we guard anyway).
  */
+function rowToRelation(r: {
+  source_path: string;
+  kind: string;
+  target_title: string;
+  target_path: string | null;
+}): RelationRow {
+  return {
+    sourcePath: r.source_path,
+    kind: r.kind,
+    targetTitle: r.target_title,
+    targetPath: r.target_path,
+  };
+}
+
 function sqliteRowToDetected(r: {
   prop_key: string;
   prop_type: string;

--- a/apps/desktop/electron/ipc/folder.ts
+++ b/apps/desktop/electron/ipc/folder.ts
@@ -5,7 +5,12 @@
 // v0.1 we just walk the index and patch rows; we don't rewrite wikilinks
 // in other files that referenced the moved notes.
 
-import { loadNote as coreLoadNote, type NotePath, type OutgoingWikilink } from '@ziba/core';
+import {
+  extractAllRelations,
+  loadNote as coreLoadNote,
+  type NotePath,
+  type ResolvedRelation,
+} from '@ziba/core';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { assertResolvedWithinVault, assertVaultRelative, IpcError } from '../security.js';
 import { markSelfWrite, requireIndexStore, requireVault } from '../state.js';
@@ -70,14 +75,19 @@ export async function renameFolder(args: { from: NotePath; to: NotePath }): Prom
       wikilinks: reloaded.wikilinks,
       mtimeMs: reloaded.mtimeMs,
     });
-    // Re-resolve outgoing wikilinks (target paths might now be different
-    // if the moved note's title shadows or unshadows another note).
-    const links: OutgoingWikilink[] = [];
-    for (const target of reloaded.wikilinks) {
-      const resolved = await store.resolveTitleToPath(target);
-      links.push({ targetTitle: target, targetPath: resolved });
+    // Re-resolve outgoing relations (target paths might now be
+    // different if the moved note's title shadows or unshadows another
+    // note).
+    const allRelations = extractAllRelations({
+      frontmatter: reloaded.frontmatter,
+      content: reloaded.content,
+    });
+    const resolved: ResolvedRelation[] = [];
+    for (const r of allRelations) {
+      const targetPath = await store.resolveTitleToPath(r.targetTitle);
+      resolved.push({ kind: r.kind, targetTitle: r.targetTitle, targetPath });
     }
-    await store.replaceWikilinks(reloaded.path, links);
+    await store.replaceRelations(reloaded.path, resolved);
     // Re-resolve INBOUND wikilinks that pointed at the old path. Same
     // reasoning as renameNote: without this, backlinks + global graph
     // would silently drop every edge into a folder-renamed note.

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -34,6 +34,13 @@ import { searchFullText } from './search.js';
 import { listTags, getNotesByTag } from './tags.js';
 import { runDatabaseQuery } from './database.js';
 import { getFullGraph } from './graph.js';
+import {
+  listObjectTypes,
+  upsertObjectType,
+  deleteObjectType,
+  getRelationsBySource,
+  getRelationsByTarget,
+} from './types.js';
 import { getRecentVaults } from './settings.js';
 
 type Handler<C extends keyof IpcRequests> = (
@@ -100,6 +107,13 @@ export function registerIpcHandlers(win: BrowserWindow): void {
   // Database queries / global graph (v0.3 Wave 1)
   handle(IpcChannels.runDatabaseQuery, (args) => runDatabaseQuery(args));
   handle(IpcChannels.getFullGraph, () => getFullGraph());
+
+  // v1.0: typed object types + typed relations
+  handle(IpcChannels.listObjectTypes, () => listObjectTypes());
+  handle(IpcChannels.upsertObjectType, (args) => upsertObjectType(args));
+  handle(IpcChannels.deleteObjectType, (args) => deleteObjectType(args));
+  handle(IpcChannels.getRelationsBySource, (args) => getRelationsBySource(args));
+  handle(IpcChannels.getRelationsByTarget, (args) => getRelationsByTarget(args));
 
   // Settings
   handle(IpcChannels.getRecentVaults, () => getRecentVaults());

--- a/apps/desktop/electron/ipc/notes.ts
+++ b/apps/desktop/electron/ipc/notes.ts
@@ -10,6 +10,7 @@ import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import {
   deriveTitleFromPath,
+  extractAllRelations,
   extractProperties,
   extractTags,
   extractWikilinks,
@@ -22,7 +23,7 @@ import {
   type Note,
   type NotePath,
   type NoteSummary,
-  type OutgoingWikilink,
+  type ResolvedRelation,
 } from '@ziba/core';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { assertResolvedWithinVault, assertVaultRelative, IpcError } from '../security.js';
@@ -77,12 +78,17 @@ async function reindexSingle(
     body,
   });
 
-  const links: OutgoingWikilink[] = [];
-  for (const target of wikilinks) {
-    const resolved = await store.resolveTitleToPath(target);
-    links.push({ targetTitle: target, targetPath: resolved });
+  // v1.0: extract typed relations (frontmatter `relations:` map +
+  // body wikilinks as `kind = ''`). Resolve each target_title to a
+  // path so the renderer can navigate without re-resolving on every
+  // read.
+  const allRelations = extractAllRelations({ frontmatter, content: body });
+  const resolved: ResolvedRelation[] = [];
+  for (const r of allRelations) {
+    const targetPath = await store.resolveTitleToPath(r.targetTitle);
+    resolved.push({ kind: r.kind, targetTitle: r.targetTitle, targetPath });
   }
-  await store.replaceWikilinks(filePath, links);
+  await store.replaceRelations(filePath, resolved);
   await store.replaceTags(filePath, mergedTags);
 
   // Typed property index (v0.3 Wave 1). Drops unsupported values silently
@@ -189,12 +195,16 @@ export async function renameNote(args: {
     mtimeMs: note.mtimeMs,
     body: note.content,
   });
-  const links: OutgoingWikilink[] = [];
-  for (const target of note.wikilinks) {
-    const resolved = await store.resolveTitleToPath(target);
-    links.push({ targetTitle: target, targetPath: resolved });
+  const allRelations = extractAllRelations({
+    frontmatter: note.frontmatter,
+    content: note.content,
+  });
+  const resolved: ResolvedRelation[] = [];
+  for (const r of allRelations) {
+    const targetPath = await store.resolveTitleToPath(r.targetTitle);
+    resolved.push({ kind: r.kind, targetTitle: r.targetTitle, targetPath });
   }
-  await store.replaceWikilinks(args.to, links);
+  await store.replaceRelations(args.to, resolved);
 
   const contentTags = extractTags(note.content);
   const mergedTags = mergeTagsFromFrontmatter(note.frontmatter, contentTags);

--- a/apps/desktop/electron/ipc/types.ts
+++ b/apps/desktop/electron/ipc/types.ts
@@ -1,0 +1,36 @@
+// IPC handlers for typed object types + typed relations (v1.0 phase 1).
+//
+// All handlers are thin pass-through to the SQLite adapter — the
+// validation that matters (slug, schema shape) happens upstream when
+// the YAML is loaded into `object_types` on vault open. These
+// handlers exist so the renderer doesn't need to know the adapter
+// shape directly.
+
+import type { NotePath, ObjectTypeRow, RelationRow } from '@ziba/core';
+import { requireIndexStore } from '../state.js';
+
+export async function listObjectTypes(): Promise<ObjectTypeRow[]> {
+  return requireIndexStore().listObjectTypes();
+}
+
+export async function upsertObjectType(args: { row: ObjectTypeRow }): Promise<void> {
+  return requireIndexStore().upsertObjectType(args.row);
+}
+
+export async function deleteObjectType(args: { id: string }): Promise<void> {
+  return requireIndexStore().deleteObjectType(args.id);
+}
+
+export async function getRelationsBySource(args: {
+  sourcePath: NotePath;
+  kind?: string;
+}): Promise<RelationRow[]> {
+  return requireIndexStore().getRelations(args);
+}
+
+export async function getRelationsByTarget(args: {
+  targetPath: NotePath;
+  kind?: string;
+}): Promise<RelationRow[]> {
+  return requireIndexStore().getReverseRelations(args);
+}

--- a/apps/desktop/electron/ipc/vault.ts
+++ b/apps/desktop/electron/ipc/vault.ts
@@ -12,6 +12,7 @@ import { IpcChannels, type VaultInfo } from '../../shared/ipc.js';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { SqliteIndexStore } from '../adapters/index-store.sqlite.js';
 import { ChokidarWatcher } from '../adapters/watcher.chokidar.js';
+import { bootstrapSchemas } from '../schema-loader.js';
 import { IpcError } from '../security.js';
 import {
   consumeIfSelfWrite,
@@ -100,6 +101,13 @@ export async function openVault(win: BrowserWindow, args: { root: string }): Pro
   const indexStore = new SqliteIndexStore();
   await indexStore.init(root);
   setIndexStore(indexStore);
+
+  // v1.0: bootstrap object-type schemas. Copies the seven seed YAMLs
+  // into `<root>/.ziba/schema/` if the dir is empty, then parses every
+  // `.yml` and syncs the result into the `object_types` cache.
+  // Errors in individual schemas are logged and skipped — one bad
+  // file shouldn't block opening the vault.
+  await bootstrapSchemas(root, indexStore);
 
   // Initial index. Push progress to the renderer so the UI can show a
   // spinner / progress bar while large vaults import.

--- a/apps/desktop/electron/schema-loader.ts
+++ b/apps/desktop/electron/schema-loader.ts
@@ -1,0 +1,102 @@
+// Loads `<vault>/.ziba/schema/*.yml` into the SQLite `object_types`
+// cache, and writes the seven first-party seed schemas if the schema
+// directory is empty.
+//
+// Called once on `openVault` after the index store is initialized but
+// before the renderer is told the vault is ready.
+
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import {
+  INDEX_DIR_NAME,
+  SEED_SCHEMAS,
+  SEED_SCHEMA_IDS,
+  parseSchemaYaml,
+  type IndexStoreAdapter,
+  type ObjectTypeRow,
+} from '@ziba/core';
+
+const SCHEMA_DIR_NAME = 'schema';
+
+/**
+ * Ensure `<vault>/.ziba/schema/` exists. If it's empty (no `.yml`
+ * files), copy the seed schemas in. Existing files are NEVER
+ * overwritten — the user owns this directory.
+ */
+async function ensureSeedSchemas(vaultRoot: string): Promise<void> {
+  const dir = path.join(vaultRoot, INDEX_DIR_NAME, SCHEMA_DIR_NAME);
+  await fsp.mkdir(dir, { recursive: true });
+  const existing = await fsp.readdir(dir);
+  const yamls = existing.filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+  if (yamls.length > 0) return;
+
+  for (const id of SEED_SCHEMA_IDS) {
+    const target = path.join(dir, `${id}.yml`);
+    await fsp.writeFile(target, SEED_SCHEMAS[id], 'utf8');
+  }
+}
+
+/**
+ * Read every `.yml` in the schema dir, parse it, and upsert into the
+ * `object_types` cache. Schemas that fail to parse are LOGGED and
+ * skipped — one broken file shouldn't prevent the rest from loading.
+ *
+ * Returns the count of types successfully loaded; the caller can
+ * surface a one-line summary on the renderer side if it wants.
+ */
+async function loadSchemasIntoStore(vaultRoot: string, store: IndexStoreAdapter): Promise<number> {
+  const dir = path.join(vaultRoot, INDEX_DIR_NAME, SCHEMA_DIR_NAME);
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    return 0;
+  }
+
+  let loaded = 0;
+  for (const file of entries) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+    const full = path.join(dir, file);
+    let content: string;
+    let mtimeMs: number;
+    try {
+      content = await fsp.readFile(full, 'utf8');
+      const stat = await fsp.stat(full);
+      mtimeMs = stat.mtimeMs;
+    } catch (err) {
+      console.error(`[schema-loader] failed to read ${full}:`, err);
+      continue;
+    }
+
+    const result = parseSchemaYaml(content);
+    if (!result.ok) {
+      console.error(`[schema-loader] schema "${file}" has errors:`, result.errors);
+      continue;
+    }
+
+    const row: ObjectTypeRow = {
+      id: result.schema.id,
+      label: result.schema.label,
+      icon: result.schema.icon ?? null,
+      color: result.schema.color ?? null,
+      schema: result.schema,
+      mtimeMs,
+    };
+    await store.upsertObjectType(row);
+    loaded += 1;
+  }
+  return loaded;
+}
+
+/**
+ * One-shot bootstrap: ensure seeds, then load every schema into the
+ * cache. Idempotent — safe to call on every vault open.
+ */
+export async function bootstrapSchemas(
+  vaultRoot: string,
+  store: IndexStoreAdapter,
+): Promise<{ loaded: number }> {
+  await ensureSeedSchemas(vaultRoot);
+  const loaded = await loadSchemasIntoStore(vaultRoot, store);
+  return { loaded };
+}

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -15,12 +15,15 @@ import type {
   Note,
   NotePath,
   NoteSummary,
+  ObjectTypeRow,
   PropertyType,
+  RelationRow,
   ScalarFilter,
 } from '@ziba/core';
 
-// Re-export the v0.3 query / graph types so renderers can keep a single
-// import surface (`'@shared/ipc'`) for everything they touch via IPC.
+// Re-export the v0.3 query / graph types + v1.0 object/relation types
+// so renderers can keep a single import surface (`'@shared/ipc'`) for
+// everything they touch via IPC.
 export type {
   DatabaseGroup,
   DatabaseQuery,
@@ -30,7 +33,9 @@ export type {
   FullGraph,
   GraphEdge,
   GraphNode,
+  ObjectTypeRow,
   PropertyType,
+  RelationRow,
   ScalarFilter,
 };
 
@@ -69,6 +74,13 @@ export const IpcChannels = {
   runDatabaseQuery: 'db:query',
   // Full graph (v0.3 Wave 1, used by Wave 2's global graph view)
   getFullGraph: 'graph:full',
+
+  // v1.0: typed object types + typed relations
+  listObjectTypes: 'types:list',
+  upsertObjectType: 'types:upsert',
+  deleteObjectType: 'types:delete',
+  getRelationsBySource: 'relations:bySource',
+  getRelationsByTarget: 'relations:byTarget',
 
   // Settings / persisted state
   getRecentVaults: 'settings:recentVaults',
@@ -150,6 +162,13 @@ export type IpcRequests = {
   [IpcChannels.runDatabaseQuery]: { query: DatabaseQuery };
   [IpcChannels.getFullGraph]: void;
 
+  // v1.0
+  [IpcChannels.listObjectTypes]: void;
+  [IpcChannels.upsertObjectType]: { row: ObjectTypeRow };
+  [IpcChannels.deleteObjectType]: { id: string };
+  [IpcChannels.getRelationsBySource]: { sourcePath: NotePath; kind?: string };
+  [IpcChannels.getRelationsByTarget]: { targetPath: NotePath; kind?: string };
+
   [IpcChannels.getRecentVaults]: void;
 };
 
@@ -204,6 +223,13 @@ export type IpcResponses = {
 
   [IpcChannels.runDatabaseQuery]: DatabaseResult;
   [IpcChannels.getFullGraph]: FullGraph;
+
+  // v1.0
+  [IpcChannels.listObjectTypes]: ObjectTypeRow[];
+  [IpcChannels.upsertObjectType]: void;
+  [IpcChannels.deleteObjectType]: void;
+  [IpcChannels.getRelationsBySource]: RelationRow[];
+  [IpcChannels.getRelationsByTarget]: RelationRow[];
 
   [IpcChannels.getRecentVaults]: VaultInfo[];
 };

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -9,6 +9,8 @@ import type {
   DatabaseResult,
   FullGraph,
   IndexProgressPayload,
+  ObjectTypeRow,
+  RelationRow,
   SearchHit,
   TagSummary,
   VaultEventPayload,
@@ -107,6 +109,23 @@ export const ipc = {
   },
   getFullGraph(): Promise<FullGraph> {
     return api().invoke(IpcChannels.getFullGraph);
+  },
+
+  // v1.0: typed object types + typed relations
+  listObjectTypes(): Promise<ObjectTypeRow[]> {
+    return api().invoke(IpcChannels.listObjectTypes);
+  },
+  upsertObjectType(args: { row: ObjectTypeRow }): Promise<void> {
+    return api().invoke(IpcChannels.upsertObjectType, args);
+  },
+  deleteObjectType(args: { id: string }): Promise<void> {
+    return api().invoke(IpcChannels.deleteObjectType, args);
+  },
+  getRelationsBySource(args: { sourcePath: NotePath; kind?: string }): Promise<RelationRow[]> {
+    return api().invoke(IpcChannels.getRelationsBySource, args);
+  },
+  getRelationsByTarget(args: { targetPath: NotePath; kind?: string }): Promise<RelationRow[]> {
+    return api().invoke(IpcChannels.getRelationsByTarget, args);
   },
 
   // Settings

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,11 +48,13 @@
     "clean": "rm -rf dist .turbo *.tsbuildinfo"
   },
   "dependencies": {
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
-    "@ziba/tsconfig": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "@vitest/coverage-v8": "^2.1.0",
+    "@ziba/tsconfig": "workspace:*",
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   }

--- a/packages/core/src/adapters/index-store.ts
+++ b/packages/core/src/adapters/index-store.ts
@@ -1,5 +1,7 @@
 import type { Note, NotePath, NoteSummary } from '../types/note.js';
 import type { DatabaseQuery, DatabaseResult, DetectedProperty, FullGraph } from '../query/index.js';
+import type { RelationEntry } from '../markdown/relations.js';
+import type { ObjectTypeSchema } from '../types/schema.js';
 
 export type WikilinkRow = {
   sourcePath: NotePath;
@@ -33,6 +35,38 @@ export type TagSummaryRow = {
   /** Display-case form (one of the canonicalised display values). */
   display: string;
   count: number;
+};
+
+/**
+ * v1.0: row form of a typed relation as stored in SQLite. The
+ * indexer's `RelationEntry` extracts kind+title from frontmatter+body;
+ * the caller then resolves `targetPath` (against `notes`) and persists
+ * via `replaceRelations`.
+ */
+export type ResolvedRelation = {
+  /** `''` for generic body wikilinks, otherwise the relation kind. */
+  kind: string;
+  targetTitle: string;
+  /** null = unresolved / broken link. */
+  targetPath: NotePath | null;
+};
+
+/** Read shape returned by getRelations / getReverseRelations. */
+export type RelationRow = {
+  sourcePath: NotePath;
+  kind: string;
+  targetTitle: string;
+  targetPath: NotePath | null;
+};
+
+/** v1.0: row form of a cached object-type schema. */
+export type ObjectTypeRow = {
+  id: string;
+  label: string;
+  icon: string | null;
+  color: string | null;
+  schema: ObjectTypeSchema;
+  mtimeMs: number;
 };
 
 /**
@@ -125,5 +159,36 @@ export interface IndexStoreAdapter {
    */
   getFullGraph(): Promise<FullGraph>;
 
+  /**
+   * v1.0: replace all relations originating from `sourcePath`. The
+   * caller is responsible for resolving each `targetTitle` →
+   * `targetPath` against the current vault before passing them in
+   * (mirroring the existing `replaceWikilinks` flow). `kind = ''` is
+   * the sentinel for generic body wikilinks.
+   */
+  replaceRelations(sourcePath: NotePath, relations: ResolvedRelation[]): Promise<void>;
+
+  /** v1.0: list all relations originating from `sourcePath`. */
+  getRelations(args: { sourcePath: NotePath; kind?: string }): Promise<RelationRow[]>;
+
+  /**
+   * v1.0: list all relations pointing AT `targetPath`. Used by the
+   * object panel to drive both the inverse-relation view and the
+   * kind-grouped backlinks panel.
+   */
+  getReverseRelations(args: { targetPath: NotePath; kind?: string }): Promise<RelationRow[]>;
+
+  /** v1.0: every cached object type, sorted by id. */
+  listObjectTypes(): Promise<ObjectTypeRow[]>;
+
+  /** v1.0: insert or replace a type's cached schema. */
+  upsertObjectType(row: ObjectTypeRow): Promise<void>;
+
+  /** v1.0: drop a type from the cache. No-op if not present. */
+  deleteObjectType(id: string): Promise<void>;
+
   clear(): Promise<void>;
 }
+
+// Re-export the entry shape so callers can import it from this module.
+export type { RelationEntry };

--- a/packages/core/src/index-store/schema.ts
+++ b/packages/core/src/index-store/schema.ts
@@ -37,17 +37,38 @@ CREATE TABLE IF NOT EXISTS notes (
   mtime            INTEGER NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS wikilinks (
+-- v1.0: replaces \`wikilinks\`. The legacy table is dropped on first
+-- open of a v1.0 vault (see MIGRATION_DROP_SQL below) — index is a
+-- cache, no data loss.
+--
+-- \`kind\` is NOT NULL with a sentinel empty string for generic body
+-- wikilinks. SQLite PRIMARY KEY requires column references (not
+-- expressions), so we encode "untyped" as '' rather than NULL.
+CREATE TABLE IF NOT EXISTS relations (
   source_path  TEXT NOT NULL,
+  kind         TEXT NOT NULL DEFAULT '',
   target_title TEXT NOT NULL,
   target_path  TEXT,
-  PRIMARY KEY (source_path, target_title),
+  PRIMARY KEY (source_path, kind, target_title),
   FOREIGN KEY (source_path) REFERENCES notes(path) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_wikilinks_target_title ON wikilinks(target_title);
-CREATE INDEX IF NOT EXISTS idx_wikilinks_target_path  ON wikilinks(target_path);
+CREATE INDEX IF NOT EXISTS idx_relations_target_title ON relations(target_title);
+CREATE INDEX IF NOT EXISTS idx_relations_target_path  ON relations(target_path, kind);
+CREATE INDEX IF NOT EXISTS idx_relations_kind         ON relations(kind) WHERE kind <> '';
 CREATE INDEX IF NOT EXISTS idx_notes_title            ON notes(title);
+
+-- v1.0: schema cache mirroring \`<vault>/.ziba/schema/*.yml\`. Loaded on
+-- vault open; consumed by sidebar TypesSection counts and editor
+-- autocomplete.
+CREATE TABLE IF NOT EXISTS object_types (
+  id          TEXT PRIMARY KEY,
+  label       TEXT NOT NULL,
+  icon        TEXT,
+  color       TEXT,
+  schema_json TEXT NOT NULL,
+  mtime       INTEGER NOT NULL
+);
 
 -- Full-text search via FTS5 virtual table. Mirrors \`notes.path\`/\`title\`/\`body\`
 -- so wildcards like \`ziba\` or \`architecture OR design\` work.
@@ -96,4 +117,43 @@ CREATE INDEX IF NOT EXISTS idx_note_props_key    ON note_properties(prop_key);
 CREATE INDEX IF NOT EXISTS idx_note_props_text   ON note_properties(prop_key, text_value);
 CREATE INDEX IF NOT EXISTS idx_note_props_number ON note_properties(prop_key, number_value);
 CREATE INDEX IF NOT EXISTS idx_note_props_date   ON note_properties(prop_key, date_value);
+`.trim();
+
+/**
+ * Cache schema version. Bumping this triggers a one-shot drop+recreate
+ * of every cache-only table on next vault open, followed by an
+ * automatic full reindex (the index is derivable from disk).
+ *
+ * Bump rules:
+ *   - Adding a new column to an existing table → bump.
+ *   - Renaming a table → bump.
+ *   - Adding a new table only → no bump needed (`IF NOT EXISTS`
+ *     handles it).
+ *
+ * History:
+ *   v0.1 — v0.5: implicit version 1 (no `user_version` set).
+ *   v1.0 phase 1: bumps to 2 (introduces `relations`, drops legacy
+ *   `wikilinks`, introduces `object_types`).
+ */
+export const EXPECTED_USER_VERSION = 2;
+
+/**
+ * SQL run when `user_version` is below `EXPECTED_USER_VERSION`. Drops
+ * tables that changed shape AND every cache-only table — the latter
+ * because reindex is cheap and we'd rather rebuild than maintain
+ * piecemeal migrations. `notes`, `note_properties`, `tags`, `notes_fts`
+ * are also cache so they get rebuilt on the next reindex; dropping
+ * them here keeps the schema fresh.
+ *
+ * Run order matters: drop first, then `SCHEMA_SQL` recreates everything,
+ * then `PRAGMA user_version = N` lands the version.
+ */
+export const MIGRATION_DROP_SQL = `
+DROP TABLE IF EXISTS wikilinks;
+DROP TABLE IF EXISTS relations;
+DROP TABLE IF EXISTS object_types;
+DROP TABLE IF EXISTS notes_fts;
+DROP TABLE IF EXISTS note_properties;
+DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS notes;
 `.trim();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,10 @@ export * from './markdown/index.js';
 export * from './vault/index.js';
 export * from './index-store/index.js';
 export { SEED_SCHEMAS, SEED_SCHEMA_IDS, type SeedSchemaId } from './seed-schemas/index.js';
+export { EXPECTED_USER_VERSION, MIGRATION_DROP_SQL } from './index-store/schema.js';
+export type {
+  RelationEntry,
+  ResolvedRelation,
+  RelationRow,
+  ObjectTypeRow,
+} from './adapters/index-store.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './adapters/index.js';
 export * from './markdown/index.js';
 export * from './vault/index.js';
 export * from './index-store/index.js';
+export { SEED_SCHEMAS, SEED_SCHEMA_IDS, type SeedSchemaId } from './seed-schemas/index.js';

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -2,3 +2,4 @@ export * from './wikilinks.js';
 export * from './parse.js';
 export * from './serialize.js';
 export * from './tags.js';
+export * from './relations.js';

--- a/packages/core/src/markdown/relations.test.ts
+++ b/packages/core/src/markdown/relations.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractType,
+  extractFrontmatterRelations,
+  extractBodyRelations,
+  extractAllRelations,
+  type RelationEntry,
+} from './relations';
+
+describe('extractType', () => {
+  it('returns the slug when frontmatter.type is a valid slug', () => {
+    expect(extractType({ type: 'book' })).toBe('book');
+    expect(extractType({ type: 'multi-word-type' })).toBe('multi-word-type');
+  });
+
+  it('returns null for missing or non-string type', () => {
+    expect(extractType({})).toBeNull();
+    expect(extractType({ type: 42 })).toBeNull();
+    expect(extractType({ type: ['book'] })).toBeNull();
+    expect(extractType({ type: null })).toBeNull();
+  });
+
+  it('returns null for slugs that fail the regex', () => {
+    expect(extractType({ type: 'Book' })).toBeNull();
+    expect(extractType({ type: 'book title' })).toBeNull();
+    expect(extractType({ type: '1book' })).toBeNull();
+    expect(extractType({ type: '' })).toBeNull();
+  });
+});
+
+describe('extractFrontmatterRelations', () => {
+  it('handles a scalar wikilink relation', () => {
+    expect(extractFrontmatterRelations({ relations: { author: '[[Tolkien]]' } })).toEqual<
+      RelationEntry[]
+    >([{ kind: 'author', targetTitle: 'Tolkien' }]);
+  });
+
+  it('handles a list of wikilinks', () => {
+    expect(extractFrontmatterRelations({ relations: { knows: ['[[Alice]]', '[[Bob]]'] } })).toEqual<
+      RelationEntry[]
+    >([
+      { kind: 'knows', targetTitle: 'Alice' },
+      { kind: 'knows', targetTitle: 'Bob' },
+    ]);
+  });
+
+  it('strips heading refs in targets', () => {
+    expect(extractFrontmatterRelations({ relations: { cites: '[[Foo#section]]' } })).toEqual<
+      RelationEntry[]
+    >([{ kind: 'cites', targetTitle: 'Foo' }]);
+  });
+
+  it('honors the alias side of a piped wikilink', () => {
+    expect(extractFrontmatterRelations({ relations: { author: '[[Tolkien|J.R.R.]]' } })).toEqual<
+      RelationEntry[]
+    >([{ kind: 'author', targetTitle: 'Tolkien' }]);
+  });
+
+  it('skips entries that are not wikilinks (silent)', () => {
+    const fm = { relations: { author: 'plain string', knows: ['[[Real]]', 42] } };
+    expect(extractFrontmatterRelations(fm)).toEqual<RelationEntry[]>([
+      { kind: 'knows', targetTitle: 'Real' },
+    ]);
+  });
+
+  it('returns [] for missing or malformed relations', () => {
+    expect(extractFrontmatterRelations({})).toEqual([]);
+    expect(extractFrontmatterRelations({ relations: 'oops' })).toEqual([]);
+    expect(extractFrontmatterRelations({ relations: ['nope'] })).toEqual([]);
+  });
+});
+
+describe('extractBodyRelations', () => {
+  it('emits one entry per body wikilink with kind=""', () => {
+    expect(extractBodyRelations('See [[Foo]] and [[Bar|alias]] for context.')).toEqual<
+      RelationEntry[]
+    >([
+      { kind: '', targetTitle: 'Foo' },
+      { kind: '', targetTitle: 'Bar' },
+    ]);
+  });
+
+  it('does not emit anything for body code blocks', () => {
+    const body = 'Inline `[[InCode]]` and:\n```\n[[AlsoInCode]]\n```\nthen [[Real]].';
+    const entries = extractBodyRelations(body);
+    expect(entries.map((e) => e.targetTitle)).toEqual(['Real']);
+  });
+
+  it('returns [] for empty / no-link body', () => {
+    expect(extractBodyRelations('')).toEqual([]);
+    expect(extractBodyRelations('plain text, no links')).toEqual([]);
+  });
+});
+
+describe('extractAllRelations', () => {
+  it('combines frontmatter relations + body wikilinks', () => {
+    const note = {
+      frontmatter: { type: 'book', relations: { author: '[[Tolkien]]' } },
+      content: 'See [[Inspiration]].',
+    };
+    expect(extractAllRelations(note)).toEqual<RelationEntry[]>([
+      { kind: 'author', targetTitle: 'Tolkien' },
+      { kind: '', targetTitle: 'Inspiration' },
+    ]);
+  });
+
+  it('keeps both kinds when target is the same but kind differs', () => {
+    const note = {
+      frontmatter: { relations: { cites: '[[Foo]]' } },
+      content: '[[Foo]] is mentioned both ways.',
+    };
+    expect(extractAllRelations(note)).toEqual<RelationEntry[]>([
+      { kind: 'cites', targetTitle: 'Foo' },
+      { kind: '', targetTitle: 'Foo' },
+    ]);
+  });
+
+  it('de-duplicates two body mentions of the same target', () => {
+    const note = {
+      frontmatter: {},
+      content: '[[Foo]] then [[Foo]] again.',
+    };
+    expect(extractAllRelations(note)).toEqual<RelationEntry[]>([{ kind: '', targetTitle: 'Foo' }]);
+  });
+});

--- a/packages/core/src/markdown/relations.ts
+++ b/packages/core/src/markdown/relations.ts
@@ -1,6 +1,6 @@
 import { extractWikilinks } from './wikilinks.js';
 import { TYPE_SLUG_RE } from '../types/schema.js';
-import type { Frontmatter } from '../types/frontmatter.js';
+import type { Frontmatter } from '../types/note.js';
 
 /**
  * One observed relation between a source note and a target. The

--- a/packages/core/src/markdown/relations.ts
+++ b/packages/core/src/markdown/relations.ts
@@ -1,0 +1,115 @@
+import { extractWikilinks } from './wikilinks.js';
+import { TYPE_SLUG_RE } from '../types/schema.js';
+import type { Frontmatter } from '../types/frontmatter.js';
+
+/**
+ * One observed relation between a source note and a target. The
+ * source path comes from the note's location on disk; we track only
+ * `kind` (the relation label, or `''` for generic body wikilinks)
+ * and `targetTitle` (the raw `[[Target]]` value, before path
+ * resolution by the adapter caller).
+ */
+export type RelationEntry = {
+  /** `''` for generic body wikilinks, otherwise the relation kind from frontmatter. */
+  kind: string;
+  /** Raw target title — what the user wrote between `[[` and `]]`, sans heading ref. */
+  targetTitle: string;
+};
+
+/**
+ * Pull a `type:` slug out of frontmatter. Returns null when the field
+ * is missing, isn't a string, is empty, or fails the slug regex.
+ * Keeping the regex strict prevents typos like `Book` (capital B) or
+ * `book title` (space) from silently splintering the type taxonomy.
+ */
+export function extractType(frontmatter: Frontmatter): string | null {
+  const t = frontmatter.type;
+  if (typeof t !== 'string') return null;
+  if (!TYPE_SLUG_RE.test(t)) return null;
+  return t;
+}
+
+/**
+ * Parse a single `[[Target]]`, `[[Target|Alias]]`, or `[[Target#heading]]`
+ * value into the canonical target title (the part *before* the alias
+ * pipe and the heading hash). Returns null for non-wikilink strings.
+ *
+ * We don't reuse `extractWikilinks` here because that one walks an
+ * entire markdown body — for a single field value the regex is
+ * cheaper and easier to reason about.
+ */
+const WIKILINK_VALUE_RE = /^\[\[([^\]]+)\]\]$/;
+function parseWikilinkValue(raw: string): string | null {
+  const trimmed = raw.trim();
+  const m = trimmed.match(WIKILINK_VALUE_RE);
+  if (m === null) return null;
+  const inner = m[1] ?? '';
+  const pipe = inner.indexOf('|');
+  const beforePipe = pipe === -1 ? inner : inner.slice(0, pipe);
+  const hash = beforePipe.indexOf('#');
+  const target = (hash === -1 ? beforePipe : beforePipe.slice(0, hash)).trim();
+  return target.length === 0 ? null : target;
+}
+
+/**
+ * Pull `relations:` out of frontmatter. Each value can be either a
+ * scalar wikilink string or a list of wikilink strings; everything
+ * else is silently skipped (it's authoring noise we'd rather not
+ * crash on — the editor will surface validation in a later phase).
+ */
+export function extractFrontmatterRelations(frontmatter: Frontmatter): RelationEntry[] {
+  const rels = frontmatter.relations;
+  if (rels === null || rels === undefined) return [];
+  if (typeof rels !== 'object' || Array.isArray(rels)) return [];
+
+  const out: RelationEntry[] = [];
+  for (const [kind, value] of Object.entries(rels as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      const target = parseWikilinkValue(value);
+      if (target !== null) out.push({ kind, targetTitle: target });
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item !== 'string') continue;
+        const target = parseWikilinkValue(item);
+        if (target !== null) out.push({ kind, targetTitle: target });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk the body markdown for generic `[[wikilinks]]` and emit them as
+ * relation entries with `kind = ''` (the SQL sentinel, see Phase 1
+ * design doc §4.1). Reuses the existing scanner so code-block
+ * exclusion + heading-ref stripping behave exactly like before.
+ */
+export function extractBodyRelations(body: string): RelationEntry[] {
+  return extractWikilinks(body).map((target) => ({ kind: '', targetTitle: target }));
+}
+
+/**
+ * Combine frontmatter relations + body wikilinks into a single
+ * deduplicated list. De-dup is per (kind, targetTitle) pair: a note
+ * that mentions `[[Foo]]` in the body AND declares a typed relation
+ * `cites: [[Foo]]` produces TWO entries (different kinds), but
+ * mentioning `[[Foo]]` twice in the body produces one.
+ */
+export function extractAllRelations(note: {
+  frontmatter: Frontmatter;
+  content: string;
+}): RelationEntry[] {
+  const seen = new Set<string>();
+  const out: RelationEntry[] = [];
+  const push = (e: RelationEntry): void => {
+    const key = `${e.kind}\x00${e.targetTitle}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(e);
+  };
+  for (const e of extractFrontmatterRelations(note.frontmatter)) push(e);
+  for (const e of extractBodyRelations(note.content)) push(e);
+  return out;
+}

--- a/packages/core/src/seed-schemas/index.test.ts
+++ b/packages/core/src/seed-schemas/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { SEED_SCHEMAS, SEED_SCHEMA_IDS } from './index';
+import { parseSchemaYaml } from '../types/schema';
+
+describe('seed schemas', () => {
+  it('exposes the canonical seven', () => {
+    expect(SEED_SCHEMA_IDS).toEqual([
+      'note',
+      'person',
+      'book',
+      'project',
+      'idea',
+      'daily',
+      'meeting',
+    ]);
+  });
+
+  it('every seed parses cleanly', () => {
+    for (const id of SEED_SCHEMA_IDS) {
+      const yaml = SEED_SCHEMAS[id];
+      const result = parseSchemaYaml(yaml);
+      if (!result.ok) {
+        throw new Error(`seed "${id}" failed to parse: ${result.errors.join(', ')}`);
+      }
+      expect(result.schema.id).toBe(id);
+      expect(result.schema.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('each seed has at least an icon and a color', () => {
+    for (const id of SEED_SCHEMA_IDS) {
+      const result = parseSchemaYaml(SEED_SCHEMAS[id]);
+      if (!result.ok) throw new Error('parse error');
+      expect(result.schema.icon).toBeDefined();
+      expect(result.schema.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});

--- a/packages/core/src/seed-schemas/index.ts
+++ b/packages/core/src/seed-schemas/index.ts
@@ -1,0 +1,188 @@
+// First-party seed schemas. Copied into `<vault>/.ziba/schema/` on
+// first open of a fresh vault by the desktop bootstrap step. The user
+// is free to edit, delete, or extend — these only seed an empty vault.
+//
+// Each schema is stored as a raw YAML string so the package stays
+// `fs`-free; the desktop side writes the strings to disk at the path
+// it owns. The strings are ALSO the source of truth for tests and
+// for any future web build that doesn't have a filesystem.
+
+export type SeedSchemaId = 'note' | 'person' | 'book' | 'project' | 'idea' | 'daily' | 'meeting';
+
+export const SEED_SCHEMA_IDS: ReadonlyArray<SeedSchemaId> = [
+  'note',
+  'person',
+  'book',
+  'project',
+  'idea',
+  'daily',
+  'meeting',
+];
+
+const NOTE_SCHEMA = `id: note
+label: Nota
+icon: 📝
+color: "#71717a"
+properties: {}
+relations: {}
+inverse:
+  cited_by:
+    reverse_of: cites
+    label: Citato da
+`;
+
+const PERSON_SCHEMA = `id: person
+label: Persona
+icon: 👤
+color: "#f97316"
+properties:
+  full_name:
+    type: text
+    label: Nome completo
+  email:
+    type: url
+relations:
+  works_at:
+    target: project
+    label: Lavora a
+  knows:
+    target: person
+    multiple: true
+    label: Conosce
+inverse:
+  authored:
+    reverse_of: author
+    label: Ha scritto
+  attended:
+    reverse_of: attended_by
+    label: Ha partecipato a
+`;
+
+const BOOK_SCHEMA = `id: book
+label: Libro
+icon: 📖
+color: "#6366f1"
+properties:
+  title:
+    type: text
+    required: true
+  year:
+    type: number
+  isbn:
+    type: text
+relations:
+  author:
+    target: person
+    label: Autore
+  in_series:
+    target: book
+    label: Serie
+inverse:
+  cited_by:
+    reverse_of: cites
+    label: Citato da
+`;
+
+const PROJECT_SCHEMA = `id: project
+label: Progetto
+icon: 🚀
+color: "#10b981"
+properties:
+  status:
+    type: text
+    label: Stato
+  due:
+    type: date
+relations:
+  owner:
+    target: person
+    label: Owner
+  blocks:
+    target: project
+    multiple: true
+    label: Blocca
+  blocked_by:
+    target: project
+    multiple: true
+    label: Bloccato da
+inverse:
+  works_on:
+    reverse_of: works_at
+    label: Persone coinvolte
+`;
+
+const IDEA_SCHEMA = `id: idea
+label: Idea
+icon: 💡
+color: "#eab308"
+properties: {}
+relations:
+  inspired_by:
+    target: idea
+    multiple: true
+    label: Ispirata da
+  related_to:
+    target: idea
+    multiple: true
+    label: Correlata a
+inverse:
+  cited_by:
+    reverse_of: cites
+    label: Citata in
+`;
+
+const DAILY_SCHEMA = `id: daily
+label: Daily
+icon: 🗓️
+color: "#06b6d4"
+properties:
+  date:
+    type: date
+    required: true
+relations:
+  worked_on:
+    target: project
+    multiple: true
+    label: Lavorato su
+  met_with:
+    target: person
+    multiple: true
+    label: Incontrato
+  read:
+    target: book
+    multiple: true
+    label: Letto
+inverse: {}
+`;
+
+const MEETING_SCHEMA = `id: meeting
+label: Meeting
+icon: 🤝
+color: "#a855f7"
+properties:
+  date:
+    type: date
+    required: true
+relations:
+  attended_by:
+    target: person
+    multiple: true
+    label: Partecipanti
+  for_project:
+    target: project
+    label: Per il progetto
+inverse:
+  notes_about:
+    reverse_of: outcome_of
+    label: Output
+`;
+
+export const SEED_SCHEMAS: Record<SeedSchemaId, string> = {
+  note: NOTE_SCHEMA,
+  person: PERSON_SCHEMA,
+  book: BOOK_SCHEMA,
+  project: PROJECT_SCHEMA,
+  idea: IDEA_SCHEMA,
+  daily: DAILY_SCHEMA,
+  meeting: MEETING_SCHEMA,
+};

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './note.js';
 export * from './frontmatter.js';
+export * from './schema.js';

--- a/packages/core/src/types/schema.test.ts
+++ b/packages/core/src/types/schema.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { parseSchemaYaml } from './schema';
+
+describe('parseSchemaYaml — happy path', () => {
+  it('parses a minimal valid schema', () => {
+    const yaml = `
+id: book
+label: Libro
+properties:
+  title:
+    type: text
+    required: true
+relations:
+  author:
+    target: person
+`;
+    const result = parseSchemaYaml(yaml);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.schema.id).toBe('book');
+    expect(result.schema.label).toBe('Libro');
+    expect(result.schema.properties.title).toEqual({ type: 'text', required: true });
+    expect(result.schema.relations.author).toEqual({ target: 'person' });
+    expect(result.schema.inverse).toEqual({});
+  });
+
+  it('keeps icon and color when provided', () => {
+    const result = parseSchemaYaml(`
+id: book
+label: Libro
+icon: 📖
+color: "#6366f1"
+properties: {}
+relations: {}
+`);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.schema.icon).toBe('📖');
+    expect(result.schema.color).toBe('#6366f1');
+  });
+});
+
+describe('parseSchemaYaml — validation', () => {
+  it('rejects malformed YAML', () => {
+    const result = parseSchemaYaml('id: book\n  label: bad-indent: extra');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0]).toMatch(/yaml/i);
+  });
+
+  it('rejects missing `id`', () => {
+    const result = parseSchemaYaml(`label: Libro\nproperties: {}\nrelations: {}`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain('id is required');
+  });
+
+  it('rejects an `id` that does not match the slug regex', () => {
+    const result = parseSchemaYaml(`
+id: Book Title!
+label: x
+properties: {}
+relations: {}
+`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.includes('slug'))).toBe(true);
+  });
+
+  it('rejects missing `label`', () => {
+    const result = parseSchemaYaml(`id: book\nproperties: {}\nrelations: {}`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain('label is required');
+  });
+
+  it('rejects an unknown property type', () => {
+    const result = parseSchemaYaml(`
+id: book
+label: Libro
+properties:
+  weird:
+    type: not-a-type
+relations: {}
+`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.includes('property type'))).toBe(true);
+  });
+
+  it('returns ALL errors at once, not just the first', () => {
+    const result = parseSchemaYaml(`
+properties: {}
+relations: {}
+`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain('id is required');
+    expect(result.errors).toContain('label is required');
+  });
+
+  it('rejects color that is not a #RRGGBB hex', () => {
+    const result = parseSchemaYaml(`
+id: book
+label: Libro
+color: red
+properties: {}
+relations: {}
+`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.includes('#RRGGBB'))).toBe(true);
+  });
+});

--- a/packages/core/src/types/schema.ts
+++ b/packages/core/src/types/schema.ts
@@ -9,7 +9,7 @@
 // by deleting + regenerating the schema file.
 
 import { load as yamlLoad, YAMLException } from 'js-yaml';
-import type { PropertyType } from './frontmatter';
+import type { PropertyType } from '../query/index.js';
 
 /**
  * Spec for one property of an object type. Mirrors `PropertyType` from

--- a/packages/core/src/types/schema.ts
+++ b/packages/core/src/types/schema.ts
@@ -1,0 +1,231 @@
+// Object-type schemas. The vault carries one YAML file per type in
+// `<vault>/.ziba/schema/<id>.yml`; this module defines the parsed
+// shape both the indexer (main process) and the editor (renderer)
+// agree on.
+//
+// Schemas are *soft* — they describe the user's intent for a type
+// (which properties to surface, which relation kinds make sense) but
+// the indexer never refuses a save that diverges. Drift is recoverable
+// by deleting + regenerating the schema file.
+
+import { load as yamlLoad, YAMLException } from 'js-yaml';
+import type { PropertyType } from './frontmatter';
+
+/**
+ * Spec for one property of an object type. Mirrors `PropertyType` from
+ * `frontmatter.ts` so the editor / database view can use the same
+ * value-rendering machinery they already use for ad-hoc properties.
+ */
+export type PropertySpec = {
+  /** Typed value used for editor input + database column rendering. */
+  type: PropertyType;
+  /** When true, the editor warns (but does not block) on missing values. */
+  required?: boolean;
+  /** Human-readable label used in the object panel and database header. */
+  label?: string;
+};
+
+/**
+ * Spec for one outgoing relation kind from this object type.
+ *
+ * `multiple: true` means the frontmatter `relations:<kind>` accepts a
+ * list of wikilinks; `multiple: false` (default) accepts a scalar.
+ *
+ * `target` is the *expected* type of the relation's target. Soft —
+ * a target whose actual `type:` differs is rendered, just flagged in
+ * the object panel as "unexpected target type".
+ */
+export type RelationSpec = {
+  target: string;
+  multiple?: boolean;
+  label?: string;
+};
+
+/**
+ * An "inverse relation" is rendered in the object panel even though it
+ * isn't declared in this note's frontmatter — it's auto-derived from
+ * other notes that point at this one with `reverse_of` matching.
+ *
+ * Example: a `book` schema declares `inverse: { cited_by: { reverse_of: 'cites' } }`,
+ * meaning the book's panel should show "Cited by ..." for every note
+ * that has `relations: { cites: [[ThisBook]] }`.
+ */
+export type InverseRelationSpec = {
+  reverse_of: string;
+  label?: string;
+};
+
+/**
+ * Top-level shape of one schema yaml. Loaded by `parseSchemaYaml`.
+ */
+export type ObjectTypeSchema = {
+  /** Slug. Lowercase, kebab-case, must match `^[a-z][a-z0-9-]*$`. */
+  id: string;
+  /** Display name for the type (sidebar, dropdowns). */
+  label: string;
+  /** Optional emoji or short icon string used in pills + graph nodes. */
+  icon?: string;
+  /** Optional CSS hex color (#RRGGBB) for sidebar pills + graph hulls. */
+  color?: string;
+  /** Map from property key → spec. */
+  properties: Record<string, PropertySpec>;
+  /** Map from relation kind → spec (outgoing). */
+  relations: Record<string, RelationSpec>;
+  /** Map from inverse-relation kind → spec (auto-derived). */
+  inverse: Record<string, InverseRelationSpec>;
+};
+
+/**
+ * Result of `parseSchemaYaml`: either a successfully-parsed schema or
+ * a list of validation issues. We return errors instead of throwing so
+ * the schema loader can surface every broken file in one pass on
+ * vault open instead of crashing on the first one.
+ */
+export type SchemaParseResult =
+  | { ok: true; schema: ObjectTypeSchema }
+  | { ok: false; errors: string[] };
+
+/** Slug regex used by both the parser and the indexer. */
+export const TYPE_SLUG_RE = /^[a-z][a-z0-9-]*$/;
+
+const ALLOWED_PROPERTY_TYPES: ReadonlySet<PropertyType> = new Set<PropertyType>([
+  'text',
+  'number',
+  'boolean',
+  'date',
+  'url',
+  'string-array',
+]);
+
+/**
+ * Parse one schema YAML file's content into an `ObjectTypeSchema`.
+ *
+ * Returns the full list of validation issues on failure rather than
+ * throwing, so the loader on vault open can report every broken
+ * schema in one pass instead of stopping on the first.
+ */
+export function parseSchemaYaml(content: string): SchemaParseResult {
+  let raw: unknown;
+  try {
+    raw = yamlLoad(content);
+  } catch (err) {
+    const message = err instanceof YAMLException ? err.message : 'invalid YAML';
+    return { ok: false, errors: [`yaml parse error: ${message}`] };
+  }
+
+  if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, errors: ['schema root must be a mapping'] };
+  }
+
+  const errors: string[] = [];
+  const obj = raw as Record<string, unknown>;
+
+  const id = obj.id;
+  if (typeof id !== 'string' || id.length === 0) {
+    errors.push('id is required');
+  } else if (!TYPE_SLUG_RE.test(id)) {
+    errors.push(`id must be a slug matching ${TYPE_SLUG_RE} (got "${id}")`);
+  }
+
+  const label = obj.label;
+  if (typeof label !== 'string' || label.length === 0) {
+    errors.push('label is required');
+  }
+
+  const icon = obj.icon;
+  if (icon !== undefined && typeof icon !== 'string') {
+    errors.push('icon, when present, must be a string');
+  }
+
+  const color = obj.color;
+  if (color !== undefined && (typeof color !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(color))) {
+    errors.push('color, when present, must be a #RRGGBB hex string');
+  }
+
+  const properties: Record<string, PropertySpec> = {};
+  const rawProps = obj.properties;
+  if (rawProps !== undefined && rawProps !== null) {
+    if (typeof rawProps !== 'object' || Array.isArray(rawProps)) {
+      errors.push('properties must be a mapping');
+    } else {
+      for (const [key, value] of Object.entries(rawProps as Record<string, unknown>)) {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+          errors.push(`properties.${key} must be a mapping`);
+          continue;
+        }
+        const v = value as Record<string, unknown>;
+        const t = v.type;
+        if (typeof t !== 'string' || !ALLOWED_PROPERTY_TYPES.has(t as PropertyType)) {
+          errors.push(`properties.${key}.type is not a known property type (got "${String(t)}")`);
+          continue;
+        }
+        const spec: PropertySpec = { type: t as PropertyType };
+        if (v.required === true) spec.required = true;
+        if (typeof v.label === 'string') spec.label = v.label;
+        properties[key] = spec;
+      }
+    }
+  }
+
+  const relations: Record<string, RelationSpec> = {};
+  const rawRels = obj.relations;
+  if (rawRels !== undefined && rawRels !== null) {
+    if (typeof rawRels !== 'object' || Array.isArray(rawRels)) {
+      errors.push('relations must be a mapping');
+    } else {
+      for (const [key, value] of Object.entries(rawRels as Record<string, unknown>)) {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+          errors.push(`relations.${key} must be a mapping`);
+          continue;
+        }
+        const v = value as Record<string, unknown>;
+        const target = v.target;
+        if (typeof target !== 'string' || target.length === 0) {
+          errors.push(`relations.${key}.target is required`);
+          continue;
+        }
+        const spec: RelationSpec = { target };
+        if (v.multiple === true) spec.multiple = true;
+        if (typeof v.label === 'string') spec.label = v.label;
+        relations[key] = spec;
+      }
+    }
+  }
+
+  const inverse: Record<string, InverseRelationSpec> = {};
+  const rawInv = obj.inverse;
+  if (rawInv !== undefined && rawInv !== null) {
+    if (typeof rawInv !== 'object' || Array.isArray(rawInv)) {
+      errors.push('inverse must be a mapping');
+    } else {
+      for (const [key, value] of Object.entries(rawInv as Record<string, unknown>)) {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+          errors.push(`inverse.${key} must be a mapping`);
+          continue;
+        }
+        const v = value as Record<string, unknown>;
+        const reverse = v.reverse_of;
+        if (typeof reverse !== 'string' || reverse.length === 0) {
+          errors.push(`inverse.${key}.reverse_of is required`);
+          continue;
+        }
+        const spec: InverseRelationSpec = { reverse_of: reverse };
+        if (typeof v.label === 'string') spec.label = v.label;
+        inverse[key] = spec;
+      }
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const schema: ObjectTypeSchema = {
+    id: id as string,
+    label: label as string,
+    properties,
+    relations,
+    inverse,
+  };
+  if (typeof icon === 'string') schema.icon = icon;
+  if (typeof color === 'string') schema.color = color;
+  return { ok: true, schema };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,7 +159,13 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@vitest/coverage-v8':
         specifier: ^2.1.0
         version: 2.1.9(vitest@2.1.9(@types/node@20.19.40)(jsdom@25.0.1))
@@ -966,6 +972,9 @@ packages:
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4700,6 +4709,8 @@ snapshots:
       '@types/node': 20.19.40
 
   '@types/http-cache-semantics@4.2.0': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
## Summary

Headless foundation for v1.0 Object-Relational. No UI changes — Phases 2-5 build on this.

### What's in
- `@ziba/core` schema TypeScript types + YAML parser (9 validator cases)
- 7 first-party seed schemas (note, person, book, project, idea, daily, meeting)
- `extractType` + `extractAllRelations` pure extractors (15 unit tests)
- SQLite schema bump to v2: drops legacy `wikilinks`, introduces unified `relations` (`kind=''` sentinel for body wikilinks) + `object_types` cache
- One-shot migration via `PRAGMA user_version` mismatch — index is a cache, no data loss
- Adapter interface extended: `replaceRelations`, `getRelations`, `getReverseRelations`, `listObjectTypes`, `upsertObjectType`, `deleteObjectType`
- `replaceWikilinks` shimmed to delegate to `replaceRelations` for v0.x compat
- Indexer pipeline (`notes.ts` save/rename, `folder.ts` rename) calls `extractAllRelations` + `replaceRelations`
- Renamed `reresolveStaleWikilinks` to operate on `relations` (preserved external name for compat)
- 5 IPC channels: `types:list`, `types:upsert`, `types:delete`, `relations:bySource`, `relations:byTarget`
- Schema loader + seed bootstrap on `openVault`: copies seed YAMLs into a fresh vault, parses every `.yml`, syncs to `object_types`
- Adapter integration tests (6 cases) using in-memory SQLite — first time we exercise real prepared statements in tests

### Numbers
- Tests: 340 → 373 (+33 across 4 new test files)
- Files: 14 changed, 7 new files
- Typecheck + lint clean

## Test plan
- [x] `pnpm typecheck` (3/3)
- [x] `pnpm test` (140 core + 206 desktop)
- [x] `pnpm lint` (clean)
- [ ] Manual: open existing v0.x vault → no data loss, backlinks panel still populated
- [ ] Manual: open empty vault → 7 seed YAMLs created in `<vault>/.ziba/schema/`
- [ ] Manual: a note with `type: book` and `relations: { author: [[Tolkien]] }` → `ipc.getRelationsBySource({ sourcePath })` returns the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)