### PR TITLE
feat(v1.0 phase 3): editor type-icon + slash relation + PropertyEditor relations

### DIFF
--- a/apps/desktop/electron/adapters/index-store.sqlite.test.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.test.ts
@@ -51,6 +51,7 @@ describe('getTypedPaths', () => {
         `SELECT source_path AS path, text_value AS type
          FROM note_properties
          WHERE prop_key = 'type'
+           AND prop_type = 'text'
            AND text_value IS NOT NULL
            AND text_value <> ''`,
       )
@@ -71,6 +72,7 @@ describe('getTypedPaths', () => {
         `SELECT source_path AS path, text_value AS type
          FROM note_properties
          WHERE prop_key = 'type'
+           AND prop_type = 'text'
            AND text_value IS NOT NULL
            AND text_value <> ''`,
       )
@@ -79,5 +81,29 @@ describe('getTypedPaths', () => {
     const got = new Map(rows.map((r) => [r.path, r.type]));
 
     expect(got.size).toBe(0);
+  });
+
+  it('excludes rows whose prop_type is not "text" even if text_value is set', () => {
+    setupNote('note.md');
+    // A note that wrote `type: https://foo.bar` — replaceProperties stores
+    // text_value='https://foo.bar' with prop_type='url'. getTypedPaths must
+    // exclude this; the type slug is reserved for prop_type='text' entries.
+    db.prepare(
+      `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+       VALUES (?, 'type', 'url', 'https://foo.bar')`,
+    ).run('note.md');
+
+    const rows = db
+      .prepare(
+        `SELECT source_path AS path, text_value AS type
+         FROM note_properties
+         WHERE prop_key = 'type'
+           AND prop_type = 'text'
+           AND text_value IS NOT NULL
+           AND text_value <> ''`,
+      )
+      .all();
+
+    expect(rows).toHaveLength(0);
   });
 });

--- a/apps/desktop/electron/adapters/index-store.sqlite.test.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { EXPECTED_USER_VERSION, PRAGMAS, SCHEMA_SQL } from '@ziba/core';
+
+// Integration tests for statements added to SqliteIndexStore that are not
+// covered by index-store-relations.test.ts. Uses an in-memory SQLite DB
+// (same pattern as that file) so we exercise the real SQL without
+// touching the filesystem or Electron APIs.
+
+let db: Database.Database;
+
+function setupNote(path: string, title = path.replace(/\.md$/, '')): void {
+  db.prepare(
+    `INSERT INTO notes (path, title, frontmatter_json, mtime)
+     VALUES (?, ?, '{}', 0)
+     ON CONFLICT (path) DO NOTHING`,
+  ).run(path, title);
+}
+
+function insertTypeProp(path: string, type: string): void {
+  db.prepare(
+    `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+     VALUES (?, 'type', 'text', ?)`,
+  ).run(path, type);
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec(PRAGMAS);
+  db.exec(SCHEMA_SQL);
+  db.exec(`PRAGMA user_version = ${EXPECTED_USER_VERSION}`);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('getTypedPaths', () => {
+  it('returns one entry per typed note, mapping path → type slug', () => {
+    setupNote('books/hobbit.md', 'The Hobbit');
+    insertTypeProp('books/hobbit.md', 'book');
+
+    setupNote('people/tolkien.md', 'Tolkien');
+    insertTypeProp('people/tolkien.md', 'person');
+
+    setupNote('untyped.md', 'Untyped');
+    // no type property for untyped.md
+
+    const rows = db
+      .prepare(
+        `SELECT source_path AS path, text_value AS type
+         FROM note_properties
+         WHERE prop_key = 'type'
+           AND text_value IS NOT NULL
+           AND text_value <> ''`,
+      )
+      .all() as { path: string; type: string }[];
+
+    const got = new Map(rows.map((r) => [r.path, r.type]));
+
+    expect(got).toBeInstanceOf(Map);
+    expect(got.size).toBe(2);
+    expect(got.get('books/hobbit.md')).toBe('book');
+    expect(got.get('people/tolkien.md')).toBe('person');
+    expect(got.has('untyped.md')).toBe(false);
+  });
+
+  it('returns an empty map on a fresh vault', () => {
+    const rows = db
+      .prepare(
+        `SELECT source_path AS path, text_value AS type
+         FROM note_properties
+         WHERE prop_key = 'type'
+           AND text_value IS NOT NULL
+           AND text_value <> ''`,
+      )
+      .all() as { path: string; type: string }[];
+
+    const got = new Map(rows.map((r) => [r.path, r.type]));
+
+    expect(got.size).toBe(0);
+  });
+});

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -135,6 +135,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     deleteObjectType: Database.Statement;
     listObjectTypes: Database.Statement;
     getTypeCounts: Database.Statement;
+    getTypedPaths: Database.Statement;
   } | null = null;
 
   async init(vaultRoot: string): Promise<void> {
@@ -348,6 +349,16 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         GROUP BY text_value
         ORDER BY count DESC, text_value ASC
       `),
+      // Full path → type slug mapping. One indexed scan on prop_key = 'type';
+      // empty-string values are excluded (shouldn't occur via replaceProperties
+      // but guard against manual DB edits or future callers that skip validation).
+      getTypedPaths: db.prepare(`
+        SELECT source_path AS path, text_value AS type
+        FROM note_properties
+        WHERE prop_key = 'type'
+          AND text_value IS NOT NULL
+          AND text_value <> ''
+      `),
     };
   }
 
@@ -522,6 +533,14 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     type R = { type: string; count: number };
     const rows = s.getTypeCounts.all() as R[];
     return Promise.resolve(rows.map((r) => ({ type: r.type, count: r.count })));
+  }
+
+  async getTypedPaths(): Promise<Map<NotePath, string>> {
+    const s = this.require();
+    const rows = s.getTypedPaths.all() as Array<{ path: string; type: string }>;
+    const out = new Map<NotePath, string>();
+    for (const r of rows) out.set(r.path, r.type);
+    return out;
   }
 
   async listObjectTypes(): Promise<ObjectTypeRow[]> {

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -356,6 +356,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         SELECT source_path AS path, text_value AS type
         FROM note_properties
         WHERE prop_key = 'type'
+          AND prop_type = 'text'
           AND text_value IS NOT NULL
           AND text_value <> ''
       `),
@@ -540,7 +541,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     const rows = s.getTypedPaths.all() as Array<{ path: string; type: string }>;
     const out = new Map<NotePath, string>();
     for (const r of rows) out.set(r.path, r.type);
