### PR TITLE
fix(v1.0.1): phase 2 followups — perf cache, hot-reload, toggle split, slug centralised

### DIFF
--- a/apps/desktop/electron/ipc/vault.ts
+++ b/apps/desktop/electron/ipc/vault.ts
@@ -12,17 +12,19 @@ import { IpcChannels, type VaultInfo } from '../../shared/ipc.js';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { SqliteIndexStore } from '../adapters/index-store.sqlite.js';
 import { ChokidarWatcher } from '../adapters/watcher.chokidar.js';
-import { bootstrapSchemas } from '../schema-loader.js';
+import { bootstrapSchemas, watchSchemas } from '../schema-loader.js';
 import { IpcError } from '../security.js';
 import {
   consumeIfSelfWrite,
   getCurrentVault,
   getIndexStore,
+  getSchemaWatcher,
   getWatcher,
   requireIndexStore,
   setCurrentVault,
   setFilesystem,
   setIndexStore,
+  setSchemaWatcher,
   setWatcher,
 } from '../state.js';
 import { pushRecentVault } from './settings.js';
@@ -56,6 +58,15 @@ async function teardown(): Promise<void> {
       // Best effort -- a watcher that fails to stop shouldn't block reopen.
     }
     setWatcher(null);
+  }
+  const sw = getSchemaWatcher();
+  if (sw) {
+    try {
+      await sw.stop();
+    } catch {
+      // Best effort.
+    }
+    setSchemaWatcher(null);
   }
   const s = getIndexStore();
   if (s) {
@@ -108,6 +119,16 @@ export async function openVault(win: BrowserWindow, args: { root: string }): Pro
   // Errors in individual schemas are logged and skipped — one bad
   // file shouldn't block opening the vault.
   await bootstrapSchemas(root, indexStore);
+
+  // v1.0.1: hot-reload schemas. Editing `.ziba/schema/<id>.yml` while
+  // the vault is open propagates to the SQLite cache and pushes a
+  // `schemasChanged` event so the renderer refreshes its taxonomy
+  // without a vault re-open.
+  const schemaW = watchSchemas(root, indexStore, () => {
+    if (win.isDestroyed()) return;
+    win.webContents.send(IpcChannels.vaultEvent, { type: 'schemasChanged' });
+  });
+  setSchemaWatcher(schemaW);
 
   // Initial index. Push progress to the renderer so the UI can show a
   // spinner / progress bar while large vaults import.

--- a/apps/desktop/electron/schema-loader.ts
+++ b/apps/desktop/electron/schema-loader.ts
@@ -7,6 +7,7 @@
 
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
+import chokidar, { type FSWatcher } from 'chokidar';
 import {
   INDEX_DIR_NAME,
   SEED_SCHEMAS,
@@ -99,4 +100,117 @@ export async function bootstrapSchemas(
   await ensureSeedSchemas(vaultRoot);
   const loaded = await loadSchemasIntoStore(vaultRoot, store);
   return { loaded };
+}
+
+/**
+ * Process a single schema file event. Re-reads + parses + upserts into
+ * the store; on parse failure or read error, logs and leaves the prior
+ * cache row in place (so a transient editor mid-save doesn't blow away
+ * a working schema).
+ *
+ * `unlink` is special: we delete the type from the cache immediately —
+ * a removed yaml is the user's explicit "drop this type" gesture.
+ */
+async function applySchemaFileEvent(
+  full: string,
+  event: 'add' | 'change' | 'unlink',
+  store: IndexStoreAdapter,
+): Promise<void> {
+  if (event === 'unlink') {
+    // Derive the type id from the filename: `<id>.yml` or `<id>.yaml`.
+    // We don't have access to the schema content (the file is gone),
+    // so the filename is the only available key.
+    const base = path.basename(full).replace(/\.(yml|yaml)$/i, '');
+    if (base.length > 0) {
+      try {
+        await store.deleteObjectType(base);
+      } catch (err) {
+        console.error(`[schema-loader] failed to drop type "${base}":`, err);
+      }
+    }
+    return;
+  }
+
+  let content: string;
+  let mtimeMs: number;
+  try {
+    content = await fsp.readFile(full, 'utf8');
+    const stat = await fsp.stat(full);
+    mtimeMs = stat.mtimeMs;
+  } catch (err) {
+    console.error(`[schema-loader] failed to read ${full}:`, err);
+    return;
+  }
+
+  const result = parseSchemaYaml(content);
+  if (!result.ok) {
+    console.error(`[schema-loader] schema "${full}" has errors:`, result.errors);
+    return;
+  }
+
+  const row: ObjectTypeRow = {
+    id: result.schema.id,
+    label: result.schema.label,
+    icon: result.schema.icon ?? null,
+    color: result.schema.color ?? null,
+    schema: result.schema,
+    mtimeMs,
+  };
+  await store.upsertObjectType(row);
+}
+
+/**
+ * Watch `<vault>/.ziba/schema/` for `.yml` / `.yaml` changes and
+ * sync them into the `object_types` cache. Each event additionally
+ * fires `onChanged()` so the caller can push a `schemasChanged`
+ * event to the renderer (which refreshes the sidebar TypesSection
+ * and the ObjectPanel labels in place — no vault re-open required).
+ *
+ * Returned `stop()` unwatches and releases handles. Call it on
+ * vault close so a subsequent `openVault` can install a fresh
+ * watcher against the new vault.
+ *
+ * The watcher is independent from the main vault watcher because the
+ * latter explicitly skips `.ziba/` to avoid recursing into our own
+ * cache directory.
+ */
+export function watchSchemas(
+  vaultRoot: string,
+  store: IndexStoreAdapter,
+  onChanged: () => void,
+): { stop: () => Promise<void> } {
+  const dir = path.join(vaultRoot, INDEX_DIR_NAME, SCHEMA_DIR_NAME);
+  const watcher: FSWatcher = chokidar.watch(dir, {
+    ignored: (p) => {
+      // Only watch yaml files. chokidar may emit events for the dir
+      // itself or for non-yaml siblings; we filter them out cheaply.
+      if (p === dir) return false;
+      return !/\.(yml|yaml)$/i.test(p);
+    },
+    persistent: true,
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 150, pollInterval: 50 },
+  });
+
+  const handle =
+    (event: 'add' | 'change' | 'unlink') =>
+    async (full: string): Promise<void> => {
+      await applySchemaFileEvent(full, event, store);
+      onChanged();
+    };
+  watcher.on('add', (p: string): void => {
+    void handle('add')(p);
+  });
+  watcher.on('change', (p: string): void => {
+    void handle('change')(p);
+  });
+  watcher.on('unlink', (p: string): void => {
+    void handle('unlink')(p);
+  });
+
+  return {
+    stop: async (): Promise<void> => {
+      await watcher.close();
+    },
+  };
 }

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -13,6 +13,7 @@ let currentVault: VaultInfo | null = null;
 let indexStore: IndexStoreAdapter | null = null;
 let watcher: WatcherAdapter | null = null;
 let filesystem: FilesystemAdapter | null = null;
+let schemaWatcher: { stop: () => Promise<void> } | null = null;
 
 // Paths we just wrote ourselves, with an expiry timestamp. The watcher
 // uses this to skip echoes of our own writes (chokidar's awaitWriteFinish
@@ -51,6 +52,14 @@ export function getFilesystem(): FilesystemAdapter | null {
 
 export function setFilesystem(fs: FilesystemAdapter | null): void {
   filesystem = fs;
+}
+
+export function getSchemaWatcher(): { stop: () => Promise<void> } | null {
+  return schemaWatcher;
+}
+
+export function setSchemaWatcher(w: { stop: () => Promise<void> } | null): void {
+  schemaWatcher = w;
 }
 
 /**

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -244,7 +244,12 @@ export type IpcResponses = {
 export type VaultEventPayload =
   | { type: 'add' | 'change'; path: NotePath; mtimeMs: number }
   | { type: 'unlink'; path: NotePath }
-  | { type: 'addDir' | 'unlinkDir'; path: NotePath };
+  | { type: 'addDir' | 'unlinkDir'; path: NotePath }
+  // v1.0.1: emitted when `<vault>/.ziba/schema/*.yml` changes —
+  // either a schema file was added, edited, or removed. Renderers
+  // refresh the taxonomy cache so sidebar / object-panel labels +
+  // icons + colors update without a vault re-open.
+  | { type: 'schemasChanged' };
 
 export type IndexProgressPayload = { processed: number; total: number | null };
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { SearchPalette } from './components/SearchPalette';
 import { ToastStack } from './components/ToastStack';
 import { useEditorStore } from './stores/editor';
 import { useSearchStore } from './stores/search';
+import { useTagsStore } from './stores/tags';
 import { useUiStore } from './stores/ui';
 import { useVaultStore } from './stores/vault';
 import { ipc } from './lib/ipc';
@@ -25,6 +26,13 @@ export function App(): JSX.Element {
     void hydrateFromMain();
 
     const offVaultEvent = ipc.onVaultEvent((event) => {
+      // v1.0.1: schema-only change (someone edited a yml in
+      // `<vault>/.ziba/schema/`). Skip the notes refresh — the file
+      // tree didn't change — and just rebuild the taxonomy.
+      if (event.type === 'schemasChanged') {
+        void useTagsStore.getState().refresh();
+        return;
+      }
       applyVaultEvent(event);
       if (event.type === 'change' || event.type === 'add') {
         applyExternalChange(event.path, event.mtimeMs);

--- a/apps/desktop/src/components/BacklinksPanel/index.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { extractType } from '@ziba/core';
 import { useEditorStore } from '../../stores/editor';
 import { useUiStore, type RightPaneTab } from '../../stores/ui';
 import { MiniGraph } from '../MiniGraph';
@@ -24,13 +25,6 @@ const TABS_TYPED: readonly TabSpec[] = [
   { id: 'backlinks', label: 'Oggetto' },
   { id: 'graph', label: 'Grafo' },
 ] as const;
-
-function readTypeFromFrontmatter(fm: Record<string, unknown> | undefined): string | null {
-  if (fm === undefined) return null;
-  const t = fm.type;
-  if (typeof t !== 'string') return null;
-  return /^[a-z][a-z0-9-]*$/.test(t) ? t : null;
-}
 
 /**
  * Tabbed shell for the right-side panel. Hosts:
@@ -64,7 +58,7 @@ export function BacklinksPanel(): JSX.Element {
   // backlinks list for the object panel. Untyped notes keep the
   // backlinks behaviour unchanged. Tab id `'backlinks'` is reused
   // for both modes (label changes; persistence stays).
-  const isTyped = readTypeFromFrontmatter(currentNote?.frontmatter) !== null;
+  const isTyped = currentNote !== null && extractType(currentNote.frontmatter) !== null;
   const tabs = isTyped ? TABS_TYPED : TABS_UNTYPED;
 
   return (

--- a/apps/desktop/src/components/ObjectPanel/index.test.tsx
+++ b/apps/desktop/src/components/ObjectPanel/index.test.tsx
@@ -127,7 +127,10 @@ describe('ObjectPanel — typed note', () => {
       },
       mtimeMs: 0,
     };
-    mock.setHandler('types:list', async () => [bookSchema]);
+    // ObjectPanel reads the schema from the renderer-side cache
+    // (`useTagsStore.objectTypeSchemas`) rather than per-mount IPC,
+    // so we seed the store directly.
+    useTagsStore.setState({ objectTypeSchemas: [bookSchema] });
     mock.setHandler('relations:bySource', async () => [
       {
         sourcePath: 'tolkien.md',

--- a/apps/desktop/src/components/ObjectPanel/index.tsx
+++ b/apps/desktop/src/components/ObjectPanel/index.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import type { NotePath } from '@ziba/core';
+import { extractType, type NotePath } from '@ziba/core';
 import type { ObjectTypeRow, RelationRow } from '../../../shared/ipc';
 import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
@@ -32,20 +32,28 @@ import { navigateToNote } from '../../lib/navigate';
 export function ObjectPanel(): JSX.Element {
   const currentNote = useEditorStore((s) => s.currentNote);
   const types = useTagsStore((s) => s.types);
+  const objectTypeSchemas = useTagsStore((s) => s.objectTypeSchemas);
 
-  // Note can be null briefly during load. Render nothing rather than
-  // a flash of "no type" — the parent decides which panel to mount.
+  // Note can be null briefly during load. Render the empty state
+  // rather than a flash of "no type" — the parent decides which
+  // panel to mount.
   if (currentNote === null) return <EmptyState />;
 
-  const typeId = readTypeFromFrontmatter(currentNote.frontmatter);
+  const typeId = extractType(currentNote.frontmatter);
   if (typeId === null) return <EmptyState />;
 
   return (
     <ObjectPanelInner
       typeId={typeId}
       sourcePath={currentNote.path}
+      // mtimeMs as a dep on the inner effect so saving the note
+      // (which re-extracts relations on the indexer side) triggers a
+      // refetch — without it the panel would show stale relations
+      // until the user reopens the note.
+      mtimeMs={currentNote.mtimeMs}
       frontmatter={currentNote.frontmatter}
       typeMeta={types.find((t) => t.id === typeId) ?? null}
+      cachedSchema={objectTypeSchemas.find((s) => s.id === typeId) ?? null}
     />
   );
 }
@@ -53,34 +61,39 @@ export function ObjectPanel(): JSX.Element {
 function ObjectPanelInner({
   typeId,
   sourcePath,
+  mtimeMs,
   frontmatter,
   typeMeta,
+  cachedSchema,
 }: {
   typeId: string;
   sourcePath: NotePath;
+  mtimeMs: number;
   frontmatter: Record<string, unknown>;
   typeMeta: { id: string; label: string; icon: string | null; color: string | null } | null;
+  cachedSchema: ObjectTypeRow | null;
 }): JSX.Element {
-  const [schema, setSchema] = useState<ObjectTypeRow | null>(null);
   const [outgoing, setOutgoing] = useState<RelationRow[]>([]);
   const [inverse, setInverse] = useState<RelationRow[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  // Effect runs whenever the source path or type id changes — both
-  // legitimate reasons to refetch (note switched, user edited the
-  // frontmatter `type:`).
+  // Refetch relations whenever the source path, the type id, or the
+  // note's mtime changes. mtime as a dep is what makes the panel
+  // reactive to saves: the indexer rewrites `relations` on each
+  // upsert, and a watcher event re-loads `currentNote` with a fresh
+  // `mtimeMs` — this useEffect catches that and pulls the new state.
+  // Schemas are taken from the renderer-side cache (`cachedSchema`),
+  // so we no longer round-trip IPC for them on every note swap.
   useEffect(() => {
     let cancelled = false;
     setError(null);
     (async (): Promise<void> => {
       try {
-        const [schemas, out, inv] = await Promise.all([
-          ipc.listObjectTypes(),
+        const [out, inv] = await Promise.all([
           ipc.getRelationsBySource({ sourcePath }),
           ipc.getRelationsByTarget({ targetPath: sourcePath }),
         ]);
         if (cancelled) return;
-        setSchema(schemas.find((s) => s.id === typeId) ?? null);
         // Filter `kind = ''` out of outgoing — those are body
         // wikilinks, which the legacy backlinks UI handled. Object
         // panel surfaces only the typed relations the user
@@ -95,7 +108,9 @@ function ObjectPanelInner({
     return (): void => {
       cancelled = true;
     };
-  }, [sourcePath, typeId]);
+  }, [sourcePath, typeId, mtimeMs]);
+
+  const schema = cachedSchema;
 
   const groupedOutgoing = useMemo(() => groupBy(outgoing, (r) => r.kind), [outgoing]);
   const groupedInverse = useMemo(() => groupBy(inverse, (r) => r.kind), [inverse]);
@@ -336,12 +351,6 @@ function EmptyHint({ children }: { children: React.ReactNode }): JSX.Element {
 }
 
 // ---- helpers --------------------------------------------------------------
-
-function readTypeFromFrontmatter(fm: Record<string, unknown>): string | null {
-  const t = fm.type;
-  if (typeof t !== 'string') return null;
-  return /^[a-z][a-z0-9-]*$/.test(t) ? t : null;
-}
 
 function groupBy<T>(items: ReadonlyArray<T>, keyOf: (t: T) => string): Record<string, T[]> {
   const out: Record<string, T[]> = {};

--- a/apps/desktop/src/components/Sidebar/TypesSection.tsx
+++ b/apps/desktop/src/components/Sidebar/TypesSection.tsx
@@ -19,20 +19,15 @@ import { useUiStore } from '../../stores/ui';
  * panel" with one click. We could split it later if the section
  * counts grow large enough to warrant separate gestures.
  */
-export function TypesSection(): JSX.Element | null {
+export function TypesSection(): JSX.Element {
   const types = useTagsStore((s) => s.types);
   const selectedType = useTagsStore((s) => s.selectedType);
   const notesForSelectedType = useTagsStore((s) => s.notesForSelectedType);
   const selectType = useTagsStore((s) => s.selectType);
-  const expanded = useUiStore((s) => s.tagsExpanded);
+  const expanded = useUiStore((s) => s.typesExpanded);
+  const toggleExpanded = useUiStore((s) => s.toggleTypes);
   const openNote = useEditorStore((s) => s.openNote);
   const currentPath = useEditorStore((s) => s.currentPath);
-
-  // Don't render the section header when the vault has zero typed
-  // notes — the "Tag" / "Note" sections give the right v0.x feel for
-  // untyped vaults. Once the user labels at least one note, the
-  // section appears automatically.
-  if (types.length === 0) return null;
 
   const handleClick = (id: string): void => {
     if (selectedType === id) {
@@ -48,9 +43,11 @@ export function TypesSection(): JSX.Element | null {
 
   return (
     <section className="shrink-0 border-b border-border" aria-label="Tipi">
-      <div
-        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-fg-muted"
-        aria-label="Tipi"
+      <button
+        type="button"
+        onClick={toggleExpanded}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-fg-muted hover:text-fg"
+        aria-expanded={expanded}
       >
         <span className="flex items-center gap-1.5">
           <span aria-hidden="true" className="inline-block w-3 text-center">
@@ -64,20 +61,32 @@ export function TypesSection(): JSX.Element | null {
         >
           {types.length}
         </span>
-      </div>
+      </button>
 
       {expanded && (
         <div className="px-1 pb-2">
-          <ul role="list" className="max-h-[200px] space-y-px overflow-y-auto">
-            {types.map((t) => (
-              <TypeRow
-                key={t.id}
-                type={t}
-                active={selectedType === t.id}
-                onClick={(): void => handleClick(t.id)}
-              />
-            ))}
-          </ul>
+          {types.length === 0 ? (
+            // Didactic empty state. Without it a v0.x user wouldn't
+            // know the feature exists. The hint is intentionally
+            // light-touch — once at least one note is typed, the
+            // section auto-populates.
+            <p className="px-2 py-2 text-xs text-fg-muted">
+              Aggiungi <code className="font-mono">type: &lt;slug&gt;</code> nel frontmatter di una
+              nota per categorizzarla. Gli schema vivono in{' '}
+              <code className="font-mono">.ziba/schema/</code>.
+            </p>
+          ) : (
+            <ul role="list" className="max-h-[200px] space-y-px overflow-y-auto">
+              {types.map((t) => (
+                <TypeRow
+                  key={t.id}
+                  type={t}
+                  active={selectedType === t.id}
+                  onClick={(): void => handleClick(t.id)}
+                />
+              ))}
+            </ul>
+          )}
 
           {selectedType !== null && (
             <div className="mt-2 border-t border-border pt-2">

--- a/apps/desktop/src/stores/tags.ts
+++ b/apps/desktop/src/stores/tags.ts
@@ -38,6 +38,13 @@ type TagsState = {
    * frontmatter (a schema with no users does not show up).
    */
   types: TypeSummary[];
+  /**
+   * v1.0: every cached object-type schema, regardless of whether any
+   * note carries that type. Populated on `refresh()` from
+   * `ipc.listObjectTypes()`. Serves as a renderer-side cache so the
+   * ObjectPanel doesn't re-fetch schemas on every note swap.
+   */
+  objectTypeSchemas: ObjectTypeRow[];
 
   /** Canonical (lowercase) tag the user is filtering by, or null. */
   selectedTag: string | null;
@@ -113,6 +120,7 @@ export const useTagsStore = create<TagsState>((set, get) => {
   return {
     tags: [],
     types: [],
+    objectTypeSchemas: [],
     selectedTag: null,
     selectedType: null,
     notesForSelectedTag: [],
@@ -124,6 +132,7 @@ export const useTagsStore = create<TagsState>((set, get) => {
         set({
           tags: [],
           types: [],
+          objectTypeSchemas: [],
           selectedTag: null,
           selectedType: null,
           notesForSelectedTag: [],
@@ -142,6 +151,9 @@ export const useTagsStore = create<TagsState>((set, get) => {
 
         const selectedTag = get().selectedTag;
         const selectedType = get().selectedType;
+        // Cache the full schemas so ObjectPanel can read them in-place
+        // instead of round-tripping IPC on every note swap.
+        set({ objectTypeSchemas: typeSchemas });
 
         // Drop a stale tag filter (the last note carrying it was
         // deleted or renamed away from this tag).

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -39,6 +39,12 @@ type Persisted = {
    */
   tagsExpanded: boolean;
   /**
+   * v1.0: whether the "Tipi" section of the sidebar is expanded.
+   * Independent of `tagsExpanded` so the user can collapse one without
+   * the other.
+   */
+  typesExpanded: boolean;
+  /**
    * Active tab in the right-side panel. Persisted so users keep the same
    * view across reloads.
    */
@@ -59,6 +65,7 @@ const DEFAULTS: Persisted = {
   backlinksOpen: true,
   expandedFolders: [],
   tagsExpanded: true,
+  typesExpanded: true,
   rightPaneTab: 'backlinks',
   mainView: 'editor',
   databaseViewMode: 'table',
@@ -112,6 +119,8 @@ function loadPersisted(): Persisted {
           ? p.expandedFolders
           : DEFAULTS.expandedFolders,
       tagsExpanded: typeof p.tagsExpanded === 'boolean' ? p.tagsExpanded : DEFAULTS.tagsExpanded,
+      typesExpanded:
+        typeof p.typesExpanded === 'boolean' ? p.typesExpanded : DEFAULTS.typesExpanded,
       rightPaneTab: isRightPaneTab(p.rightPaneTab) ? p.rightPaneTab : DEFAULTS.rightPaneTab,
       mainView: isMainView(p.mainView) ? p.mainView : DEFAULTS.mainView,
       databaseViewMode: isDatabaseViewMode(p.databaseViewMode)
@@ -147,6 +156,7 @@ type UiState = Persisted & {
   toggleFolder(path: string): void;
   setExpandedFolders(paths: string[]): void;
   toggleTags(): void;
+  toggleTypes(): void;
   setRightPaneTab(tab: RightPaneTab): void;
   setMainView(view: MainView): void;
   setDatabaseViewMode(mode: DatabaseViewMode): void;
@@ -164,6 +174,7 @@ export const useUiStore = create<UiState>((set, get) => {
       backlinksOpen,
       expandedFolders,
       tagsExpanded,
+      typesExpanded,
       rightPaneTab,
       mainView,
       databaseViewMode,
@@ -174,6 +185,7 @@ export const useUiStore = create<UiState>((set, get) => {
       backlinksOpen,
       expandedFolders,
       tagsExpanded,
+      typesExpanded,
       rightPaneTab,
       mainView,
       databaseViewMode,
@@ -222,6 +234,10 @@ export const useUiStore = create<UiState>((set, get) => {
     },
     toggleTags() {
       set({ tagsExpanded: !get().tagsExpanded });
+      persist();
+    },
+    toggleTypes() {
+      set({ typesExpanded: !get().typesExpanded });
       persist();
     },
     setRightPaneTab(tab) {


### PR DESCRIPTION
## Summary

Six items deferred from the Phase 2 review. All low-risk, all in service of "best code".

1. **Slug regex centralised** — `extractType` from `@ziba/core` is the single source of truth. `BacklinksPanel` and `ObjectPanel` no longer carry inline `/^[a-z][a-z0-9-]*$/` copies.
2. **ObjectPanel reactive on save** — useEffect now depends on `currentNote.mtimeMs`. Editing `relations:` and saving updates the panel without a re-open.
3. **ObjectPanel schema cache** — schemas come from `useTagsStore.objectTypeSchemas` (populated by the existing taxonomy refresh) instead of per-mount `ipc.listObjectTypes`. One IPC call eliminated per note swap.
4. **Types/Tags toggle split** — `useUiStore.typesExpanded` is now independent from `tagsExpanded`. Persisted alongside the other sidebar layout prefs.
5. **TypesSection didactic empty state** — empty `types: []` no longer hides the section. A short hint walks the user through `type:` + `.ziba/schema/` so the feature is discoverable.
6. **Schema YAML hot-reload** — chokidar watcher on `<vault>/.ziba/schema/*.{yml,yaml}` re-parses + upserts on every change, then pushes a new `schemasChanged` vault event so the renderer's taxonomy refreshes without a vault re-open. Watcher stops on `closeVault`. Falls back gracefully on parse errors (logs + leaves prior cache row in place).

### Numbers
- Tests: 387 stable (no regressions; failing test fixed by seeding `useTagsStore.objectTypeSchemas` directly).
- Files: 11 changed (1 new IPC payload variant `schemasChanged`, 1 new state slot `schemaWatcher`, 1 new `watchSchemas` function with `applySchemaFileEvent` helper).
- Typecheck + lint clean.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm lint`
- [ ] Manual: edit `<vault>/.ziba/schema/book.yml` (change icon/label/color) while Ziba is open → sidebar TypesSection picks up the change within ~150ms (chokidar awaitWriteFinish stability)
- [ ] Manual: delete `<vault>/.ziba/schema/idea.yml` → sidebar drops the row
- [ ] Manual: collapse Tipi independently of Tag → state survives reload
- [ ] Manual: open a typed note, edit `relations:`, save → ObjectPanel relations refresh in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)