### PR TITLE
feat(v1.0 phase 4): database view type filter + schema-aware columns

### DIFF
--- a/apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ColumnPicker } from './ColumnPicker';
+
+describe('<ColumnPicker>', () => {
+  it('renders a button with the visible-column count', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        visibleColumns={['title']}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Colonne (1)' })).toBeInTheDocument();
+  });
+
+  it('opens the menu and lists available properties', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.getByLabelText('title')).toBeInTheDocument();
+    expect(screen.getByLabelText('year')).toBeInTheDocument();
+  });
+
+  it('toggling a checkbox calls onChange with the new set', () => {
+    const onChange = vi.fn();
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        visibleColumns={['title']}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    fireEvent.click(screen.getByLabelText('year'));
+    expect(onChange).toHaveBeenCalledWith(['title', 'year']);
+  });
+
+  it('shows the empty-state when no available properties and no suggestions', () => {
+    render(<ColumnPicker availableProperties={[]} visibleColumns={[]} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.getByText('Nessuna proprietà rilevata.')).toBeInTheDocument();
+  });
+});
+
+describe('<ColumnPicker> — suggestedKeys', () => {
+  it('renders suggested keys in a dedicated "Suggerite" group at the top of the menu', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        suggestedKeys={['author', 'isbn']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.getByText('Suggerite')).toBeInTheDocument();
+    expect(screen.getByLabelText('author')).toBeInTheDocument();
+    expect(screen.getByLabelText('isbn')).toBeInTheDocument();
+    expect(screen.getByLabelText('title')).toBeInTheDocument();
+    expect(screen.getByLabelText('year')).toBeInTheDocument();
+  });
+
+  it('does not render a suggested group when the prop is empty', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        suggestedKeys={[]}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.queryByText('Suggerite')).not.toBeInTheDocument();
+  });
+
+  it('clicking a suggested key adds it to visibleColumns even if not in availableProperties', () => {
+    const onChange = vi.fn();
+    render(
+      <ColumnPicker
+        availableProperties={['title']}
+        suggestedKeys={['author']}
+        visibleColumns={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    fireEvent.click(screen.getByLabelText('author'));
+    expect(onChange).toHaveBeenCalledWith(['author']);
+  });
+
+  it('deduplicates keys that appear in both suggested and available lists', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'author']}
+        suggestedKeys={['author']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    // `author` appears once — in the suggested group only.
+    expect(screen.getAllByLabelText('author')).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/components/DatabaseView/ColumnPicker.tsx
+++ b/apps/desktop/src/components/DatabaseView/ColumnPicker.tsx
@@ -4,6 +4,13 @@ import type { JSX } from 'react';
 type Props = {
   /** All distinct property keys discovered in the current result, sorted. */
   availableProperties: string[];
+  /**
+   * Schema-derived keys to surface at the top of the menu in a
+   * dedicated "Suggerite" group. Empty array (or omitted) suppresses
+   * the group entirely. Keys overlapping with `availableProperties`
+   * are deduplicated to the suggested group so each key shows once.
+   */
+  suggestedKeys?: ReadonlyArray<string>;
   /** Property keys currently selected as visible columns. */
   visibleColumns: string[];
   onChange(next: string[]): void;
@@ -20,6 +27,7 @@ type Props = {
  */
 export function ColumnPicker({
   availableProperties,
+  suggestedKeys,
   visibleColumns,
   onChange,
 }: Props): JSX.Element {
@@ -44,19 +52,47 @@ export function ColumnPicker({
 
   const visibleSet = new Set(visibleColumns);
 
+  const suggested = suggestedKeys ?? [];
+  const suggestedSet = new Set(suggested);
+  const restProperties = availableProperties.filter((k) => !suggestedSet.has(k));
+
   const toggle = (key: string): void => {
     if (visibleSet.has(key)) {
       onChange(visibleColumns.filter((k) => k !== key));
-    } else {
-      // Preserve the alphabetical-then-append order: if the key sits in
-      // `availableProperties` between two already-visible keys, slot it
-      // there; otherwise append. Keeps column order stable as the user
-      // toggles.
-      const next = [...visibleColumns, key].sort((a, b) => {
-        return availableProperties.indexOf(a) - availableProperties.indexOf(b);
-      });
-      onChange(next);
+      return;
     }
+    // Keep stable column order. Keys that exist in availableProperties
+    // slot into their alphabetical position; schema-suggested keys
+    // absent from availableProperties append at the end. The sort
+    // comparator handles both cases by treating -1 as "after any
+    // known key".
+    const next = [...visibleColumns, key].sort((a, b) => {
+      const ai = availableProperties.indexOf(a);
+      const bi = availableProperties.indexOf(b);
+      if (ai === -1 && bi === -1) return 0;
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    onChange(next);
+  };
+
+  const renderRow = (key: string): JSX.Element => {
+    const checked = visibleSet.has(key);
+    return (
+      <label
+        key={key}
+        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted"
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(): void => toggle(key)}
+          className="h-3 w-3"
+        />
+        <span className="truncate">{key}</span>
+      </label>
+    );
   };
 
   return (
@@ -76,26 +112,21 @@ export function ColumnPicker({
           aria-label="Colonne visibili"
           className="absolute right-0 top-[calc(100%+4px)] z-20 max-h-72 w-56 overflow-auto rounded-md border border-border bg-bg-subtle p-1 shadow-lg"
         >
-          {availableProperties.length === 0 && (
+          {suggested.length > 0 && (
+            <>
+              <p className="px-2 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-fg-muted">
+                Suggerite
+              </p>
+              {suggested.map((k) => renderRow(k))}
+              {restProperties.length > 0 && (
+                <div role="separator" className="my-1 border-t border-border" />
+              )}
+            </>
+          )}
+          {restProperties.length === 0 && suggested.length === 0 && (
             <p className="px-2 py-1.5 text-xs text-fg-muted">Nessuna proprietà rilevata.</p>
           )}
-          {availableProperties.map((key) => {
-            const checked = visibleSet.has(key);
-            return (
-              <label
-                key={key}
-                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted"
-              >
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={(): void => toggle(key)}
-                  className="h-3 w-3"
-                />
-                <span className="truncate">{key}</span>
-              </label>
-            );
-          })}
+          {restProperties.map((k) => renderRow(k))}
         </div>
       )}
     </div>

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { TypeFilterDropdown } from './TypeFilterDropdown';
 
 const TYPES = [
-  { id: 'book', label: 'Libro', icon: '📖', color: null, count: 12 },
-  { id: 'person', label: 'Persona', icon: '👤', color: null, count: 8 },
+  { id: 'book', label: 'Libro', icon: '📖', count: 12 },
+  { id: 'person', label: 'Persona', icon: '👤', count: 8 },
 ];
 
 describe('<TypeFilterDropdown>', () => {

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TypeFilterDropdown } from './TypeFilterDropdown';
+
+const TYPES = [
+  { id: 'book', label: 'Libro', icon: '📖', color: null, count: 12 },
+  { id: 'person', label: 'Persona', icon: '👤', color: null, count: 8 },
+];
+
+describe('<TypeFilterDropdown>', () => {
+  it('shows "Tutti" when selectedType is null', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Tipo: Tutti/i })).toBeInTheDocument();
+  });
+
+  it('shows the selected type label when one is selected', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType="book" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Tipo: 📖 Libro/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the type slug when no schema label is available', () => {
+    render(<TypeFilterDropdown types={[]} selectedType="custom" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Tipo: custom/i })).toBeInTheDocument();
+  });
+
+  it('opening the dropdown lists Tutti + every type with its count', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByRole('menuitemradio', { name: /Tutti/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /📖 Libro/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /👤 Persona/i })).toBeInTheDocument();
+    expect(screen.getByText(/\(12\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(8\)/)).toBeInTheDocument();
+  });
+
+  it('selecting "Tutti" calls onChange(null) and closes the menu', () => {
+    const onChange = vi.fn();
+    render(<TypeFilterDropdown types={TYPES} selectedType="book" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Tutti/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
+  });
+
+  it('selecting a type calls onChange with its id', () => {
+    const onChange = vi.fn();
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /📖 Libro/i }));
+    expect(onChange).toHaveBeenCalledWith('book');
+  });
+
+  it('closes on outside click', () => {
+    render(
+      <div>
+        <TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />
+        <button type="button">elsewhere</button>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByRole('menuitemradio', { name: /Tutti/i })).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'elsewhere' }));
+    expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-state hint when no types are available', () => {
+    render(<TypeFilterDropdown types={[]} selectedType={null} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByText('Nessun tipo nel vault.')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
+
+export type TypeFilterOption = {
+  /** Type slug (e.g. `book`). */
+  id: string;
+  /** Display label — schema label, or the slug as a fallback. */
+  label: string;
+  /** Optional emoji / glyph from the schema. */
+  icon: string | null;
+  /** Kept for parity with `useTagsStore.types`; unused in the dropdown. */
+  color: string | null;
+  /** Number of notes carrying this type. */
+  count: number;
+};
+
+type Props = {
+  types: ReadonlyArray<TypeFilterOption>;
+  selectedType: string | null;
+  onChange(type: string | null): void;
+};
+
+/**
+ * Page-level type filter for the DatabaseView header. Mirrors the
+ * ColumnPicker dropdown's architecture: local open/closed state,
+ * close on outside-click via mousedown, no portal (the header has
+ * room for an absolute-positioned menu).
+ */
+export function TypeFilterDropdown({ types, selectedType, onChange }: Props): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on click-outside. Using mousedown rather than click so the
+  // dropdown closes before the would-be click target receives focus —
+  // same pattern as the search palette.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent): void => {
+      const node = containerRef.current;
+      if (node === null) return;
+      if (e.target instanceof Node && !node.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    return (): void => window.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  const activeOption =
+    selectedType === null ? null : (types.find((t) => t.id === selectedType) ?? null);
+  const buttonLabel = ((): string => {
+    if (selectedType === null) return 'Tipo: Tutti';
+    if (activeOption === null) return `Tipo: ${selectedType}`;
+    const icon =
+      activeOption.icon !== null && activeOption.icon !== '' ? `${activeOption.icon} ` : '';
+    return `Tipo: ${icon}${activeOption.label}`;
+  })();
+
+  const choose = (next: string | null): void => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={(): void => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+      >
+        {buttonLabel}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Filtra per tipo"
+          className="absolute left-0 top-[calc(100%+4px)] z-20 max-h-72 w-56 overflow-auto rounded-md border border-border bg-bg-subtle p-1 shadow-lg"
+        >
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={selectedType === null}
+            onClick={(): void => choose(null)}
+            className={[
+              'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
+              selectedType === null ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+            ].join(' ')}
+          >
+            <span className="flex-1 truncate">Tutti</span>
+          </button>
+          {types.length === 0 && (
+            <p className="px-2 py-1.5 text-xs italic text-fg-muted">Nessun tipo nel vault.</p>
+          )}
+          {types.map((t) => {
+            const isActive = t.id === selectedType;
+            const iconPrefix = t.icon !== null && t.icon !== '' ? `${t.icon} ` : '';
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={isActive}
+                onClick={(): void => choose(t.id)}
+                className={[
+                  'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
+                  isActive ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+                ].join(' ')}
+              >
+                <span className="flex-1 truncate">{`${iconPrefix}${t.label}`}</span>
+                <span className="tabular-nums text-fg-muted">{`(${t.count})`}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
@@ -8,8 +8,6 @@ export type TypeFilterOption = {
   label: string;
   /** Optional emoji / glyph from the schema. */
   icon: string | null;
-  /** Kept for parity with `useTagsStore.types`; unused in the dropdown. */
-  color: string | null;
   /** Number of notes carrying this type. */
   count: number;
 };

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -152,6 +152,7 @@ export function DatabaseView(): JSX.Element {
   const clearAllFilters = (): void => {
     setFilters([]);
     setFolder(undefined);
+    setType(null);
   };
 
   const onRowClick = (path: NotePath): void => {
@@ -167,7 +168,8 @@ export function DatabaseView(): JSX.Element {
   //   2. empty result — distinguish "vault is empty" vs "filters are too
   //      narrow" so the empty-state copy is actionable.
   //   3. populated table.
-  const hasFilterOrFolder = filters.length > 0 || (query.folder ?? '') !== '';
+  const hasFilterOrFolder =
+    filters.length > 0 || (query.folder ?? '') !== '' || selectedType !== null;
   const isEmpty = result !== null && result.rows.length === 0;
   const emptyDueToFilters = isEmpty && hasFilterOrFolder;
   const emptyDueToVault = isEmpty && !hasFilterOrFolder;

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -6,6 +6,8 @@ import { useDatabaseStore } from '../../stores/database';
 import { navigateToNote } from '../../lib/navigate';
 import { useUiStore, type DatabaseViewMode } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
+import { useTagsStore } from '../../stores/tags';
+import { TypeFilterDropdown } from './TypeFilterDropdown';
 import { BoardView } from './BoardView';
 import { CalendarView } from './CalendarView';
 import { ColumnPicker } from './ColumnPicker';
@@ -62,6 +64,11 @@ export function DatabaseView(): JSX.Element {
   const runQuery = useDatabaseStore((s) => s.runQuery);
   const subscribeToVaultEvents = useDatabaseStore((s) => s.subscribeToVaultEvents);
 
+  const selectedType = useDatabaseStore((s) => s.selectedType);
+  const setType = useDatabaseStore((s) => s.setType);
+  const tagTypes = useTagsStore((s) => s.types);
+  const tagSchemas = useTagsStore((s) => s.objectTypeSchemas);
+
   const currentVault = useVaultStore((s) => s.current);
   const databaseViewMode = useUiStore((s) => s.databaseViewMode);
   const setDatabaseViewMode = useUiStore((s) => s.setDatabaseViewMode);
@@ -113,6 +120,25 @@ export function DatabaseView(): JSX.Element {
   const sortDirection = sort?.[0]?.direction ?? 'asc';
 
   const filters = useMemo(() => query.filters ?? [], [query.filters]);
+
+  const suggestedColumnKeys = useMemo<string[]>(() => {
+    if (selectedType === null) return [];
+    const schema = tagSchemas.find((s) => s.id === selectedType);
+    if (schema === undefined) return [];
+    const propKeys = Object.keys(schema.schema.properties);
+    const relKeys = Object.keys(schema.schema.relations);
+    // Properties first, then relations. Dedup within the local
+    // accumulator only; overlap with availableProperties is handled
+    // in ColumnPicker.
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const k of [...propKeys, ...relKeys]) {
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(k);
+    }
+    return out;
+  }, [selectedType, tagSchemas]);
 
   const rows = result?.rows ?? EMPTY_ROWS;
   const groups = result?.groups ?? EMPTY_GROUPS;
@@ -174,11 +200,15 @@ export function DatabaseView(): JSX.Element {
               </span>
             )}
           </div>
-          <ColumnPicker
-            availableProperties={availableProperties}
-            visibleColumns={visibleColumns}
-            onChange={setVisibleColumns}
-          />
+          <div className="flex items-center gap-2">
+            <TypeFilterDropdown types={tagTypes} selectedType={selectedType} onChange={setType} />
+            <ColumnPicker
+              availableProperties={availableProperties}
+              suggestedKeys={suggestedColumnKeys}
+              visibleColumns={visibleColumns}
+              onChange={setVisibleColumns}
+            />
+          </div>
         </div>
 
         <div className="mt-2 flex flex-wrap items-center gap-2">

--- a/apps/desktop/src/stores/database.test.ts
+++ b/apps/desktop/src/stores/database.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DatabaseResult, ScalarFilter, VaultInfo } from '../../shared/ipc';
+import type { DatabaseQuery, DatabaseResult, ScalarFilter, VaultInfo } from '../../shared/ipc';
 import { IpcChannels } from '../../shared/ipc';
 import { installMockIpc, type MockController } from '../test/mock-ipc';
 
@@ -251,5 +251,81 @@ describe('useDatabaseStore — vault subscription', () => {
     expect(s.availableProperties).toEqual([]);
     expect(s.error).toBeNull();
     unsub();
+  });
+});
+
+describe('useDatabaseStore — selectedType slice', () => {
+  it('initial state is null', async () => {
+    const { useDatabaseStore } = await loadStores();
+    expect(useDatabaseStore.getState().selectedType).toBeNull();
+  });
+
+  it('setType(value) stores the slug', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    mock.setHandler(IpcChannels.runDatabaseQuery, async () => ({
+      rows: [],
+      groups: [],
+      totalCount: 0,
+    }));
+    useVaultStore.setState({ current: FAKE_VAULT });
+    useDatabaseStore.getState().setType('book');
+    expect(useDatabaseStore.getState().selectedType).toBe('book');
+  });
+
+  it('setType(null) clears the slug', async () => {
+    const { useDatabaseStore } = await loadStores();
+    useDatabaseStore.setState({ selectedType: 'book' });
+    useDatabaseStore.getState().setType(null);
+    expect(useDatabaseStore.getState().selectedType).toBeNull();
+  });
+
+  it('runQuery merges a {type=value} eq filter into the outgoing query when selectedType is set', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    useVaultStore.setState({ current: FAKE_VAULT });
+    useDatabaseStore.setState({ selectedType: 'book' });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed).not.toBeNull();
+    expect(observed!.filters).toEqual([{ kind: 'eq', key: 'type', value: 'book' }]);
+  });
+
+  it('runQuery preserves user filters AND prepends the type filter', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    useVaultStore.setState({ current: FAKE_VAULT });
+    const userFilter: ScalarFilter = { kind: 'eq', key: 'year', value: 1937 };
+    useDatabaseStore.setState({
+      selectedType: 'book',
+      query: { filters: [userFilter], limit: 1000 },
+    });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed!.filters).toEqual([{ kind: 'eq', key: 'type', value: 'book' }, userFilter]);
+  });
+
+  it('runQuery does NOT include a type filter when selectedType is null', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    useVaultStore.setState({ current: FAKE_VAULT });
+    useDatabaseStore.setState({ selectedType: null });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed!.filters?.some((f) => f.key === 'type')).toBe(false);
   });
 });

--- a/apps/desktop/src/stores/database.ts
+++ b/apps/desktop/src/stores/database.ts
@@ -229,6 +229,7 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
             requestSeq++;
             set({
               query: INITIAL_QUERY,
+              selectedType: null,
               result: null,
               loading: false,
               error: null,

--- a/apps/desktop/src/stores/database.ts
+++ b/apps/desktop/src/stores/database.ts
@@ -23,6 +23,14 @@ type DatabaseState = {
   availableProperties: string[];
   /** Last-update timestamp (ms since epoch) of a successful query. */
   lastUpdatedAt: number | null;
+  /**
+   * v1.0 Phase 4: page-level type filter. When non-null, runQuery
+   * prepends `{ kind: 'eq', key: 'type', value: selectedType }` to
+   * the outgoing IPC filter list. Kept out of `query.filters` so the
+   * FilterBar doesn't render a redundant chip for the page-level
+   * scope.
+   */
+  selectedType: string | null;
 
   // ---- Filter actions ----------------------------------------------------
   setFilters(filters: ScalarFilter[]): void;
@@ -34,6 +42,8 @@ type DatabaseState = {
   setSort(sort: DatabaseQuery['sort']): void;
   setGroupBy(key: string | null): void;
   setFolder(folder: string | undefined): void;
+  /** v1.0 Phase 4: set or clear the page-level type filter. */
+  setType(type: string | null): void;
 
   // ---- Execution ---------------------------------------------------------
   /** Run the query immediately. Cancels any pending debounced run. */
@@ -87,6 +97,7 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
     error: null,
     availableProperties: [],
     lastUpdatedAt: null,
+    selectedType: null,
 
     setFilters(filters) {
       set({ query: { ...get().query, filters } });
@@ -149,6 +160,11 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
       scheduleRun();
     },
 
+    setType(type) {
+      set({ selectedType: type });
+      scheduleRun();
+    },
+
     async runQuery() {
       // Skip if no vault open — the IPC handler would throw and we'd have
       // to swallow it. Same guard as `useTagsStore`.
@@ -169,7 +185,14 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
       const seq = ++requestSeq;
       set({ loading: true, error: null });
       try {
-        const result = await ipc.runDatabaseQuery({ query: get().query });
+        const baseQuery = get().query;
+        const selectedType = get().selectedType;
+        const outgoingFilters: ScalarFilter[] =
+          selectedType === null
+            ? (baseQuery.filters ?? [])
+            : [{ kind: 'eq', key: 'type', value: selectedType }, ...(baseQuery.filters ?? [])];
+        const outgoing: DatabaseQuery = { ...baseQuery, filters: outgoingFilters };
+        const result = await ipc.runDatabaseQuery({ query: outgoing });
         if (seq !== requestSeq) return;
         set({
           result,


### PR DESCRIPTION
## Summary

Phase 4 of v1.0 Object-Relational Foundation — the DatabaseView learns about object types.

- **`selectedType` slice** in `useDatabaseStore` (+ `setType(type | null)` action). `runQuery` prepends `{ kind: 'eq', key: 'type', value: <type> }` to the outgoing IPC filters when set, without mutating `query.filters` — so the FilterBar stays free of the redundant page-level chip.
- **`<TypeFilterDropdown>`** in the DatabaseView header. Reads `types` from `useTagsStore`. Lists "Tutti" + every typed type with `icon label (count)`. Mirrors the ColumnPicker's outside-click + menu-radio architecture.
- **`<ColumnPicker>` `suggestedKeys` prop** — schema-derived property + relation kinds render in a dedicated "Suggerite" group at the top of the menu, separated by a divider, deduplicated against `availableProperties`.
- **DatabaseView wiring**: computes `suggestedColumnKeys` from the active type's schema (properties first, then relations) and threads it through to `ColumnPicker`. The "Mostra tutte le note" CTA now clears the type filter too; the "vault empty" copy correctly recognises a type filter as filtering.

## Tests

- Database store: 6 cases (initial state, setType set/clear, filter merge with + without selectedType, user-filter preservation)
- TypeFilterDropdown: 8 cases (selected variants, empty state, list, Tutti, choose, outside-click)
- ColumnPicker: 8 cases (existing behaviour + suggestedKeys group, dedup, append-when-not-present)
- **289 desktop + 167 core = 456 total**, all green.

## Test plan

- [x] `pnpm typecheck` — 3/3 green
- [x] `pnpm lint` — clean
- [x] `pnpm test` — green
- [ ] Manual smoke — verify dropdown lists vault types, selection narrows table, Suggerite group appears with the schema's keys, "Tutti" clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)