-    return out;
+    return Promise.resolve(out);
   }
 
   async listObjectTypes(): Promise<ObjectTypeRow[]> {

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -21,6 +21,7 @@ import {
 } from './vault.js';
 import {
   listNotes,
+  getTypedPaths,
   loadNote,
   saveNote,
   createNote,
@@ -84,6 +85,7 @@ export function registerIpcHandlers(win: BrowserWindow): void {
 
   // Notes
   handle(IpcChannels.listNotes, () => listNotes());
+  handle(IpcChannels.getTypedPaths, () => getTypedPaths());
   handle(IpcChannels.loadNote, (args) => loadNote(args));
   handle(IpcChannels.saveNote, (args) => saveNote(args));
   handle(IpcChannels.createNote, (args) => createNote(args));

--- a/apps/desktop/electron/ipc/notes.ts
+++ b/apps/desktop/electron/ipc/notes.ts
@@ -36,6 +36,11 @@ export async function listNotes(): Promise<NoteSummary[]> {
   return requireIndexStore().listNotes();
 }
 
+export async function getTypedPaths(): Promise<Array<[NotePath, string]>> {
+  const map = await requireIndexStore().getTypedPaths();
+  return Array.from(map.entries());
+}
+
 export async function loadNote(args: { path: NotePath }): Promise<Note> {
   assertVaultRelative(args.path);
   const vault = requireVault();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.11",
     "@types/katex": "^0.16.7",

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -51,6 +51,7 @@ export const IpcChannels = {
 
   // Note operations
   listNotes: 'notes:list',
+  getTypedPaths: 'notes:typedPaths',
   loadNote: 'notes:load',
   saveNote: 'notes:save',
   createNote: 'notes:create',
@@ -144,6 +145,7 @@ export type IpcRequests = {
   [IpcChannels.reindexVault]: void;
 
   [IpcChannels.listNotes]: void;
+  [IpcChannels.getTypedPaths]: void;
   [IpcChannels.loadNote]: { path: NotePath };
   [IpcChannels.saveNote]: { path: NotePath; body: string; frontmatter: Frontmatter };
   [IpcChannels.createNote]: { path: NotePath; initialBody?: string };
@@ -207,6 +209,10 @@ export type IpcResponses = {
   [IpcChannels.reindexVault]: { count: number };
 
   [IpcChannels.listNotes]: NoteSummary[];
+  // Tuples (not Map) so the contextBridge serializer round-trips
+  // cleanly across the renderer boundary. Renderer rebuilds the
+  // Map at the IPC client wrapper.
+  [IpcChannels.getTypedPaths]: Array<[NotePath, string]>;
   [IpcChannels.loadNote]: Note;
   [IpcChannels.saveNote]: { mtimeMs: number };
   [IpcChannels.createNote]: Note;

--- a/apps/desktop/src/components/Editor/EditorExtensions.ts
+++ b/apps/desktop/src/components/Editor/EditorExtensions.ts
@@ -5,7 +5,11 @@ import { CalloutExtension } from './extensions/Callout';
 import { EmbedExtension } from './extensions/Embed';
 import { MathBlockExtension } from './extensions/MathBlock';
 import { MathInlineExtension } from './extensions/MathInline';
-import { SlashCommandExtension, type SlashCommandRenderer } from './extensions/SlashCommand';
+import {
+  SlashCommandExtension,
+  type SlashCommandRenderer,
+  type SlashCommandOptions,
+} from './extensions/SlashCommand';
 import { TagMarkExtension } from './extensions/TagMark';
 import { Wikilink } from './extensions/Wikilink';
 import {
@@ -27,6 +31,9 @@ export type BuildExtensionsOptions = {
    * headless/test setups that don't need slash UI.
    */
   createSlashRenderer?: () => SlashCommandRenderer;
+  /** Forwarded to `SlashCommandExtension.configure(...)`. */
+  onSlashRelationRequested?: SlashCommandOptions['onRelationRequested'];
+  slashLatestRect?: SlashCommandOptions['latestRect'];
 };
 
 /**
@@ -92,6 +99,10 @@ export function buildEditorExtensions(options: BuildExtensionsOptions): Extensio
           },
           onExit(): void {},
         })),
+      ...(options.onSlashRelationRequested !== undefined && {
+        onRelationRequested: options.onSlashRelationRequested,
+      }),
+      ...(options.slashLatestRect !== undefined && { latestRect: options.slashLatestRect }),
     }),
     Markdown.configure({
       html: false,

--- a/apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx
+++ b/apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RelationPickerPopup } from './RelationPickerPopup';
+
+describe('<RelationPickerPopup>', () => {
+  it('renders a kind input that starts empty', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const kindInput = screen.getByPlaceholderText('Tipo di relazione') as HTMLInputElement;
+    expect(kindInput.value).toBe('');
+  });
+
+  it('renders one chip per suggested kind', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={['author', 'cites']}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'author' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'cites' })).toBeInTheDocument();
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onCancel = vi.fn();
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCommit({kind, target}) when both fields have values and the user submits', () => {
+    const onCommit = vi.fn();
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('Tipo di relazione'), {
+      target: { value: 'author' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Nota di destinazione'), {
+      target: { value: 'Tolkien' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Inserisci' }));
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'author', target: 'Tolkien' });
+  });
+
+  it('disables the commit button when either field is empty', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const commit = screen.getByRole('button', { name: 'Inserisci' });
+    expect(commit).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('Tipo di relazione'), {
+      target: { value: 'author' },
+    });
+    expect(commit).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('Nota di destinazione'), {
+      target: { value: 'Tolkien' },
+    });
+    expect(commit).not.toBeDisabled();
+  });
+
+  it('clicking a suggested-kind chip populates the kind input', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={['author']}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'author' }));
+    expect((screen.getByPlaceholderText('Tipo di relazione') as HTMLInputElement).value).toBe(
+      'author',
+    );
+  });
+
+  it('trims whitespace from both fields before committing', () => {
+    const onCommit = vi.fn();
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('Tipo di relazione'), {
+      target: { value: '  author  ' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Nota di destinazione'), {
+      target: { value: '  Tolkien  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Inserisci' }));
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'author', target: 'Tolkien' });
+  });
+});

--- a/apps/desktop/src/components/Editor/RelationPickerPopup.tsx
+++ b/apps/desktop/src/components/Editor/RelationPickerPopup.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export type RelationPickerPopupProps = {
+  /** Page-coordinate anchor (same shape as SlashMenuPopup). */
+  position: { top: number; left: number; bottom: number };
+  /**
+   * Relation kinds suggested for the current note's type — surfaced
+   * as quick-pick chips. Empty array is fine: the user can free-type
+   * a kind.
+   */
+  suggestedKinds: ReadonlyArray<string>;
+  onCommit(args: { kind: string; target: string }): void;
+  onCancel(): void;
+};
+
+const POPUP_HEIGHT_ESTIMATE = 260;
+
+/**
+ * Two-field popover triggered by the `/relazione` slash command. Kind
+ * + target as free-text inputs with optional schema-derived
+ * quick-pick chips. Commit button stays disabled until both fields
+ * carry non-empty trimmed text.
+ *
+ * The wikilink autocomplete that powers `[[...]]` is intentionally
+ * NOT reused here: the kind field is unrelated, and a richer target
+ * picker is a v1.1 follow-up once we have user signal.
+ */
+export function RelationPickerPopup(props: RelationPickerPopupProps): JSX.Element | null {
+  const { position, suggestedKinds, onCommit, onCancel } = props;
+
+  const [kind, setKind] = useState('');
+  const [target, setTarget] = useState('');
+  const kindInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    kindInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  // Flip above the trigger when there's not enough room below — same
+  // heuristic the SlashMenuPopup uses, no Floating UI dependency.
+  const placement = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { top: position.bottom + 4, left: position.left };
+    }
+    const wouldOverflow = position.bottom + POPUP_HEIGHT_ESTIMATE > window.innerHeight;
+    if (wouldOverflow && position.top - POPUP_HEIGHT_ESTIMATE > 0) {
+      return { top: position.top - POPUP_HEIGHT_ESTIMATE - 4, left: position.left };
+    }
+    return { top: position.bottom + 4, left: position.left };
+  }, [position.top, position.bottom, position.left]);
+
+  if (typeof document === 'undefined') return null;
+
+  const canCommit = kind.trim().length > 0 && target.trim().length > 0;
+
+  const commit = (): void => {
+    if (!canCommit) return;
+    onCommit({ kind: kind.trim(), target: target.trim() });
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label="Aggiungi relazione"
+      className="fixed z-50 w-72 rounded-md border border-border bg-bg-subtle p-3 shadow-lg"
+      style={{ top: placement.top, left: placement.left }}
+    >
+      <div className="flex flex-col gap-2">
+        <input
+          ref={kindInputRef}
+          type="text"
+          value={kind}
+          placeholder="Tipo di relazione"
+          onChange={(e): void => setKind(e.target.value)}
+          onKeyDown={(e): void => {
+            if (e.key === 'Enter' && canCommit) {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+        />
+
+        {suggestedKinds.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {suggestedKinds.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={(): void => setKind(k)}
+                className="rounded border border-border bg-bg px-2 py-0.5 text-xs text-fg-subtle hover:bg-accent/10 hover:text-fg"
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <input
+          type="text"
+          value={target}
+          placeholder="Nota di destinazione"
+          onChange={(e): void => setTarget(e.target.value)}
+          onKeyDown={(e): void => {
+            if (e.key === 'Enter' && canCommit) {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+        />
+
+        <div className="mt-1 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+          >
+            Annulla
+          </button>
+          <button
+            type="button"
+            onClick={commit}
+            disabled={!canCommit}
+            className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90 disabled:opacity-50"
+          >
+            Inserisci
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/components/Editor/extensions/SlashCommand.ts
+++ b/apps/desktop/src/components/Editor/extensions/SlashCommand.ts
@@ -39,6 +39,26 @@ export type SlashCommandOptions = {
    * the extension a no-op until the Editor wires up a real renderer.
    */
   createRenderer(): SlashCommandRenderer;
+  /**
+   * Callback invoked when the user picks the `relation` slash entry.
+   * The renderer is expected to surface a relation-picker popover
+   * anchored at `position`, then write into `frontmatter.relations`
+   * on commit. Omitted → the entry is a no-op (safe for headless /
+   * test usage).
+   */
+  onRelationRequested?: (args: {
+    editor: Editor;
+    range: Range;
+    position: { top: number; left: number; bottom: number };
+  }) => void;
+  /**
+   * The latest trigger-anchor rect, mutated by the renderer on every
+   * suggestion `onStart` / `onUpdate`. We use it inside `command` to
+   * anchor the relation popover at the slash position. A ref-like
+   * object is mutated in place by the renderer; cheaper than
+   * round-tripping through React state.
+   */
+  latestRect?: { current: { top: number; left: number; bottom: number } | null };
 };
 
 export const SlashCommandPluginKey = new PluginKey('slashCommand');
@@ -168,6 +188,13 @@ const SLASH_MENU_ITEMS: ReadonlyArray<SlashMenuItem> = [
     icon: '↪',
   },
   {
+    id: 'relation',
+    title: 'Aggiungi relazione',
+    description: 'Crea una relazione tipizzata nel frontmatter',
+    keywords: ['relation', 'relazione', 'rel', 'link'],
+    icon: '↗',
+  },
+  {
     id: 'math-block',
     title: 'Formula matematica',
     description: 'Blocco LaTeX `$$..$$` con rendering KaTeX',
@@ -243,7 +270,15 @@ function filterItems(query: string): SlashMenuItem[] {
  * is closed-set, so an unknown id is a programming error rather than a
  * user-facing failure.
  */
-function runSlashCommand(editor: Editor, id: string): void {
+function runSlashCommand(
+  editor: Editor,
+  id: string,
+  context: {
+    range: Range;
+    position: { top: number; left: number; bottom: number };
+    onRelationRequested?: SlashCommandOptions['onRelationRequested'];
+  },
+): void {
   switch (id) {
     case 'heading-1':
       editor.chain().focus().setNode('heading', { level: 1 }).run();
@@ -296,6 +331,15 @@ function runSlashCommand(editor: Editor, id: string): void {
         .focus()
         .insertContent({ type: 'mathInline', attrs: { formula: '' } })
         .run();
+      return;
+    case 'relation':
+      // Renderer handles the popover; the suggestion plugin already
+      // deleted the slash + query above us, so we just delegate.
+      context.onRelationRequested?.({
+        editor,
+        range: context.range,
+        position: context.position,
+      });
       return;
     default: {
       // Callout entries share the `callout-<kind>` id pattern. We map
@@ -385,8 +429,13 @@ export const SlashCommandExtension = Extension.create<SlashCommandOptions>({
           // them. We do this in a separate chain so the subsequent
           // node-mutating commands operate on a clean selection.
           editor.chain().focus().deleteRange(range).run();
-          // Step 2: insert the chosen block.
-          runSlashCommand(editor, props.id);
+          // Step 2: insert the chosen block (or delegate to the renderer
+          // for entries like `relation` that open a popover instead).
+          runSlashCommand(editor, props.id, {
+            range,
+            position: options.latestRect?.current ?? { top: 0, left: 0, bottom: 0 },
+            onRelationRequested: options.onRelationRequested,
+          });
         },
 
         render: () => options.createRenderer(),

--- a/apps/desktop/src/components/Editor/extensions/Wikilink.test.ts
+++ b/apps/desktop/src/components/Editor/extensions/Wikilink.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Wikilink } from './Wikilink';
+
+// StarterKit provides the required Document, Paragraph, and Text nodes so
+// the ProseMirror schema is complete when testing the Wikilink node in
+// isolation.
+function makeEditor(): Editor {
+  return new Editor({
+    extensions: [StarterKit, Wikilink],
+    content: { type: 'doc', content: [{ type: 'paragraph' }] },
+  });
+}
+
+describe('Wikilink renderHTML', () => {
+  it('prefixes the display text with the type icon when the target resolves to a typed note', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    const typeIconByPath = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    resolved.set('Tolkien', 'people/tolkien.md');
+    typeIconByPath.set('people/tolkien.md', '👤');
+    editor.commands.insertWikilink({ target: 'Tolkien' });
+    expect(editor.view.dom.textContent).toContain('👤 Tolkien');
+    editor.destroy();
+  });
+
+  it('omits the icon when the target is broken', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    resolved.set('UnknownPlace', false);
+    editor.commands.insertWikilink({ target: 'UnknownPlace' });
+    expect(editor.view.dom.textContent).toBe('UnknownPlace');
+    editor.destroy();
+  });
+
+  it('omits the icon when the target resolves to an untyped note', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    resolved.set('Plain', 'plain.md');
+    // typeIconByPath has no entry for plain.md
+    editor.commands.insertWikilink({ target: 'Plain' });
+    expect(editor.view.dom.textContent).toBe('Plain');
+    editor.destroy();
+  });
+
+  it('uses the alias as the display text and still prefixes the icon', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    const typeIconByPath = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    resolved.set('John Ronald Reuel Tolkien', 'people/tolkien.md');
+    typeIconByPath.set('people/tolkien.md', '👤');
+    editor.commands.insertWikilink({ target: 'John Ronald Reuel Tolkien', alias: 'JRR' });
+    expect(editor.view.dom.textContent).toContain('👤 JRR');
+    editor.destroy();
+  });
+});

--- a/apps/desktop/src/components/Editor/extensions/Wikilink.ts
+++ b/apps/desktop/src/components/Editor/extensions/Wikilink.ts
@@ -139,14 +139,16 @@ export const Wikilink = Node.create<WikilinkOptions>({
 
   addStorage() {
     const resolved: WikilinkResolutionMap = new Map();
-    // Keyed by vault-relative path; populated by useWikilinkTypes from the
-    // vault store's typedPaths slice × objectTypeSchemas icon fields.
+    // Path-keyed icon cache used by renderHTML to prepend the type icon
+    // without an extra IPC round-trip. Stays in lockstep with the
+    // vault's typed-paths slice through a renderer-side sync.
     const typeIconByPath: Map<string, string> = new Map();
     return {
       resolved,
       typeIconByPath,
-      // Hook consumed by tiptap-markdown's MarkdownSerializer (see
-      // packages/tiptap-markdown/src/util/extensions.js: getMarkdownSpec).
+      // The key `markdown` is a tiptap-markdown contract: the
+      // MarkdownSerializer discovers per-node serialize/parse hooks by
+      // scanning each extension's storage for this exact field.
       markdown: {
         serialize(state: MarkdownSerializerState, node: ProseMirrorNode): void {
           const target = String(node.attrs.target ?? '');

--- a/apps/desktop/src/components/Editor/extensions/Wikilink.ts
+++ b/apps/desktop/src/components/Editor/extensions/Wikilink.ts
@@ -3,16 +3,15 @@ import type { MarkdownSerializerState } from '@tiptap/pm/markdown';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 
 /**
- * `WikilinkResolutionMap` lives in `editor.storage.wikilink.resolved` and
- * maps a target string (the inner text between `[[` and `]]`, no alias) to
- * `true` if the title resolves to an existing note, `false` if it's broken.
- *
- * The map is populated by the React layer (`useResolvedWikilinks`) which
- * batch-calls `ipc.resolveTitle` and writes back here. The decoration logic
- * doesn't need it — `renderHTML` reads from storage at render time and the
- * DOM is updated by Tiptap on every `update()` cycle.
+ * One entry per wikilink target the editor has tried to resolve. The
+ * value is either `false` (the title could not be resolved to a note)
+ * or the resolved note's vault-relative path. Storing the path lets
+ * downstream renderers chain `title → path → type` lookups without
+ * round-tripping IPC at render time. Treats an absent key as
+ * optimistically resolved (avoids a "broken" flash during async fill).
  */
-export type WikilinkResolutionMap = Map<string, boolean>;
+export type WikilinkResolution = string | false;
+export type WikilinkResolutionMap = Map<string, WikilinkResolution>;
 
 export interface WikilinkOptions {
   /**

--- a/apps/desktop/src/components/Editor/extensions/Wikilink.ts
+++ b/apps/desktop/src/components/Editor/extensions/Wikilink.ts
@@ -100,7 +100,13 @@ export const Wikilink = Node.create<WikilinkOptions>({
     // "valid" (optimistic) so we don't flash red while resolution is in
     // flight; `useResolvedWikilinks` will repaint shortly after.
     const resolvedMap = this.storage?.resolved as WikilinkResolutionMap | undefined;
-    const isResolved = resolvedMap === undefined ? true : resolvedMap.get(target) !== false;
+    const resolution = resolvedMap?.get(target);
+    const isResolved = resolution !== false;
+    const resolvedPath = typeof resolution === 'string' ? resolution : null;
+
+    const iconMap = this.storage?.typeIconByPath as Map<string, string> | undefined;
+    const icon = resolvedPath !== null ? iconMap?.get(resolvedPath) : undefined;
+    const labelText = icon !== undefined ? `${icon} ${display}` : display;
 
     const baseClass = 'ziba-wikilink';
     const stateClass = isResolved ? 'ziba-wikilink--resolved' : 'ziba-wikilink--broken';
@@ -115,7 +121,7 @@ export const Wikilink = Node.create<WikilinkOptions>({
         // without inspecting the ProseMirror state. Also useful for
         // copy-paste fallback: the inner text round-trips as the alias.
       }),
-      display,
+      labelText,
     ];
   },
 
@@ -133,8 +139,12 @@ export const Wikilink = Node.create<WikilinkOptions>({
 
   addStorage() {
     const resolved: WikilinkResolutionMap = new Map();
+    // Keyed by vault-relative path; populated by useWikilinkTypes from the
+    // vault store's typedPaths slice × objectTypeSchemas icon fields.
+    const typeIconByPath: Map<string, string> = new Map();
     return {
       resolved,
+      typeIconByPath,
       // Hook consumed by tiptap-markdown's MarkdownSerializer (see
       // packages/tiptap-markdown/src/util/extensions.js: getMarkdownSpec).
       markdown: {

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -17,6 +17,7 @@ import {
 } from './extensions/WikilinkSuggestion';
 import { SlashMenuPopup } from './SlashMenuPopup';
 import { useResolvedWikilinks } from './useResolvedWikilinks';
+import { useWikilinkTypes } from './useWikilinkTypes';
 import { WikilinkPopup } from './WikilinkPopup';
 
 export type EditorProps = {
@@ -398,6 +399,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
   // Resolve wikilinks against the index so broken targets get the red
   // styling. Re-keyed on note path so the cache resets on navigation.
   useResolvedWikilinks(editor, currentNote?.path ?? null);
+  useWikilinkTypes(editor);
 
   // Click router: resolve the title; if it exists, open the note; if
   // not, create a `<title>.md` at the vault root and open that. The

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -8,13 +8,16 @@ import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
 import { debounce } from '../../lib/debounce';
 import { AUTOSAVE_DEBOUNCE_MS, PROPERTY_AUTOSAVE_DEBOUNCE_MS } from '../../lib/timings';
+import { setRelationInFrontmatter } from '../../lib/relations-frontmatter';
+import { useTagsStore } from '../../stores/tags';
 import { PropertyEditor } from '../PropertyEditor';
-import { buildEditorExtensions } from './EditorExtensions';
+import { buildEditorExtensions, type BuildExtensionsOptions } from './EditorExtensions';
 import { type SlashCommandRenderer, type SlashMenuItem } from './extensions/SlashCommand';
 import {
   type WikilinkSuggestionItem,
   type WikilinkSuggestionRenderer,
 } from './extensions/WikilinkSuggestion';
+import { RelationPickerPopup } from './RelationPickerPopup';
 import { SlashMenuPopup } from './SlashMenuPopup';
 import { useResolvedWikilinks } from './useResolvedWikilinks';
 import { useWikilinkTypes } from './useWikilinkTypes';
@@ -58,6 +61,18 @@ const INITIAL_SLASH_STATE: SlashState = {
   items: [],
   position: { top: 0, left: 0, bottom: 0 },
   selectedIndex: 0,
+};
+
+type RelationPickerState = {
+  open: boolean;
+  position: { top: number; left: number; bottom: number };
+  suggestedKinds: string[];
+};
+
+const INITIAL_RELATION_PICKER_STATE: RelationPickerState = {
+  open: false,
+  position: { top: 0, left: 0, bottom: 0 },
+  suggestedKinds: [],
 };
 
 /**
@@ -117,6 +132,15 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
   useEffect(() => {
     slashRef.current = slash;
   }, [slash]);
+
+  const [relationPicker, setRelationPicker] = useState<RelationPickerState>(
+    INITIAL_RELATION_PICKER_STATE,
+  );
+
+  // Mutable ref shared with the SlashCommand extension so the relation
+  // popover is anchored at the latest slash anchor (rather than where
+  // the cursor was when the command closure was created).
+  const slashLatestRect = useRef<{ top: number; left: number; bottom: number } | null>(null);
 
   // The `command` callback baked into the suggestion plugin captures the
   // initial reference. We keep the latest one in a ref so item-selection
@@ -207,6 +231,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
           props.command(item);
         };
         const rect = props.clientRect?.();
+        if (rect) slashLatestRect.current = { top: rect.top, left: rect.left, bottom: rect.bottom };
         setSlash({
           open: true,
           items: props.items,
@@ -221,6 +246,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
           props.command(item);
         };
         const rect = props.clientRect?.();
+        if (rect) slashLatestRect.current = { top: rect.top, left: rect.left, bottom: rect.bottom };
         setSlash((prev) => ({
           open: true,
           items: props.items,
@@ -274,11 +300,45 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
     };
   }, []);
 
+  const objectTypeSchemas = useTagsStore((s) => s.objectTypeSchemas);
+  const suggestedRelationKinds = useMemo<string[]>(() => {
+    if (currentNote === null) return [];
+    const t = currentNote.frontmatter.type;
+    if (typeof t !== 'string') return [];
+    const schema = objectTypeSchemas.find((s) => s.id === t);
+    if (schema === undefined) return [];
+    return Object.keys(schema.schema.relations);
+  }, [currentNote, objectTypeSchemas]);
+
+  const handleRelationRequested = useCallback<
+    NonNullable<BuildExtensionsOptions['onSlashRelationRequested']>
+  >(
+    ({ position }) => {
+      setRelationPicker({
+        open: true,
+        position,
+        suggestedKinds: suggestedRelationKinds,
+      });
+    },
+    [suggestedRelationKinds],
+  );
+
+  const handleRelationRequestedRef = useRef(handleRelationRequested);
+  useEffect(() => {
+    handleRelationRequestedRef.current = handleRelationRequested;
+  });
+
   // Build extensions once. The closure captures `createSuggestionRenderer`
   // which is stable across renders (it's wrapped in useCallback with no
   // deps). Recomputing extensions would force a full editor remount.
   const extensions = useMemo(
-    () => buildEditorExtensions({ createSuggestionRenderer, createSlashRenderer }),
+    () =>
+      buildEditorExtensions({
+        createSuggestionRenderer,
+        createSlashRenderer,
+        onSlashRelationRequested: (args) => handleRelationRequestedRef.current(args),
+        slashLatestRect,
+      }),
     [createSuggestionRenderer, createSlashRenderer],
   );
 
@@ -571,6 +631,24 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
           onHover={(idx): void => {
             setSlash((prev) => ({ ...prev, selectedIndex: idx }));
           }}
+        />
+      )}
+
+      {relationPicker.open && (
+        <RelationPickerPopup
+          position={relationPicker.position}
+          suggestedKinds={relationPicker.suggestedKinds}
+          onCommit={({ kind, target }): void => {
+            if (currentNote === null) {
+              setRelationPicker(INITIAL_RELATION_PICKER_STATE);
+              return;
+            }
+            const next = setRelationInFrontmatter(currentNote.frontmatter, kind, target);
+            setFrontmatterRef.current(next);
+            debouncedPropertySave();
+            setRelationPicker(INITIAL_RELATION_PICKER_STATE);
+          }}
+          onCancel={(): void => setRelationPicker(INITIAL_RELATION_PICKER_STATE)}
         />
       )}
     </section>

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -597,7 +597,11 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
         // so we don't need a new CSS file. Tailwind utilities cover the
         // rest of the typography via `ziba-prose`.
       >
-        <PropertyEditor frontmatter={currentNote.frontmatter} onChange={handleFrontmatterChange} />
+        <PropertyEditor
+          frontmatter={currentNote.frontmatter}
+          onChange={handleFrontmatterChange}
+          suggestedRelationKinds={suggestedRelationKinds}
+        />
         <div className="mx-auto max-w-[720px]">
           <EditorContent editor={editor} />
         </div>

--- a/apps/desktop/src/components/Editor/useResolvedWikilinks.ts
+++ b/apps/desktop/src/components/Editor/useResolvedWikilinks.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import type { Editor } from '@tiptap/core';
 import { ipc } from '../../lib/ipc';
-import type { WikilinkResolutionMap } from './extensions/Wikilink';
+import type { WikilinkResolution, WikilinkResolutionMap } from './extensions/Wikilink';
 
 /**
  * Walk the editor doc, collect every wikilink target, and resolve each
@@ -64,9 +64,9 @@ export function useResolvedWikilinks(editor: Editor | null, noteKey: string | nu
       let changed = false;
       for (const r of results) {
         if (r.status !== 'fulfilled') continue;
-        const exists = r.value.path !== null;
-        if (resolvedMap.get(r.value.title) !== exists) {
-          resolvedMap.set(r.value.title, exists);
+        const next: WikilinkResolution = r.value.path ?? false;
+        if (resolvedMap.get(r.value.title) !== next) {
+          resolvedMap.set(r.value.title, next);
           changed = true;
         }
       }

--- a/apps/desktop/src/components/Editor/useWikilinkTypes.test.tsx
+++ b/apps/desktop/src/components/Editor/useWikilinkTypes.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Wikilink } from './extensions/Wikilink';
+import { useWikilinkTypes } from './useWikilinkTypes';
+import { useVaultStore } from '../../stores/vault';
+import { useTagsStore } from '../../stores/tags';
+
+function makeEditor(): Editor {
+  return new Editor({
+    extensions: [StarterKit, Wikilink],
+    content: { type: 'doc', content: [{ type: 'paragraph' }] },
+  });
+}
+
+describe('useWikilinkTypes', () => {
+  beforeEach(() => {
+    useVaultStore.setState({ typedPaths: new Map() });
+    useTagsStore.setState({ objectTypeSchemas: [] });
+  });
+
+  it('writes path → icon into editor.storage.wikilink.typeIconByPath', () => {
+    const editor = makeEditor();
+    useVaultStore.setState({ typedPaths: new Map([['people/tolkien.md', 'person']]) });
+    useTagsStore.setState({
+      objectTypeSchemas: [
+        {
+          id: 'person',
+          label: 'Person',
+          icon: '👤',
+          color: null,
+          schema: { id: 'person', label: 'Person', properties: {}, relations: {}, inverse: {} },
+          mtimeMs: 0,
+        },
+      ],
+    });
+    renderHook(() => useWikilinkTypes(editor));
+    const iconMap = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    expect(iconMap.get('people/tolkien.md')).toBe('👤');
+    editor.destroy();
+  });
+
+  it('removes entries whose path lost its type', () => {
+    const editor = makeEditor();
+    const iconMap = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    iconMap.set('people/tolkien.md', '👤');
+    useVaultStore.setState({ typedPaths: new Map() });
+    useTagsStore.setState({ objectTypeSchemas: [] });
+    renderHook(() => useWikilinkTypes(editor));
+    expect(iconMap.has('people/tolkien.md')).toBe(false);
+    editor.destroy();
+  });
+});

--- a/apps/desktop/src/components/Editor/useWikilinkTypes.ts
+++ b/apps/desktop/src/components/Editor/useWikilinkTypes.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/core';
+import { useTagsStore } from '../../stores/tags';
+import { useVaultStore } from '../../stores/vault';
+
+/**
+ * Sync `editor.storage.wikilink.typeIconByPath` with the vault store's
+ * typed-paths slice + the cached object-type schemas. Keeps the map
+ * authoritative for whichever notes currently have a `type:` and
+ * whose schema declares an icon. Dispatches a no-op transaction when
+ * the map changes so the Wikilink renderHTML repaints without a full
+ * doc recompute.
+ *
+ * No internal IPC: both inputs are renderer-side caches already kept
+ * fresh by their stores. Cost is one Map diff per dependency change.
+ */
+export function useWikilinkTypes(editor: Editor | null): void {
+  const typedPaths = useVaultStore((s) => s.typedPaths);
+  const schemas = useTagsStore((s) => s.objectTypeSchemas);
+
+  useEffect(() => {
+    if (editor === null || editor.isDestroyed) return;
+    const iconMap = editor.storage.wikilink?.typeIconByPath as Map<string, string> | undefined;
+    if (iconMap === undefined) return;
+
+    const schemaIconById = new Map<string, string>();
+    for (const s of schemas) {
+      if (s.icon !== null && s.icon !== '') schemaIconById.set(s.id, s.icon);
+    }
+
+    let changed = false;
+    const nextKeys = new Set<string>();
+    for (const [path, type] of typedPaths) {
+      const icon = schemaIconById.get(type);
+      if (icon === undefined) continue;
+      nextKeys.add(path);
+      if (iconMap.get(path) !== icon) {
+        iconMap.set(path, icon);
+        changed = true;
+      }
+    }
+    for (const k of Array.from(iconMap.keys())) {
+      if (!nextKeys.has(k)) {
+        iconMap.delete(k);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      const tr = editor.state.tr.setMeta('zibaWikilinkTypes', true);
+      editor.view.dispatch(tr);
+    }
+  }, [editor, typedPaths, schemas]);
+}

--- a/apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx
+++ b/apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RelationsSection } from './RelationsSection';
+
+describe('<RelationsSection>', () => {
+  it('renders an empty-state hint with an add button when no relations exist', () => {
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={vi.fn()} />);
+    expect(screen.getByText('Nessuna relazione dichiarata.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Aggiungi relazione' })).toBeInTheDocument();
+  });
+
+  it('renders one row per (kind, target) pair, flattening lists', () => {
+    render(
+      <RelationsSection
+        frontmatter={{ relations: { author: '[[Tolkien]]', cites: ['[[A]]', '[[B]]'] } }}
+        suggestedKinds={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('author')).toBeInTheDocument();
+    expect(screen.getByText('Tolkien')).toBeInTheDocument();
+    expect(screen.getAllByText('cites').length).toBe(2);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the relation removed when the user clicks the row delete button', () => {
+    const onChange = vi.fn();
+    render(
+      <RelationsSection
+        frontmatter={{ relations: { author: '[[Tolkien]]' } }}
+        suggestedKinds={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Rimuovi relazione author → Tolkien' }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('clicking the add button reveals an inline form; commit calls onChange with the new relation', () => {
+    const onChange = vi.fn();
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi relazione' }));
+
+    fireEvent.change(screen.getByPlaceholderText('Tipo'), { target: { value: 'author' } });
+    fireEvent.change(screen.getByPlaceholderText('Destinazione'), { target: { value: 'Tolkien' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Aggiungi' }));
+
+    expect(onChange).toHaveBeenCalledWith({ relations: { author: '[[Tolkien]]' } });
+  });
+
+  it('clicking cancel closes the inline form without calling onChange', () => {
+    const onChange = vi.fn();
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi relazione' }));
+    fireEvent.change(screen.getByPlaceholderText('Tipo'), { target: { value: 'author' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText('Tipo')).not.toBeInTheDocument();
+  });
+
+  it('shows an error and rejects commit when either field is empty', () => {
+    const onChange = vi.fn();
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi relazione' }));
+    fireEvent.change(screen.getByPlaceholderText('Tipo'), { target: { value: 'author' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Aggiungi' }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Tipo e destinazione sono entrambi obbligatori.')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/PropertyEditor/RelationsSection.tsx
+++ b/apps/desktop/src/components/PropertyEditor/RelationsSection.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from 'react';
+import type { Frontmatter } from '@ziba/core';
+import {
+  relationsFromFrontmatter,
+  setRelationInFrontmatter,
+  removeRelationFromFrontmatter,
+} from '../../lib/relations-frontmatter';
+
+export type RelationsSectionProps = {
+  frontmatter: Frontmatter;
+  /**
+   * Relation kinds suggested for the current note's type (schema's
+   * `relations` keys). Empty array is fine; the user can free-type a
+   * kind via the autocomplete.
+   */
+  suggestedKinds: ReadonlyArray<string>;
+  onChange(next: Frontmatter): void;
+};
+
+/**
+ * Section sibling to the properties block, dedicated to
+ * `frontmatter.relations`. Each row shows `kind → target` with an
+ * inline delete; the "Aggiungi relazione" button reveals a kind +
+ * target form. Edit-in-place is intentionally NOT supported in v1.0:
+ * change a relation by removing and re-adding it.
+ */
+export function RelationsSection({
+  frontmatter,
+  suggestedKinds,
+  onChange,
+}: RelationsSectionProps): JSX.Element {
+  const rows = useMemo(() => relationsFromFrontmatter(frontmatter), [frontmatter]);
+
+  const [adding, setAdding] = useState(false);
+  const [kindDraft, setKindDraft] = useState('');
+  const [targetDraft, setTargetDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const cancelAdd = (): void => {
+    setAdding(false);
+    setKindDraft('');
+    setTargetDraft('');
+    setError(null);
+  };
+
+  const commitAdd = (): void => {
+    const kind = kindDraft.trim();
+    const target = targetDraft.trim();
+    if (kind.length === 0 || target.length === 0) {
+      setError('Tipo e destinazione sono entrambi obbligatori.');
+      return;
+    }
+    onChange(setRelationInFrontmatter(frontmatter, kind, target));
+    cancelAdd();
+  };
+
+  return (
+    <section className="shrink-0 border-b border-border bg-bg px-4 py-2">
+      <div className="mx-auto max-w-[720px]">
+        <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
+          Relazioni{rows.length > 0 ? ` (${rows.length})` : ''}
+        </h3>
+
+        {rows.length === 0 ? (
+          <p className="px-1 py-1 text-xs italic text-fg-muted">Nessuna relazione dichiarata.</p>
+        ) : (
+          <ul role="list" className="flex flex-col gap-0.5">
+            {rows.map((r) => (
+              <li
+                key={`${r.kind}|${r.target}`}
+                className="group flex min-h-[28px] items-center gap-2 rounded px-1 hover:bg-bg-subtle"
+              >
+                <span className="shrink-0 font-mono text-xs uppercase tracking-wide text-fg-muted">
+                  {r.kind}
+                </span>
+                <span aria-hidden="true" className="text-fg-muted">
+                  →
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm text-fg">{r.target}</span>
+                <button
+                  type="button"
+                  aria-label={`Rimuovi relazione ${r.kind} → ${r.target}`}
+                  onClick={(): void =>
+                    onChange(removeRelationFromFrontmatter(frontmatter, r.kind, r.target))
+                  }
+                  className="rounded px-1 text-fg-muted opacity-0 group-hover:opacity-100 hover:bg-bg-muted hover:text-fg"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {adding ? (
+          <div className="mt-1 flex flex-col gap-1 rounded border border-border bg-bg-subtle p-2">
+            <input
+              autoFocus
+              type="text"
+              value={kindDraft}
+              placeholder="Tipo"
+              list="ziba-relation-kinds"
+              onChange={(e): void => {
+                setKindDraft(e.target.value);
+                setError(null);
+              }}
+              className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+            />
+            {suggestedKinds.length > 0 && (
+              <datalist id="ziba-relation-kinds">
+                {suggestedKinds.map((k) => (
+                  <option key={k} value={k} />
+                ))}
+              </datalist>
+            )}
+            <input
+              type="text"
+              value={targetDraft}
+              placeholder="Destinazione"
+              onChange={(e): void => {
+                setTargetDraft(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e): void => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitAdd();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelAdd();
+                }
+              }}
+              className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+            />
+            {error !== null && <span className="text-xs text-red-500">{error}</span>}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={cancelAdd}
+                className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+              >
+                Annulla
+              </button>
+              <button
+                type="button"
+                onClick={commitAdd}
+                className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90"
+              >
+                Aggiungi
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={(): void => setAdding(true)}
+            className="mt-1 self-start rounded px-2 py-1 text-xs text-fg-muted hover:bg-bg-muted hover:text-fg"
+          >
+            + Aggiungi relazione
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/components/PropertyEditor/index.tsx
+++ b/apps/desktop/src/components/PropertyEditor/index.tsx
@@ -9,10 +9,17 @@ import { DateField } from './fields/DateField';
 import { UrlField } from './fields/UrlField';
 import { MultiSelectField } from './fields/MultiSelectField';
 import { UnsupportedField } from './fields/UnsupportedField';
+import { RelationsSection } from './RelationsSection';
 
 export type PropertyEditorProps = {
   frontmatter: Frontmatter;
   onChange: (next: Frontmatter) => void;
+  /**
+   * Relation kinds suggested for the current type, surfaced as an
+   * autocomplete in the "Aggiungi relazione" form. Empty array = no
+   * suggestions (untyped note or schema-less type).
+   */
+  suggestedRelationKinds?: ReadonlyArray<string>;
 };
 
 /**
@@ -91,7 +98,11 @@ function normalizeIncoming(value: unknown): unknown {
  * leaking into the on-disk frontmatter (gray-matter would happily round
  * the override away).
  */
-export function PropertyEditor({ frontmatter, onChange }: PropertyEditorProps): JSX.Element {
+export function PropertyEditor({
+  frontmatter,
+  onChange,
+  suggestedRelationKinds,
+}: PropertyEditorProps): JSX.Element {
   // Per-key type override: when the user clicks the type icon and picks
   // a different switchable type, we record it here. Detection still
   // runs first; the override only applies when present.
@@ -251,104 +262,111 @@ export function PropertyEditor({ frontmatter, onChange }: PropertyEditorProps): 
   const propertyCountLabel = isEmpty ? '' : ` (${entries.length})`;
 
   return (
-    <section className="shrink-0 border-b border-border bg-bg px-4 py-2">
-      <div className="mx-auto max-w-[720px]">
-        <button
-          type="button"
-          onClick={(): void => setCollapsed((v) => !v)}
-          className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-fg-muted hover:text-fg"
-        >
-          <span className="inline-block w-3" aria-hidden="true">
-            {collapsed ? '▸' : '▾'}
-          </span>
-          <span>Proprietà{propertyCountLabel}</span>
-        </button>
+    <>
+      <section className="shrink-0 border-b border-border bg-bg px-4 py-2">
+        <div className="mx-auto max-w-[720px]">
+          <button
+            type="button"
+            onClick={(): void => setCollapsed((v) => !v)}
+            className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-fg-muted hover:text-fg"
+          >
+            <span className="inline-block w-3" aria-hidden="true">
+              {collapsed ? '▸' : '▾'}
+            </span>
+            <span>Proprietà{propertyCountLabel}</span>
+          </button>
 
-        {!collapsed && (
-          <div className="flex flex-col gap-0.5">
-            {entries.map(([key, rawValue]) => {
-              const value = normalizeIncoming(rawValue);
-              const type = resolveType(key, value);
-              // The user can only switch INTO a type that's in
-              // SWITCHABLE_TYPES; we further hide the current type
-              // from its own menu so it doesn't act as a no-op entry.
-              // For non-switchable starting types (boolean,
-              // multi-select, tags, unsupported) we still let them
-              // pivot to text/number/date/url to recover.
-              const switchableTo = SWITCHABLE_TYPES.filter((t) => t !== type);
-              return (
-                <div
-                  key={key}
-                  className="group flex min-h-[28px] items-start gap-2 rounded hover:bg-bg-subtle"
-                >
-                  <PropertyHeader
-                    name={key}
-                    type={type}
-                    switchableTo={switchableTo}
-                    validateRename={validateRename(key)}
-                    onRename={(next): void => handleRename(key, next)}
-                    onSwitchType={(target): void => handleSwitchType(key, target)}
-                    onDelete={(): void => handleDelete(key)}
+          {!collapsed && (
+            <div className="flex flex-col gap-0.5">
+              {entries.map(([key, rawValue]) => {
+                const value = normalizeIncoming(rawValue);
+                const type = resolveType(key, value);
+                // The user can only switch INTO a type that's in
+                // SWITCHABLE_TYPES; we further hide the current type
+                // from its own menu so it doesn't act as a no-op entry.
+                // For non-switchable starting types (boolean,
+                // multi-select, tags, unsupported) we still let them
+                // pivot to text/number/date/url to recover.
+                const switchableTo = SWITCHABLE_TYPES.filter((t) => t !== type);
+                return (
+                  <div
+                    key={key}
+                    className="group flex min-h-[28px] items-start gap-2 rounded hover:bg-bg-subtle"
+                  >
+                    <PropertyHeader
+                      name={key}
+                      type={type}
+                      switchableTo={switchableTo}
+                      validateRename={validateRename(key)}
+                      onRename={(next): void => handleRename(key, next)}
+                      onSwitchType={(target): void => handleSwitchType(key, target)}
+                      onDelete={(): void => handleDelete(key)}
+                    />
+                    <div className="flex min-w-0 flex-1 items-center py-0.5">
+                      {renderField(key, type, value)}
+                    </div>
+                  </div>
+                );
+              })}
+
+              {adding ? (
+                <div className="mt-1 flex flex-col gap-1 rounded border border-border bg-bg-subtle p-2">
+                  <input
+                    autoFocus
+                    type="text"
+                    value={newKeyDraft}
+                    placeholder="Nome proprietà"
+                    onChange={(e): void => {
+                      setNewKeyDraft(e.target.value);
+                      setAddError(null);
+                    }}
+                    onKeyDown={(e): void => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleAddProperty();
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelAdd();
+                      }
+                    }}
+                    className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
                   />
-                  <div className="flex min-w-0 flex-1 items-center py-0.5">
-                    {renderField(key, type, value)}
+                  {addError !== null && <span className="text-xs text-red-500">{addError}</span>}
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={cancelAdd}
+                      className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                    >
+                      Annulla
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleAddProperty}
+                      className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90"
+                    >
+                      Aggiungi
+                    </button>
                   </div>
                 </div>
-              );
-            })}
-
-            {adding ? (
-              <div className="mt-1 flex flex-col gap-1 rounded border border-border bg-bg-subtle p-2">
-                <input
-                  autoFocus
-                  type="text"
-                  value={newKeyDraft}
-                  placeholder="Nome proprietà"
-                  onChange={(e): void => {
-                    setNewKeyDraft(e.target.value);
-                    setAddError(null);
-                  }}
-                  onKeyDown={(e): void => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      handleAddProperty();
-                    } else if (e.key === 'Escape') {
-                      e.preventDefault();
-                      cancelAdd();
-                    }
-                  }}
-                  className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
-                />
-                {addError !== null && <span className="text-xs text-red-500">{addError}</span>}
-                <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={cancelAdd}
-                    className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
-                  >
-                    Annulla
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleAddProperty}
-                    className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90"
-                  >
-                    Aggiungi
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={(): void => setAdding(true)}
-                className="mt-1 self-start rounded px-2 py-1 text-xs text-fg-muted hover:bg-bg-muted hover:text-fg"
-              >
-                + Aggiungi proprietà
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-    </section>
+              ) : (
+                <button
+                  type="button"
+                  onClick={(): void => setAdding(true)}
+                  className="mt-1 self-start rounded px-2 py-1 text-xs text-fg-muted hover:bg-bg-muted hover:text-fg"
+                >
+                  + Aggiungi proprietà
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+      <RelationsSection
+        frontmatter={frontmatter}
+        suggestedKinds={suggestedRelationKinds ?? []}
+        onChange={onChange}
+      />
+    </>
   );
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -51,6 +51,10 @@ export const ipc = {
   listNotes(): Promise<NoteSummary[]> {
     return api().invoke(IpcChannels.listNotes);
   },
+  async getTypedPaths(): Promise<Map<NotePath, string>> {
+    const tuples = await api().invoke(IpcChannels.getTypedPaths);
+    return new Map(tuples);
+  },
   loadNote(args: { path: NotePath }): Promise<Note> {
     return api().invoke(IpcChannels.loadNote, args);
   },

--- a/apps/desktop/src/lib/relations-frontmatter.test.ts
+++ b/apps/desktop/src/lib/relations-frontmatter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  relationsFromFrontmatter,
+  setRelationInFrontmatter,
+  removeRelationFromFrontmatter,
+} from './relations-frontmatter';
+
+describe('relationsFromFrontmatter', () => {
+  it('returns [] when no relations field is present', () => {
+    expect(relationsFromFrontmatter({})).toEqual([]);
+    expect(relationsFromFrontmatter({ relations: null })).toEqual([]);
+  });
+
+  it('flattens scalars and lists into a single ordered array', () => {
+    const fm = { relations: { author: '[[Tolkien]]', cites: ['[[A]]', '[[B]]'] } };
+    expect(relationsFromFrontmatter(fm)).toEqual([
+      { kind: 'author', target: 'Tolkien' },
+      { kind: 'cites', target: 'A' },
+      { kind: 'cites', target: 'B' },
+    ]);
+  });
+
+  it('skips non-wikilink scalar values and non-string list entries', () => {
+    const fm = {
+      relations: {
+        author: 'not a wikilink',
+        cites: ['[[A]]', 42, null, '[[B]]'],
+      },
+    };
+    expect(relationsFromFrontmatter(fm)).toEqual([
+      { kind: 'cites', target: 'A' },
+      { kind: 'cites', target: 'B' },
+    ]);
+  });
+});
+
+describe('setRelationInFrontmatter', () => {
+  it('creates the relations map if absent and stores a scalar wikilink for a single target', () => {
+    const result = setRelationInFrontmatter({}, 'author', 'Tolkien');
+    expect(result.relations).toEqual({ author: '[[Tolkien]]' });
+  });
+
+  it('upgrades to a list when adding a second target of the same kind', () => {
+    const start = { relations: { cites: '[[A]]' } };
+    const result = setRelationInFrontmatter(start, 'cites', 'B');
+    expect(result.relations).toEqual({ cites: ['[[A]]', '[[B]]'] });
+  });
+
+  it('is idempotent — adding the same (kind, target) does not duplicate', () => {
+    const start = { relations: { cites: ['[[A]]', '[[B]]'] } };
+    const result = setRelationInFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({ cites: ['[[A]]', '[[B]]'] });
+  });
+
+  it('keeps other relations untouched', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = setRelationInFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({
+      author: '[[Tolkien]]',
+      cites: '[[A]]',
+    });
+  });
+});
+
+describe('removeRelationFromFrontmatter', () => {
+  it('drops the scalar target and removes the relations field when it becomes empty', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = removeRelationFromFrontmatter(start, 'author', 'Tolkien');
+    expect(result).not.toHaveProperty('relations');
+  });
+
+  it('drops the kind entirely when its only list entry was removed', () => {
+    const start = { relations: { cites: ['[[A]]'] } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'A');
+    expect(result).not.toHaveProperty('relations');
+  });
+
+  it('collapses a one-entry list into a scalar', () => {
+    const start = { relations: { cites: ['[[A]]', '[[B]]'] } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({ cites: '[[B]]' });
+  });
+
+  it('removes the relations field entirely when all kinds are empty', () => {
+    const start = { relations: { author: '[[Tolkien]]', cites: '[[A]]' } };
+    const r1 = removeRelationFromFrontmatter(start, 'author', 'Tolkien');
+    const r2 = removeRelationFromFrontmatter(r1, 'cites', 'A');
+    expect(r2).not.toHaveProperty('relations');
+  });
+
+  it('is a no-op when (kind, target) was not present', () => {
+    const start = { relations: { cites: '[[A]]' } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'Z');
+    expect(result.relations).toEqual({ cites: '[[A]]' });
+  });
+});

--- a/apps/desktop/src/lib/relations-frontmatter.test.ts
+++ b/apps/desktop/src/lib/relations-frontmatter.test.ts
@@ -40,6 +40,12 @@ describe('setRelationInFrontmatter', () => {
     expect(result.relations).toEqual({ author: '[[Tolkien]]' });
   });
 
+  it('is idempotent when the existing entry is a scalar wikilink', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = setRelationInFrontmatter(start, 'author', 'Tolkien');
+    expect(result.relations).toEqual({ author: '[[Tolkien]]' });
+  });
+
   it('upgrades to a list when adding a second target of the same kind', () => {
     const start = { relations: { cites: '[[A]]' } };
     const result = setRelationInFrontmatter(start, 'cites', 'B');

--- a/apps/desktop/src/lib/relations-frontmatter.ts
+++ b/apps/desktop/src/lib/relations-frontmatter.ts
@@ -1,0 +1,114 @@
+import type { Frontmatter } from '@ziba/core';
+
+/**
+ * Flat representation of one relation entry — the kind from the
+ * frontmatter map's key and the canonical target title parsed from
+ * the wikilink scalar/list value.
+ */
+export type FrontmatterRelation = { kind: string; target: string };
+
+const WIKILINK_VALUE_RE = /^\[\[([^\]]+)\]\]$/;
+
+function parseWikilinkValue(raw: string): string | null {
+  const trimmed = raw.trim();
+  const m = trimmed.match(WIKILINK_VALUE_RE);
+  if (m === null) return null;
+  const inner = m[1] ?? '';
+  // Strip piped alias ([[target|alias]] → "target") then heading anchor
+  // ([[target#section]] → "target") so the stored target is the bare title.
+  const pipe = inner.indexOf('|');
+  const beforePipe = pipe === -1 ? inner : inner.slice(0, pipe);
+  const hash = beforePipe.indexOf('#');
+  const target = (hash === -1 ? beforePipe : beforePipe.slice(0, hash)).trim();
+  return target.length === 0 ? null : target;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export function relationsFromFrontmatter(fm: Frontmatter): FrontmatterRelation[] {
+  const rels = fm.relations;
+  if (!isPlainObject(rels)) return [];
+  const out: FrontmatterRelation[] = [];
+  for (const [kind, value] of Object.entries(rels)) {
+    if (typeof value === 'string') {
+      const target = parseWikilinkValue(value);
+      if (target !== null) out.push({ kind, target });
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item !== 'string') continue;
+        const target = parseWikilinkValue(item);
+        if (target !== null) out.push({ kind, target });
+      }
+    }
+  }
+  return out;
+}
+
+export function setRelationInFrontmatter(
+  fm: Frontmatter,
+  kind: string,
+  target: string,
+): Frontmatter {
+  const link = `[[${target}]]`;
+  const relsSource = isPlainObject(fm.relations) ? fm.relations : {};
+  const existing = relsSource[kind];
+
+  const collectExisting = (): string[] => {
+    if (typeof existing === 'string') return [existing];
+    if (Array.isArray(existing)) {
+      return existing.filter((v): v is string => typeof v === 'string');
+    }
+    return [];
+  };
+
+  const current = collectExisting();
+  const currentTargets = new Set(
+    current.map((s) => parseWikilinkValue(s)).filter((t): t is string => t !== null),
+  );
+  // Already present — return a stable new object without duplicating the entry.
+  if (currentTargets.has(target)) {
+    return { ...fm, relations: { ...relsSource } };
+  }
+  const nextList = [...current, link];
+  // Keep a scalar when there is only one target; promote to list otherwise.
+  const nextValue: string | string[] = nextList.length === 1 ? nextList[0]! : nextList;
+  return {
+    ...fm,
+    relations: { ...relsSource, [kind]: nextValue },
+  };
+}
+
+export function removeRelationFromFrontmatter(
+  fm: Frontmatter,
+  kind: string,
+  target: string,
+): Frontmatter {
+  if (!isPlainObject(fm.relations)) return fm;
+  const rels = { ...fm.relations };
+  const existing = rels[kind];
+
+  if (typeof existing === 'string') {
+    const parsed = parseWikilinkValue(existing);
+    if (parsed === target) delete rels[kind];
+  } else if (Array.isArray(existing)) {
+    const filtered = existing
+      .filter((v): v is string => typeof v === 'string')
+      .filter((s) => parseWikilinkValue(s) !== target);
+    if (filtered.length === 0) delete rels[kind];
+    else if (filtered.length === 1) rels[kind] = filtered[0]!;
+    else rels[kind] = filtered;
+  }
+
+  // When the relations map is empty, remove the field entirely rather than
+  // leaving an empty object in the frontmatter.
+  if (Object.keys(rels).length === 0) {
+    const next = { ...fm };
+    delete next['relations'];
+    return next;
+  }
+  return { ...fm, relations: rels };
+}

--- a/apps/desktop/src/stores/vault.test.ts
+++ b/apps/desktop/src/stores/vault.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NoteSummary } from '@ziba/core';
+import { IpcChannels } from '../../shared/ipc';
+import { installMockIpc, type MockController } from '../test/mock-ipc';
+
+// `useVaultStore` is module-level state; reset between tests so each
+// test starts with a clean store and fresh IPC spies.
+async function loadStore(): Promise<{
+  useVaultStore: typeof import('./vault').useVaultStore;
+}> {
+  vi.resetModules();
+  const vault = await import('./vault');
+  return { useVaultStore: vault.useVaultStore };
+}
+
+const NOTE_HOBBIT: NoteSummary = { path: 'books/hobbit.md', title: 'The Hobbit', mtimeMs: 1 };
+
+let mock: MockController;
+
+beforeEach(() => {
+  mock = installMockIpc();
+});
+
+describe('useVaultStore — typedPaths slice', () => {
+  it('populates typedPaths on openVault → refreshNotes', async () => {
+    const { useVaultStore } = await loadStore();
+    mock.setHandler(IpcChannels.openVault, async () => ({
+      root: '/tmp/v',
+      name: 'v',
+      openedAt: 0,
+    }));
+    mock.setHandler(IpcChannels.listNotes, async () => [NOTE_HOBBIT]);
+    mock.setHandler(
+      IpcChannels.getTypedPaths,
+      async () => [['books/hobbit.md', 'book']] as [string, string][],
+    );
+    mock.setHandler(IpcChannels.getRecentVaults, async () => []);
+
+    await useVaultStore.getState().openVault('/tmp/v');
+
+    expect(useVaultStore.getState().typedPaths.get('books/hobbit.md')).toBe('book');
+  });
+
+  it('resets typedPaths to an empty map on closeVault', async () => {
+    const { useVaultStore } = await loadStore();
+    useVaultStore.setState({
+      current: { root: '/tmp/v', name: 'v', openedAt: 0 },
+      typedPaths: new Map([['x.md', 'book']]),
+    });
+    mock.setHandler(IpcChannels.closeVault, async () => undefined);
+
+    await useVaultStore.getState().closeVault();
+
+    expect(useVaultStore.getState().typedPaths.size).toBe(0);
+  });
+
+  it('refreshNotes() fetches typedPaths in lockstep with notes', async () => {
+    const { useVaultStore } = await loadStore();
+    useVaultStore.setState({
+      current: { root: '/tmp/v', name: 'v', openedAt: 0 },
+    });
+    mock.setHandler(IpcChannels.listNotes, async () => [NOTE_HOBBIT]);
+    mock.setHandler(
+      IpcChannels.getTypedPaths,
+      async () => [['books/hobbit.md', 'book']] as [string, string][],
+    );
+
+    await useVaultStore.getState().refreshNotes();
+
+    expect(useVaultStore.getState().notes).toEqual([NOTE_HOBBIT]);
+    expect(useVaultStore.getState().typedPaths.get('books/hobbit.md')).toBe('book');
+  });
+
+  it('refreshNotes() is a no-op when no vault is open', async () => {
+    const { useVaultStore } = await loadStore();
+    useVaultStore.setState({ current: null });
+    mock.setHandler(IpcChannels.listNotes, async () => [NOTE_HOBBIT]);
+    mock.setHandler(
+      IpcChannels.getTypedPaths,
+      async () => [['books/hobbit.md', 'book']] as [string, string][],
+    );
+
+    await useVaultStore.getState().refreshNotes();
+
+    expect(mock.getSpy(IpcChannels.listNotes)).not.toHaveBeenCalled();
+    expect(mock.getSpy(IpcChannels.getTypedPaths)).not.toHaveBeenCalled();
+    expect(useVaultStore.getState().typedPaths.size).toBe(0);
+  });
+});

--- a/apps/desktop/src/stores/vault.ts
+++ b/apps/desktop/src/stores/vault.ts
@@ -1,4 +1,4 @@
-import type { NoteSummary } from '@ziba/core';
+import type { NotePath, NoteSummary } from '@ziba/core';
 import { create } from 'zustand';
 import type { IndexProgressPayload, VaultEventPayload, VaultInfo } from '../../shared/ipc';
 import { debounce } from '../lib/debounce';
@@ -10,6 +10,13 @@ type IndexProgress = { processed: number; total: number | null };
 type VaultState = {
   current: VaultInfo | null;
   notes: NoteSummary[];
+  /**
+   * path → type slug for every note that declares `type:` in its frontmatter.
+   * Populated alongside `notes` on every refresh so the two are always in
+   * lockstep. Absent entries mean the note has no declared type — callers
+   * must treat a missing key the same as an empty/unknown type.
+   */
+  typedPaths: ReadonlyMap<NotePath, string>;
   recentVaults: VaultInfo[];
   indexProgress: IndexProgress | null;
 
@@ -34,19 +41,20 @@ export const useVaultStore = create<VaultState>((set, get) => {
   return {
     current: null,
     notes: [],
+    typedPaths: new Map(),
     recentVaults: [],
     indexProgress: null,
 
     async openVault(root) {
       const info = await ipc.openVault({ root });
-      set({ current: info, notes: [] });
+      set({ current: info, notes: [], typedPaths: new Map() });
       await get().refreshNotes();
       await get().loadRecentVaults();
     },
 
     async closeVault() {
       await ipc.closeVault();
-      set({ current: null, notes: [], indexProgress: null });
+      set({ current: null, notes: [], typedPaths: new Map(), indexProgress: null });
     },
 
     async pickAndOpenVault() {
@@ -59,8 +67,8 @@ export const useVaultStore = create<VaultState>((set, get) => {
     async refreshNotes() {
       const current = get().current;
       if (current === null) return;
-      const notes = await ipc.listNotes();
-      set({ notes });
+      const [notes, typedPaths] = await Promise.all([ipc.listNotes(), ipc.getTypedPaths()]);
+      set({ notes, typedPaths });
     },
 
     async loadRecentVaults() {

--- a/apps/desktop/src/test/mock-ipc.ts
+++ b/apps/desktop/src/test/mock-ipc.ts
@@ -129,6 +129,9 @@ function buildDefaultHandlers(): Required<MockHandlers> {
     [IpcChannels.getRelationsByTarget]: async () => [],
 
     [IpcChannels.getRecentVaults]: async () => [],
+
+    // v1.0 Phase 3 — typed-paths index
+    [IpcChannels.getTypedPaths]: async () => [],
   };
   return defaults as unknown as Required<MockHandlers>;
 }

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -1,4 +1,6 @@
 import { afterEach, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
 import type { ZibaApi } from '../../shared/ipc';
 
 // Vitest setup file — runs once per worker before any test in `src/**`.
@@ -83,6 +85,11 @@ window.ziba = makeFailingApi();
 installLocalStorage();
 
 afterEach(() => {
+  // Unmount all React trees rendered in the current test so portals
+  // mounted to document.body don't leak into subsequent tests.
+  // `@testing-library/react` normally auto-cleans via a global afterEach,
+  // but `globals: false` in vitest means that hook never runs.
+  cleanup();
   // Clear localStorage so the UI store can re-hydrate cleanly between
   // tests. The shim from `installLocalStorage()` exposes a real `clear`.
   window.localStorage.clear();

--- a/packages/core/src/adapters/index-store.ts
+++ b/packages/core/src/adapters/index-store.ts
@@ -199,6 +199,18 @@ export interface IndexStoreAdapter {
    */
   getTypeCounts(): Promise<TypeCountRow[]>;
 
+  /**
+   * v1.0: all notes carrying a `type:` slug, returned as a path → type
+   * map. Reads from `note_properties` so the cost is one indexed scan
+   * on `prop_key = 'type'`. Untyped notes are absent from the map.
+   *
+   * The renderer keeps this map for the editor's wikilink decoration
+   * (per-link `path → type → icon` lookup) and refreshes on vault /
+   * schema events. Bounded cost: typed notes are a fraction of total
+   * notes for realistic vaults.
+   */
+  getTypedPaths(): Promise<Map<NotePath, string>>;
+
   /** v1.0: insert or replace a type's cached schema. */
   upsertObjectType(row: ObjectTypeRow): Promise<void>;
 

--- a/packages/core/src/adapters/index-store.ts
+++ b/packages/core/src/adapters/index-store.ts
@@ -204,10 +204,8 @@ export interface IndexStoreAdapter {
    * map. Reads from `note_properties` so the cost is one indexed scan
    * on `prop_key = 'type'`. Untyped notes are absent from the map.
    *
-   * The renderer keeps this map for the editor's wikilink decoration
-   * (per-link `path → type → icon` lookup) and refreshes on vault /
-   * schema events. Bounded cost: typed notes are a fraction of total
-   * notes for realistic vaults.
+   * Bounded cost: typed notes are a fraction of total notes for
+   * realistic vaults.
    */
   getTypedPaths(): Promise<Map<NotePath, string>>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -185,6 +188,9 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -753,6 +759,10 @@ packages:
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
@@ -1585,6 +1595,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1697,6 +1710,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -2697,6 +2713,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3196,6 +3216,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3511,6 +3535,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -3943,6 +3971,8 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -4474,6 +4504,15 @@ snapshots:
       lz-string: 1.5.0
       picocolors: 1.1.1
       pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5479,6 +5518,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   cssstyle@4.6.0:
@@ -5597,6 +5638,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -6807,6 +6850,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -7348,6 +7393,11 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -7750,6 +7800,10 @@ snapshots:
   strip-bom-string@1.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Phase 3 of v1.0 Object-Relational Foundation — the editor learns about typed relations.

- **Foundation**: new adapter `getTypedPaths()` returns `Map<NotePath, type>` for every typed note. IPC `notes:typedPaths` exposes it. Vault store gains a `typedPaths: ReadonlyMap<NotePath, string>` slice fetched alongside notes.
- **Wikilink decoration**: `WikilinkResolutionMap` widened from `Map<string, boolean>` to `Map<string, NotePath | false>`. New per-editor `typeIconByPath` cache + `useWikilinkTypes` hook syncs it from vault store × schemas. `renderHTML` prepends the schema icon to the display text when the target resolves to a typed note (e.g. `[[Tolkien]]` → `👤 Tolkien`).
- **Slash `/relazione`**: new menu entry opens `RelationPickerPopup` (two-field portal). Commit writes via pure `setRelationInFrontmatter` helper + the existing autosave pipeline.
- **PropertyEditor `RelationsSection`**: sibling to the properties block. Lists each `(kind, target)` with delete affordance + inline add form with schema-derived `datalist` suggestions.
- **Pure helpers**: `relations-frontmatter.ts` exports `relationsFromFrontmatter`, `setRelationInFrontmatter`, `removeRelationFromFrontmatter`. Idempotent set, scalar↔list shape transitions, empty-relations-field cleanup.

## Tests

- Adapter SQL (`getTypedPaths` query + `prop_type='text'` defensive filter): 3 cases
- Pure helpers: 13 cases (parse, set, remove)
- Wikilink renderHTML decoration: 4 cases (icon prefix, broken, untyped, aliased)
- `useWikilinkTypes` hook: 2 cases (write, evict)
- `RelationPickerPopup`: 7 cases (input, chips, Escape, commit, disabled, trim)
- `RelationsSection`: 6 cases (empty state, rows, delete, add, cancel, validation)
- Vault store `typedPaths` slice: 4 cases
- **426 total** (259 desktop + 167 core), all green.

## Manual smoke (TODO when reviewing)

- Open the seed vault (`pnpm seed-vault`), open a `book` note, check the wikilink to `[[Tolkien]]` shows the 👤 icon prefix.
- Type `/relazione` at the start of a line, pick the entry, type `author` + `Tolkien`, commit — the PropertyEditor's "Relazioni" section should list `author → Tolkien` and the markdown frontmatter should round-trip.
- Click the × next to a relation row, confirm removal.

I did not run the manual smoke in this environment (no display); test suite + typecheck + lint give the structural confidence.

## Test plan

- [x] `pnpm typecheck` — 3/3 green
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 426 / 426 green
- [ ] Manual smoke on a seeded vault
- [ ] Visual inspection of the icon decoration and popover positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)