### PR TITLE
feat(v1.0 phase 5): constellation graph — cluster bias + hulls + kind filter

### DIFF
--- a/apps/desktop/electron/adapters/index-store.sqlite.test.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.test.ts
@@ -107,3 +107,100 @@ describe('getTypedPaths', () => {
     expect(rows).toHaveLength(0);
   });
 });
+
+describe('graph nodes — type + color join', () => {
+  it('returns null type/color for untyped notes', () => {
+    setupNote('untyped.md');
+    const rows = db
+      .prepare(
+        `SELECT n.path AS path, n.title AS title, np.text_value AS type, ot.color AS color
+         FROM notes n
+         LEFT JOIN note_properties np
+           ON np.source_path = n.path
+          AND np.prop_key = 'type'
+          AND np.prop_type = 'text'
+          AND np.text_value IS NOT NULL
+          AND np.text_value <> ''
+         LEFT JOIN object_types ot ON ot.id = np.text_value`,
+      )
+      .all() as Array<{ path: string; title: string; type: string | null; color: string | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ path: 'untyped.md', title: 'untyped', type: null, color: null });
+  });
+
+  it('returns the type slug + null color when no schema is cached for the type', () => {
+    setupNote('book.md');
+    db.prepare(
+      `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+       VALUES (?, 'type', 'text', 'book')`,
+    ).run('book.md');
+    const rows = db
+      .prepare(
+        `SELECT n.path AS path, np.text_value AS type, ot.color AS color
+         FROM notes n
+         LEFT JOIN note_properties np
+           ON np.source_path = n.path
+          AND np.prop_key = 'type'
+          AND np.prop_type = 'text'
+          AND np.text_value IS NOT NULL
+          AND np.text_value <> ''
+         LEFT JOIN object_types ot ON ot.id = np.text_value`,
+      )
+      .all() as Array<{ path: string; type: string | null; color: string | null }>;
+    expect(rows[0]?.type).toBe('book');
+    expect(rows[0]?.color).toBeNull();
+  });
+
+  it('returns type + color when a schema with a color is cached', () => {
+    setupNote('book.md');
+    db.prepare(
+      `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+       VALUES (?, 'type', 'text', 'book')`,
+    ).run('book.md');
+    db.prepare(
+      `INSERT INTO object_types (id, label, icon, color, schema_json, mtime)
+       VALUES ('book', 'Libro', '📖', '#6366f1', '{}', 0)`,
+    ).run();
+    const rows = db
+      .prepare(
+        `SELECT n.path AS path, np.text_value AS type, ot.color AS color
+         FROM notes n
+         LEFT JOIN note_properties np
+           ON np.source_path = n.path
+          AND np.prop_key = 'type'
+          AND np.prop_type = 'text'
+          AND np.text_value IS NOT NULL
+          AND np.text_value <> ''
+         LEFT JOIN object_types ot ON ot.id = np.text_value`,
+      )
+      .all() as Array<{ path: string; type: string | null; color: string | null }>;
+    expect(rows[0]?.type).toBe('book');
+    expect(rows[0]?.color).toBe('#6366f1');
+  });
+});
+
+describe('graph edges — kind passthrough', () => {
+  it('returns the kind column on every edge (empty string for generic body wikilinks)', () => {
+    setupNote('a.md');
+    setupNote('b.md');
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, '', 'B', 'b.md')`,
+    ).run('a.md');
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, 'author', 'B', 'b.md')`,
+    ).run('a.md');
+    const rows = db
+      .prepare(
+        `SELECT r.source_path AS source, r.target_path AS target,
+                n.title AS target_title, r.kind AS kind
+         FROM relations r
+         JOIN notes n ON n.path = r.target_path
+         WHERE r.target_path IS NOT NULL
+         ORDER BY r.kind`,
+      )
+      .all() as Array<{ source: string; target: string; target_title: string; kind: string }>;
+    expect(rows.map((r) => r.kind)).toEqual(['', 'author']);
+  });
+});

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -309,7 +309,21 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `),
       clearProps: db.prepare(`DELETE FROM note_properties`),
-      graphNodes: db.prepare(`SELECT path, title FROM notes`),
+      graphNodes: db.prepare(`
+        SELECT
+          n.path  AS path,
+          n.title AS title,
+          np.text_value AS type,
+          ot.color      AS color
+        FROM notes n
+        LEFT JOIN note_properties np
+          ON np.source_path = n.path
+         AND np.prop_key = 'type'
+         AND np.prop_type = 'text'
+         AND np.text_value IS NOT NULL
+         AND np.text_value <> ''
+        LEFT JOIN object_types ot ON ot.id = np.text_value
+      `),
       graphEdges: db.prepare(`
         SELECT r.source_path AS source,
                r.target_path  AS target,
@@ -858,16 +872,29 @@ export class SqliteIndexStore implements IndexStoreAdapter {
 
   async getFullGraph(): Promise<FullGraph> {
     const s = this.require();
-    type NodeRow = { path: string; title: string };
-    type EdgeRow = { source: string; target: string; target_title: string };
+    type NodeRow = {
+      path: string;
+      title: string;
+      type: string | null;
+      color: string | null;
+    };
+    type EdgeRow = {
+      source: string;
+      target: string;
+      target_title: string;
+      kind: string;
+    };
     const nodes = (s.graphNodes.all() as NodeRow[]).map((r) => ({
       path: r.path,
       title: r.title,
+      type: r.type,
+      color: r.color,
     }));
     const edges = (s.graphEdges.all() as EdgeRow[]).map((r) => ({
       source: r.source,
       target: r.target,
       targetTitle: r.target_title,
+      kind: r.kind,
     }));
     return Promise.resolve({ nodes, edges });
   }

--- a/apps/desktop/src/components/GlobalGraph/Canvas.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { Canvas, type CanvasHandle, type CanvasNode, type CanvasEdge } from './Canvas';
+
+function makeNode(id: string, opts?: Partial<CanvasNode>): CanvasNode {
+  return {
+    id,
+    x: 0,
+    y: 0,
+    r: 4,
+    degree: 1,
+    title: id,
+    type: null,
+    color: null,
+    ...opts,
+  };
+}
+
+describe('<Canvas> — dim precedence', () => {
+  it('dims a neighbour of the selected node when the neighbour is outside the active type filter', () => {
+    const nodes: CanvasNode[] = [
+      makeNode('a', { x: 100, y: 100, type: 'book' }),
+      makeNode('b', { x: 200, y: 200, type: 'person' }),
+    ];
+    const edges: CanvasEdge[] = [{ source: 'a', target: 'b', kind: '' }];
+    const ref = createRef<CanvasHandle>();
+    const { container } = render(
+      <Canvas
+        ref={ref}
+        nodes={nodes}
+        edges={edges}
+        width={500}
+        height={500}
+        initialView={{ tx: 0, ty: 0, scale: 1 }}
+        selectedId="a"
+        matchedIds={new Set()}
+        neighborIds={new Set(['b'])}
+        onNodeClick={vi.fn()}
+        onNodeDoubleClick={vi.fn()}
+        onBackgroundMouseDown={vi.fn()}
+        onWheel={vi.fn()}
+        onBackgroundClick={vi.fn()}
+        panning={false}
+        clusterOverlayOn={false}
+        highlightType="book"
+        highlightKinds={new Set()}
+      />,
+    );
+
+    // The neighbour group (b) wraps a <circle>; find it by the node's
+    // transform translate. The dim treatment shows up as opacity < 1.
+    const groups = container.querySelectorAll('g[transform^="translate(200"]');
+    expect(groups.length).toBeGreaterThan(0);
+    const nodeGroup = groups[0]!;
+    const opacityAttr = nodeGroup.getAttribute('opacity');
+    expect(opacityAttr).not.toBeNull();
+    expect(Number(opacityAttr)).toBeLessThan(1);
+  });
+
+  it('renders the neighbour at full opacity when no type filter is active', () => {
+    const nodes: CanvasNode[] = [
+      makeNode('a', { x: 100, y: 100, type: 'book' }),
+      makeNode('b', { x: 200, y: 200, type: 'person' }),
+    ];
+    const edges: CanvasEdge[] = [{ source: 'a', target: 'b', kind: '' }];
+    const ref = createRef<CanvasHandle>();
+    const { container } = render(
+      <Canvas
+        ref={ref}
+        nodes={nodes}
+        edges={edges}
+        width={500}
+        height={500}
+        initialView={{ tx: 0, ty: 0, scale: 1 }}
+        selectedId="a"
+        matchedIds={new Set()}
+        neighborIds={new Set(['b'])}
+        onNodeClick={vi.fn()}
+        onNodeDoubleClick={vi.fn()}
+        onBackgroundMouseDown={vi.fn()}
+        onWheel={vi.fn()}
+        onBackgroundClick={vi.fn()}
+        panning={false}
+        clusterOverlayOn={false}
+        highlightType={null}
+        highlightKinds={new Set()}
+      />,
+    );
+
+    const groups = container.querySelectorAll('g[transform^="translate(200"]');
+    expect(groups.length).toBeGreaterThan(0);
+    const nodeGroup = groups[0]!;
+    const opacityAttr = nodeGroup.getAttribute('opacity');
+    // Either explicitly 1 or unset (full opacity by default).
+    if (opacityAttr !== null) {
+      expect(Number(opacityAttr)).toBe(1);
+    }
+  });
+});

--- a/apps/desktop/src/components/GlobalGraph/Canvas.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.tsx
@@ -1,9 +1,19 @@
-import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
 import type { NotePath } from '@ziba/core';
 import {
   GRAPH_DIM_OPACITY as DIM_OPACITY,
   GRAPH_LABEL_TOP_DEGREE_QUANTILE as LABEL_TOP_DEGREE_QUANTILE,
 } from '../../lib/graph-tuning';
+import { kindToHsl } from '../../lib/kind-color';
+import { HullsLayer } from './HullsLayer';
 
 /**
  * Stylable graph node with the bits the canvas needs to render. We keep
@@ -20,11 +30,17 @@ export type CanvasNode = {
   title: string;
   /** Pre-computed degree so the canvas can decide whether to label it. */
   degree: number;
+  /** v1.0 Phase 5: type slug (null = untyped). */
+  type: string | null;
+  /** v1.0 Phase 5: hex color from the type's schema; canvas tints the fill. */
+  color: string | null;
 };
 
 export type CanvasEdge = {
   source: NotePath;
   target: NotePath;
+  /** v1.0 Phase 5: relation kind. `''` = generic body wikilink. */
+  kind: string;
 };
 
 /** Initial transform handed to the canvas. */
@@ -75,6 +91,15 @@ type Props = {
   onBackgroundClick(): void;
   /** True while a pan gesture is in progress; switches to grabbing cursor. */
   panning: boolean;
+  /** v1.0 Phase 5: when true, render convex-hull overlays per type. */
+  clusterOverlayOn: boolean;
+  /** v1.0 Phase 5: when non-null, fade nodes/edges not matching this type. */
+  highlightType: string | null;
+  /**
+   * v1.0 Phase 5: when non-empty, only edges whose `kind` is in this
+   * set render at full opacity. Empty set means "all kinds shown".
+   */
+  highlightKinds: ReadonlySet<string>;
 };
 
 // Below this scale we hide labels entirely — they pile up and become
@@ -89,11 +114,13 @@ const NODE_FILL = 'rgb(var(--accent) / 0.18)';
 const NODE_STROKE = 'rgb(var(--accent))';
 const NODE_FILL_DIM = 'rgb(var(--bg-muted))';
 const NODE_STROKE_DIM = 'rgb(var(--border))';
-const EDGE_STROKE = 'rgb(var(--fg-muted) / 0.4)';
+// EDGE_STROKE removed: edges now use kindToHsl() for per-kind color.
 const EDGE_STROKE_HIGHLIGHT = 'rgb(var(--accent))';
 const LABEL_FILL = 'rgb(var(--fg))';
 
 const FULL_OPACITY = 1;
+
+const EMPTY_STRING_SET: ReadonlySet<string> = new Set();
 
 function transformString(view: CanvasView): string {
   return `translate(${view.tx} ${view.ty}) scale(${view.scale})`;
@@ -127,6 +154,9 @@ export const Canvas = memo(
       onWheel,
       onBackgroundClick,
       panning,
+      clusterOverlayOn,
+      highlightType,
+      highlightKinds,
     } = props;
 
     // The single source of truth for the live transform. We mirror it
@@ -177,6 +207,19 @@ export const Canvas = memo(
     const isFiltered = matchedIds.size > 0;
     const hasSelection = selectedId !== null;
 
+    // When a specific type is highlighted, hide every other type's hull
+    // so the visual focus matches the dimmed nodes.
+    const hiddenHullTypes = useMemo<ReadonlySet<string>>(() => {
+      if (highlightType === null) return EMPTY_STRING_SET;
+      const set = new Set<string>();
+      for (const n of nodes) {
+        if (n.type !== null && n.type !== '' && n.type !== highlightType) {
+          set.add(n.type);
+        }
+      }
+      return set;
+    }, [nodes, highlightType]);
+
     const handleNodeClick = useCallback(
       (e: React.MouseEvent<SVGGElement>, id: NotePath) => {
         e.stopPropagation();
@@ -224,6 +267,7 @@ export const Canvas = memo(
         </defs>
 
         <g ref={transformRef} transform={transformString(initialView)}>
+          {clusterOverlayOn && <HullsLayer nodes={nodes} hiddenTypes={hiddenHullTypes} />}
           {/* Edges first so node circles paint on top. */}
           <g pointerEvents="none">
             {edges.map((e, i) => {
@@ -232,7 +276,17 @@ export const Canvas = memo(
               if (a === null || b === null) return null;
               const highlight =
                 hasSelection && (e.source === selectedId || e.target === selectedId);
+              // When a node is selected (highlight), use accent color regardless of kind —
+              // the selection visual takes precedence over kind information.
+              const kindColor = kindToHsl(e.kind);
+              const stroke = highlight ? EDGE_STROKE_HIGHLIGHT : kindColor;
+              const dimByKindFilter = highlightKinds.size > 0 && !highlightKinds.has(e.kind);
+              const dimByTypeFilter =
+                highlightType !== null &&
+                !(nodeMatchesType(a, highlightType) && nodeMatchesType(b, highlightType));
               const dim =
+                dimByKindFilter ||
+                dimByTypeFilter ||
                 (hasSelection && !highlight) ||
                 (isFiltered && !(matchedIds.has(e.source) && matchedIds.has(e.target)));
               return (
@@ -242,7 +296,7 @@ export const Canvas = memo(
                   y1={a.y}
                   x2={b.x}
                   y2={b.y}
-                  stroke={highlight ? EDGE_STROKE_HIGHLIGHT : EDGE_STROKE}
+                  stroke={stroke}
                   strokeWidth={highlight ? 1.2 : 0.8}
                   opacity={dim ? DIM_OPACITY : FULL_OPACITY}
                   markerEnd="url(#global-graph-arrow)"
@@ -257,8 +311,13 @@ export const Canvas = memo(
               const isSelected = selectedId === n.id;
               const isNeighbor = neighborIds.has(n.id);
               const matchesFilter = !isFiltered || matchedIds.has(n.id);
+              // When highlightType is null the filter is inactive — no node should be dimmed
+              // purely because of type. When non-null, only nodes of that type stay bright.
+              const isHighlightedByType = highlightType === null || n.type === highlightType;
               const dim =
-                (hasSelection && !isSelected && !isNeighbor) || (isFiltered && !matchesFilter);
+                (hasSelection && !isSelected && !isNeighbor) ||
+                (isFiltered && !matchesFilter) ||
+                !isHighlightedByType;
               const opacity = dim ? DIM_OPACITY : FULL_OPACITY;
               const labelEligible = showLabels && n.degree >= labelDegreeThreshold;
               return (
@@ -278,7 +337,15 @@ export const Canvas = memo(
                   <title>{n.title}</title>
                   <circle
                     r={n.r}
-                    fill={dim ? NODE_FILL_DIM : isSelected ? NODE_STROKE : NODE_FILL}
+                    fill={
+                      dim
+                        ? NODE_FILL_DIM
+                        : isSelected
+                          ? NODE_STROKE
+                          : n.color !== null
+                            ? n.color
+                            : NODE_FILL
+                    }
                     stroke={dim ? NODE_STROKE_DIM : NODE_STROKE}
                     strokeWidth={isSelected ? 2 : 1}
                   />
@@ -303,6 +370,10 @@ export const Canvas = memo(
     );
   }),
 );
+
+function nodeMatchesType(n: CanvasNode, type: string): boolean {
+  return n.type === type;
+}
 
 // Linear scan because for n < 1000 it is faster than building a Map
 // (the constant factor of the hash function dominates), and we already

--- a/apps/desktop/src/components/GlobalGraph/Canvas.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.tsx
@@ -314,6 +314,10 @@ export const Canvas = memo(
               // When highlightType is null the filter is inactive — no node should be dimmed
               // purely because of type. When non-null, only nodes of that type stay bright.
               const isHighlightedByType = highlightType === null || n.type === highlightType;
+              // Type filter takes unconditional precedence: even a
+              // neighbour of the selected node is dimmed when it sits
+              // outside the active type scope. This keeps node dimming
+              // visually consistent with the hull visibility rule.
               const dim =
                 (hasSelection && !isSelected && !isNeighbor) ||
                 (isFiltered && !matchesFilter) ||

--- a/apps/desktop/src/components/GlobalGraph/HullsLayer.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/HullsLayer.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { HullsLayer } from './HullsLayer';
+import type { CanvasNode } from './Canvas';
+
+function n(id: string, x: number, y: number, type: string | null): CanvasNode {
+  return { id, x, y, r: 4, degree: 0, title: id, type, color: '#6366f1' };
+}
+
+describe('<HullsLayer>', () => {
+  it('renders nothing when fewer than 3 typed nodes share the same type', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer nodes={[n('a', 0, 0, 'book'), n('b', 10, 0, 'book')]} hiddenTypes={new Set()} />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  it('renders one hull when ≥ 3 nodes share the same type', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[n('a', 0, 0, 'book'), n('b', 10, 0, 'book'), n('c', 5, 10, 'book')]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelectorAll('path').length).toBe(1);
+  });
+
+  it('omits hulls whose type is in hiddenTypes', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[n('a', 0, 0, 'book'), n('b', 10, 0, 'book'), n('c', 5, 10, 'book')]}
+          hiddenTypes={new Set(['book'])}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  it('skips nodes whose type is null or empty string', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[
+            n('a', 0, 0, null),
+            n('b', 10, 0, null),
+            n('c', 5, 10, null),
+            n('d', 0, 0, ''),
+            n('e', 10, 0, ''),
+            n('f', 5, 10, ''),
+          ]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  it('renders one hull per typed cluster when multiple types are present', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[
+            n('a', 0, 0, 'book'),
+            n('b', 10, 0, 'book'),
+            n('c', 5, 10, 'book'),
+            n('d', 100, 100, 'person'),
+            n('e', 110, 100, 'person'),
+            n('f', 105, 110, 'person'),
+          ]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelectorAll('path').length).toBe(2);
+  });
+});

--- a/apps/desktop/src/components/GlobalGraph/HullsLayer.tsx
+++ b/apps/desktop/src/components/GlobalGraph/HullsLayer.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import type { JSX } from 'react';
+import { convexHull } from './convexHull';
+import type { CanvasNode } from './Canvas';
+
+const MIN_NODES_FOR_HULL = 3;
+const HULL_FILL_OPACITY = 0.08;
+const HULL_STROKE_OPACITY = 0.25;
+const HULL_PADDING = 24;
+
+type Props = {
+  nodes: ReadonlyArray<CanvasNode>;
+  /**
+   * Types whose hulls should not render. Drives the visual response to
+   * the type filter chip row: when a type is selected, every OTHER
+   * type's hull is hidden so the active type stands alone.
+   */
+  hiddenTypes: ReadonlySet<string>;
+};
+
+/**
+ * Renders one semi-transparent convex-hull polygon per type with
+ * ≥ 3 visible nodes. Hulls sit underneath the nodes/edges layer in
+ * the parent SVG. Color comes from the first node of the group that
+ * has a non-null `color`; all nodes of a given type share the same
+ * schema color in practice.
+ */
+export function HullsLayer({ nodes, hiddenTypes }: Props): JSX.Element | null {
+  const hulls = useMemo(() => {
+    const byType = new Map<string, CanvasNode[]>();
+    for (const n of nodes) {
+      if (n.type === null || n.type === '') continue;
+      if (hiddenTypes.has(n.type)) continue;
+      const bucket = byType.get(n.type);
+      if (bucket === undefined) byType.set(n.type, [n]);
+      else bucket.push(n);
+    }
+    const out: Array<{ type: string; color: string; path: string }> = [];
+    for (const [type, group] of byType) {
+      if (group.length < MIN_NODES_FOR_HULL) continue;
+      const color = group.find((n) => n.color !== null)?.color ?? 'rgb(99, 102, 241)';
+      const pts = convexHull(group.map((n) => ({ x: n.x, y: n.y })));
+      if (pts.length < MIN_NODES_FOR_HULL) continue;
+      const padded = padOutward(pts, HULL_PADDING);
+      out.push({ type, color, path: polygonPath(padded) });
+    }
+    return out;
+  }, [nodes, hiddenTypes]);
+
+  if (hulls.length === 0) return null;
+  return (
+    <g aria-hidden="true">
+      {hulls.map((h) => (
+        <path
+          key={h.type}
+          d={h.path}
+          fill={h.color}
+          fillOpacity={HULL_FILL_OPACITY}
+          stroke={h.color}
+          strokeOpacity={HULL_STROKE_OPACITY}
+          strokeLinejoin="round"
+        />
+      ))}
+    </g>
+  );
+}
+
+function polygonPath(pts: ReadonlyArray<{ x: number; y: number }>): string {
+  if (pts.length === 0) return '';
+  return pts.map((p, i) => (i === 0 ? `M ${p.x} ${p.y}` : `L ${p.x} ${p.y}`)).join(' ') + ' Z';
+}
+
+/**
+ * Inflate the polygon outward from its centroid by `pad` units so the
+ * hull encloses node radii (not just centres).
+ */
+function padOutward(
+  pts: ReadonlyArray<{ x: number; y: number }>,
+  pad: number,
+): Array<{ x: number; y: number }> {
+  if (pts.length === 0) return [];
+  let cx = 0;
+  let cy = 0;
+  for (const p of pts) {
+    cx += p.x;
+    cy += p.y;
+  }
+  cx /= pts.length;
+  cy /= pts.length;
+  return pts.map((p) => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d < 0.0001) return { x: p.x, y: p.y };
+    return { x: p.x + (dx / d) * pad, y: p.y + (dy / d) * pad };
+  });
+}

--- a/apps/desktop/src/components/GlobalGraph/KindFilterDropdown.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/KindFilterDropdown.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KindFilterDropdown } from './KindFilterDropdown';
+
+describe('<KindFilterDropdown>', () => {
+  it('shows "Tutte" when selection is empty', () => {
+    render(
+      <KindFilterDropdown
+        kinds={['author', 'cites']}
+        selectedKinds={new Set()}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Filtra relazioni: Tutte/ })).toBeInTheDocument();
+  });
+
+  it('shows the count when selection is non-empty', () => {
+    render(
+      <KindFilterDropdown
+        kinds={['author', 'cites']}
+        selectedKinds={new Set(['author'])}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Filtra relazioni \(1\)/ })).toBeInTheDocument();
+  });
+
+  it('opens the menu and lists every kind with a checkbox', () => {
+    render(
+      <KindFilterDropdown
+        kinds={['author', 'cites']}
+        selectedKinds={new Set()}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Filtra relazioni/ }));
+    expect(screen.getByLabelText('author')).toBeInTheDocument();
+    expect(screen.getByLabelText('cites')).toBeInTheDocument();
+  });
+
+  it('toggling a checkbox calls onChange with the new set', () => {
+    const onChange = vi.fn();
+    render(
+      <KindFilterDropdown
+        kinds={['author', 'cites']}
+        selectedKinds={new Set()}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Filtra relazioni/ }));
+    fireEvent.click(screen.getByLabelText('author'));
+    const arg = onChange.mock.calls[0]?.[0] as Set<string>;
+    expect(arg).toBeInstanceOf(Set);
+    expect(arg.has('author')).toBe(true);
+    expect(arg.has('cites')).toBe(false);
+  });
+
+  it('"Mostra tutte" clears the selection', () => {
+    const onChange = vi.fn();
+    render(
+      <KindFilterDropdown
+        kinds={['author', 'cites']}
+        selectedKinds={new Set(['author'])}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Filtra relazioni/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mostra tutte' }));
+    const arg = onChange.mock.calls[0]?.[0] as Set<string>;
+    expect(arg.size).toBe(0);
+  });
+
+  it('shows the empty hint when no kinds are available', () => {
+    render(<KindFilterDropdown kinds={[]} selectedKinds={new Set()} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Filtra relazioni/ }));
+    expect(screen.getByText('Nessuna relazione tipizzata nel grafo.')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/GlobalGraph/KindFilterDropdown.tsx
+++ b/apps/desktop/src/components/GlobalGraph/KindFilterDropdown.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
+import { kindToHsl } from '../../lib/kind-color';
+
+type Props = {
+  /** All distinct relation kinds present in the current graph (excluding the empty sentinel). */
+  kinds: ReadonlyArray<string>;
+  /** Currently active kinds. Empty set = no filter (all shown). */
+  selectedKinds: ReadonlySet<string>;
+  onChange(next: ReadonlySet<string>): void;
+};
+
+/**
+ * Multi-select dropdown for relation kinds. Each option is rendered
+ * with its kind-hash color swatch so users can map the kind name to
+ * the edge color they see in the graph. Empty selection means
+ * "no filter" — all kinds render at full opacity.
+ */
+export function KindFilterDropdown({ kinds, selectedKinds, onChange }: Props): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent): void => {
+      const node = containerRef.current;
+      if (node === null) return;
+      if (e.target instanceof Node && !node.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    return (): void => window.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  const buttonLabel =
+    selectedKinds.size === 0
+      ? 'Filtra relazioni: Tutte'
+      : `Filtra relazioni (${selectedKinds.size})`;
+
+  const toggle = (kind: string): void => {
+    const next = new Set(selectedKinds);
+    if (next.has(kind)) next.delete(kind);
+    else next.add(kind);
+    onChange(next);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={(): void => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+      >
+        {buttonLabel}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Filtra per tipo di relazione"
+          className="absolute right-0 top-[calc(100%+4px)] z-20 max-h-72 w-56 overflow-auto rounded-md border border-border bg-bg-subtle p-1 shadow-lg"
+        >
+          {kinds.length === 0 && (
+            <p className="px-2 py-1.5 text-xs italic text-fg-muted">
+              Nessuna relazione tipizzata nel grafo.
+            </p>
+          )}
+          {kinds.map((k) => {
+            const checked = selectedKinds.has(k);
+            return (
+              <label
+                key={k}
+                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(): void => toggle(k)}
+                  className="h-3 w-3"
+                />
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2 w-2 shrink-0 rounded-full"
+                  style={{ background: kindToHsl(k) }}
+                />
+                <span className="truncate">{k}</span>
+              </label>
+            );
+          })}
+          {selectedKinds.size > 0 && (
+            <button
+              type="button"
+              onClick={(): void => onChange(new Set())}
+              className="mt-1 w-full rounded px-2 py-1 text-left text-xs text-fg-muted hover:bg-bg-muted hover:text-fg"
+            >
+              Mostra tutte
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/GlobalGraph/Legend.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Legend.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from 'react';
+import { kindToHsl } from '../../lib/kind-color';
+
+type Props = {
+  /** Types currently visible / active in the graph (chips selected → just the one). */
+  visibleTypes: ReadonlyArray<{ id: string; label: string; color: string | null }>;
+  /** Active relation kinds. Empty array → legend omits the kinds section. */
+  visibleKinds: ReadonlyArray<string>;
+};
+
+/**
+ * Top-right floating panel that maps colors to types + relation kinds.
+ * Hidden entirely when there's nothing to legend (no types AND no
+ * kinds visible).
+ */
+export function Legend({ visibleTypes, visibleKinds }: Props): JSX.Element | null {
+  if (visibleTypes.length === 0 && visibleKinds.length === 0) return null;
+  return (
+    <div
+      aria-label="Legenda"
+      className="pointer-events-none absolute right-2 top-2 z-10 max-w-[200px] rounded-md border border-border bg-bg-subtle/95 p-2 text-xs text-fg shadow"
+    >
+      {visibleTypes.length > 0 && (
+        <div>
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-fg-muted">
+            Tipi
+          </p>
+          <ul className="flex flex-col gap-0.5">
+            {visibleTypes.map((t) => (
+              <li key={t.id} className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ background: t.color ?? 'rgb(99, 102, 241)' }}
+                />
+                <span className="truncate">{t.label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {visibleKinds.length > 0 && (
+        <div className={visibleTypes.length > 0 ? 'mt-2' : ''}>
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-fg-muted">
+            Relazioni
+          </p>
+          <ul className="flex flex-col gap-0.5">
+            {visibleKinds.map((k) => (
+              <li key={k} className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2 w-2 shrink-0 rounded-full"
+                  style={{ background: kindToHsl(k) }}
+                />
+                <span className="truncate">{k}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/GlobalGraph/TypeChips.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/TypeChips.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TypeChips } from './TypeChips';
+
+const TYPES = [
+  { id: 'book', label: 'Libro', icon: '📖', color: '#6366f1' },
+  { id: 'person', label: 'Persona', icon: '👤', color: null },
+];
+
+describe('<TypeChips>', () => {
+  it('renders Tutti + every type chip', () => {
+    render(<TypeChips types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Tutti' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /📖 Libro/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /👤 Persona/ })).toBeInTheDocument();
+  });
+
+  it('Tutti is pressed when selectedType is null', () => {
+    render(<TypeChips types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Tutti' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('the matching chip is pressed when its id is selected', () => {
+    render(<TypeChips types={TYPES} selectedType="book" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /📖 Libro/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Tutti' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking a chip calls onChange with its id', () => {
+    const onChange = vi.fn();
+    render(<TypeChips types={TYPES} selectedType={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /📖 Libro/ }));
+    expect(onChange).toHaveBeenCalledWith('book');
+  });
+
+  it('clicking the already-active chip clears (calls onChange(null))', () => {
+    const onChange = vi.fn();
+    render(<TypeChips types={TYPES} selectedType="book" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /📖 Libro/ }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('clicking Tutti calls onChange(null)', () => {
+    const onChange = vi.fn();
+    render(<TypeChips types={TYPES} selectedType="book" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tutti' }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/desktop/src/components/GlobalGraph/TypeChips.tsx
+++ b/apps/desktop/src/components/GlobalGraph/TypeChips.tsx
@@ -1,0 +1,66 @@
+import type { JSX } from 'react';
+
+export type TypeChip = {
+  /** Slug. */
+  id: string;
+  /** Display label (schema label or slug fallback). */
+  label: string;
+  /** Optional icon glyph from the schema. */
+  icon: string | null;
+  /** Optional schema color used as the chip's left-border tint. */
+  color: string | null;
+};
+
+type Props = {
+  types: ReadonlyArray<TypeChip>;
+  selectedType: string | null;
+  onChange(type: string | null): void;
+};
+
+/**
+ * Single-select chip row for the constellation graph header. "Tutti"
+ * resets to null (no scope). Each typed chip toggles to its slug; if
+ * already active, clicking again clears (back to Tutti). Mirrors the
+ * Notion-style filter chip pattern.
+ */
+export function TypeChips({ types, selectedType, onChange }: Props): JSX.Element {
+  return (
+    <div role="group" aria-label="Filtra per tipo" className="flex flex-wrap items-center gap-1">
+      <button
+        type="button"
+        onClick={(): void => onChange(null)}
+        aria-pressed={selectedType === null}
+        className={chipClasses(selectedType === null)}
+      >
+        Tutti
+      </button>
+      {types.map((t) => {
+        const isActive = t.id === selectedType;
+        const iconPrefix = t.icon !== null && t.icon !== '' ? `${t.icon} ` : '';
+        const borderStyle: React.CSSProperties | undefined =
+          t.color !== null ? { borderLeftColor: t.color, borderLeftWidth: 3 } : undefined;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            onClick={(): void => onChange(isActive ? null : t.id)}
+            aria-pressed={isActive}
+            style={borderStyle}
+            className={chipClasses(isActive)}
+          >
+            {`${iconPrefix}${t.label}`}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function chipClasses(active: boolean): string {
+  return [
+    'rounded border px-2 py-0.5 text-xs transition-colors',
+    active
+      ? 'border-accent bg-accent/10 text-fg'
+      : 'border-border bg-bg-subtle text-fg-subtle hover:bg-bg-muted hover:text-fg',
+  ].join(' ');
+}

--- a/apps/desktop/src/components/GlobalGraph/cluster-bias.test.ts
+++ b/apps/desktop/src/components/GlobalGraph/cluster-bias.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { initializePositions, runGlobalLayout } from './layout';
+import {
+  initializeOnCircle,
+  simulateLayout,
+  type LayoutEdge,
+  type LayoutNode,
+} from '../MiniGraph/layout';
+
+describe('cluster bias', () => {
+  it('with intra-group edges, cluster bias increases same-type centroid separation versus no bias', () => {
+    // Two groups of 10, connected within their group plus one bridge.
+    // The intra-group edges provide a restoring force that prevents
+    // nodes from flying apart; the cluster-bias force then pushes the
+    // two type centroids further from each other than repulsion alone.
+    // This is the primary regression guard: it fails if the cluster-bias
+    // loop is removed (kClusterStrength = 0).
+    const bookIds = Array.from({ length: 10 }, (_, i) => `b${i}`);
+    const personIds = Array.from({ length: 10 }, (_, i) => `p${i}`);
+    const ids = [...bookIds, ...personIds];
+    const typeById = new Map<string, string>([
+      ...bookIds.map((id): [string, string] => [id, 'book']),
+      ...personIds.map((id): [string, string] => [id, 'person']),
+    ]);
+    const edges: LayoutEdge[] = [
+      ...Array.from({ length: 9 }, (_, i) => ({ source: `b${i}`, target: `b${i + 1}` })),
+      ...Array.from({ length: 9 }, (_, i) => ({ source: `p${i}`, target: `p${i + 1}` })),
+      // Single bridge — keeps both chains in the same force field without
+      // strongly pulling the two groups together.
+      { source: 'b9', target: 'p0' },
+    ];
+
+    function runAndMeasureSep(kCluster: number): number {
+      const nodes: LayoutNode[] = initializePositions(ids, 1000, 1000, typeById);
+      simulateLayout(nodes, edges, {
+        width: 1000,
+        height: 1000,
+        iterations: 800,
+        kRepulsive: 6500,
+        kAttractive: 0.025,
+        restLen: 55,
+        damping: 0.82,
+        kCenter: 0.01,
+        kClusterStrength: kCluster,
+      });
+      const books = nodes.filter((n) => n.nodeType === 'book');
+      const people = nodes.filter((n) => n.nodeType === 'person');
+      return dist(centroid(books), centroid(people));
+    }
+
+    const sepWithout = runAndMeasureSep(0);
+    const sepWith = runAndMeasureSep(0.3);
+
+    // Cluster bias must increase inter-group centroid separation by at
+    // least 10% beyond what repulsion + edge-springs alone achieve.
+    expect(sepWith).toBeGreaterThan(sepWithout * 1.1);
+  });
+
+  it('nodeType is stamped on nodes returned by initializePositions', () => {
+    // Verifies the nodeType propagation path from typeById → LayoutNode,
+    // including the null / empty-string guard.
+    const ids = ['a', 'b', 'c', 'd'];
+    const typeById = new Map<string, string | null>([
+      ['a', 'book'],
+      ['b', 'person'],
+      ['c', null], // explicit null → no nodeType field
+      ['d', ''], // empty string → no nodeType field
+    ]);
+    const nodes = initializePositions(ids, 800, 800, typeById);
+
+    const a = nodes.find((n) => n.id === 'a');
+    const b = nodes.find((n) => n.id === 'b');
+    const c = nodes.find((n) => n.id === 'c');
+    const d = nodes.find((n) => n.id === 'd');
+
+    expect(a?.nodeType).toBe('book');
+    expect(b?.nodeType).toBe('person');
+    expect(c?.nodeType).toBeUndefined();
+    expect(d?.nodeType).toBeUndefined();
+  });
+
+  it('an untyped node is not assigned a nodeType even when typeById maps it to null', () => {
+    // Ensures the null guard in initializePositions keeps untyped nodes
+    // out of the cluster-bias loop in simulateLayout.
+    const ids = ['u', 'n0', 'n1'];
+    const typeById = new Map<string, string | null>([
+      ['u', null],
+      ['n0', 'book'],
+      ['n1', 'person'],
+    ]);
+    const nodes = initializePositions(ids, 800, 800, typeById);
+    runGlobalLayout(nodes, [], { width: 800, height: 800, iterations: 200 });
+
+    const untyped = nodes.find((n) => n.id === 'u');
+    expect(untyped).toBeDefined();
+    expect(untyped!.nodeType).toBeUndefined();
+  });
+
+  it('mini-graph callers without kClusterStrength see identical output to explicit kClusterStrength=0', () => {
+    // Regression guard: the cluster loop must be a strict no-op when
+    // kClusterStrength is omitted, so existing mini-graph behaviour is
+    // numerically unchanged.
+    const ids = [
+      { id: 's', kind: 'self' as const },
+      { id: 'a', kind: 'outbound' as const },
+      { id: 'b', kind: 'outbound' as const },
+    ];
+    const edges: LayoutEdge[] = [
+      { source: 's', target: 'a' },
+      { source: 's', target: 'b' },
+    ];
+
+    const nodes1 = initializeOnCircle(ids, 600, 600, 80);
+    const nodes2 = initializeOnCircle(ids, 600, 600, 80);
+
+    // Run one without kClusterStrength (mini-graph path) and one with
+    // explicit 0 — they must produce identical results.
+    simulateLayout(nodes1, edges, { width: 600, height: 600, iterations: 100 });
+    simulateLayout(nodes2, edges, {
+      width: 600,
+      height: 600,
+      iterations: 100,
+      kClusterStrength: 0,
+    });
+
+    for (let i = 0; i < nodes1.length; i++) {
+      expect(nodes1[i]!.x).toBeCloseTo(nodes2[i]!.x, 8);
+      expect(nodes1[i]!.y).toBeCloseTo(nodes2[i]!.y, 8);
+    }
+  });
+});
+
+function centroid(ns: { x: number; y: number }[]): { x: number; y: number } {
+  let sx = 0;
+  let sy = 0;
+  for (const n of ns) {
+    sx += n.x;
+    sy += n.y;
+  }
+  return { x: sx / ns.length, y: sy / ns.length };
+}
+
+function dist(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}

--- a/apps/desktop/src/components/GlobalGraph/convexHull.test.ts
+++ b/apps/desktop/src/components/GlobalGraph/convexHull.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { convexHull } from './convexHull';
+
+describe('convexHull', () => {
+  it('returns [] for 0 points', () => {
+    expect(convexHull([])).toEqual([]);
+  });
+
+  it('returns the single point for 1 input', () => {
+    expect(convexHull([{ x: 1, y: 1 }])).toEqual([{ x: 1, y: 1 }]);
+  });
+
+  it('returns both endpoints for 2 collinear inputs (no triangle yet)', () => {
+    const got = convexHull([
+      { x: 0, y: 0 },
+      { x: 2, y: 2 },
+    ]);
+    expect(got).toHaveLength(2);
+  });
+
+  it('returns the three vertices of a triangle (3 inputs)', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1, y: 2 },
+    ];
+    const got = convexHull(pts);
+    expect(got).toHaveLength(3);
+    expect(new Set(got.map((p) => `${p.x},${p.y}`))).toEqual(new Set(['0,0', '2,0', '1,2']));
+  });
+
+  it('excludes interior points from the hull', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      { x: 4, y: 4 },
+      { x: 0, y: 4 }, // square corners
+      { x: 2, y: 2 }, // interior
+    ];
+    const got = convexHull(pts);
+    expect(got).toHaveLength(4);
+    expect(got.some((p) => p.x === 2 && p.y === 2)).toBe(false);
+  });
+
+  it('handles duplicate inputs without producing degenerate output', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+      { x: 1, y: 1 },
+    ];
+    const got = convexHull(pts);
+    expect(got.length).toBeGreaterThanOrEqual(1);
+    // Should not contain a duplicate vertex.
+    const unique = new Set(got.map((p) => `${p.x},${p.y}`));
+    expect(unique.size).toBe(got.length);
+  });
+});

--- a/apps/desktop/src/components/GlobalGraph/convexHull.ts
+++ b/apps/desktop/src/components/GlobalGraph/convexHull.ts
@@ -1,0 +1,54 @@
+export type HullPoint = { x: number; y: number };
+
+/**
+ * Andrew's monotone-chain convex hull. O(n log n), no dependencies.
+ * Returns the hull vertices in counter-clockwise order starting at
+ * the lowest-then-leftmost point. Duplicate inputs are deduplicated
+ * implicitly so the cross-product check never produces zero-area
+ * artifacts.
+ *
+ * Edge cases:
+ *   - 0 points → []
+ *   - 1 point  → [the point]
+ *   - 2+ collinear inputs → the two extreme points
+ *   - duplicates → deduplicated; no degenerate hull
+ */
+export function convexHull(points: ReadonlyArray<HullPoint>): HullPoint[] {
+  if (points.length === 0) return [];
+  if (points.length === 1) return [{ x: points[0]!.x, y: points[0]!.y }];
+
+  const sorted = [...points].sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+
+  const uniq: HullPoint[] = [];
+  for (const p of sorted) {
+    const last = uniq[uniq.length - 1];
+    if (last === undefined || last.x !== p.x || last.y !== p.y) uniq.push(p);
+  }
+  if (uniq.length < 2) return uniq;
+
+  const cross = (o: HullPoint, a: HullPoint, b: HullPoint): number =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+  const lower: HullPoint[] = [];
+  for (const p of uniq) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2]!, lower[lower.length - 1]!, p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: HullPoint[] = [];
+  for (let i = uniq.length - 1; i >= 0; i--) {
+    const p = uniq[i]!;
+    while (upper.length >= 2 && cross(upper[upper.length - 2]!, upper[upper.length - 1]!, p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  // The last point of each half is the start of the other half — drop
+  // it so the concatenation doesn't repeat vertices.
+  lower.pop();
+  upper.pop();
+  return lower.concat(upper);
+}

--- a/apps/desktop/src/components/GlobalGraph/index.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.tsx
@@ -14,6 +14,10 @@ import {
   type CanvasView,
 } from './Canvas';
 import { computeBounds, initializePositions, runGlobalLayout } from './layout';
+import { TypeChips, type TypeChip } from './TypeChips';
+import { KindFilterDropdown } from './KindFilterDropdown';
+import { Legend } from './Legend';
+import { useTagsStore } from '../../stores/tags';
 
 // Logical canvas the simulation runs on. The SVG `viewBox` matches
 // these numbers; on screen we just stretch to fill the container, with
@@ -45,6 +49,9 @@ export function GlobalGraph(): JSX.Element {
   const [load, setLoad] = useState<LoadState>({ kind: 'idle' });
   const [search, setSearch] = useState('');
   const [selectedId, setSelectedId] = useState<NotePath | null>(null);
+  const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [selectedKinds, setSelectedKinds] = useState<ReadonlySet<string>>(EMPTY_STRING_SET);
+  const [clusterOverlayOn, setClusterOverlayOn] = useState(false);
   // We bump `viewVersion` whenever we want to force the canvas to apply
   // a fresh `initialView` (fit-to-screen, +/- zoom button). Pan/wheel
   // gestures bypass this and write directly into the canvas via its
@@ -53,6 +60,8 @@ export function GlobalGraph(): JSX.Element {
   const [panning, setPanning] = useState(false);
   const requestSeq = useRef(0);
   const canvasRef = useRef<CanvasHandle | null>(null);
+
+  const objectTypeSchemas = useTagsStore((s) => s.objectTypeSchemas);
 
   // Initial fetch + watcher-driven refetch.
   useEffect(() => {
@@ -116,6 +125,49 @@ export function GlobalGraph(): JSX.Element {
     return m;
   }, [load]);
 
+  // Chip list for the type filter row. Sources from the graph nodes so
+  // only types actually present in this vault appear.
+  const typeChips = useMemo<TypeChip[]>(() => {
+    if (load.kind !== 'ready') return [];
+    const seen = new Set<string>();
+    const byType = new Map<
+      string,
+      { id: string; label: string; icon: string | null; color: string | null }
+    >();
+    for (const n of load.graph.nodes) {
+      if (n.type === null || n.type === '') continue;
+      if (seen.has(n.type)) continue;
+      seen.add(n.type);
+      const schema = objectTypeSchemas.find((s) => s.id === n.type);
+      byType.set(n.type, {
+        id: n.type,
+        label: schema?.label ?? n.type,
+        icon: schema?.icon ?? null,
+        // Node color wins over schema color because that's what the Canvas renders.
+        color: n.color ?? schema?.color ?? null,
+      });
+    }
+    return Array.from(byType.values()).sort((a, b) => a.label.localeCompare(b.label));
+  }, [load, objectTypeSchemas]);
+
+  // Distinct relation kinds present in the graph (empty-string sentinel excluded).
+  const kindOptions = useMemo<string[]>(() => {
+    if (load.kind !== 'ready') return [];
+    const seen = new Set<string>();
+    for (const e of load.graph.edges) {
+      if (e.kind !== '') seen.add(e.kind);
+    }
+    return Array.from(seen).sort();
+  }, [load]);
+
+  // path → type slug; feeds initializePositions for cluster-bias seeding.
+  const typeById = useMemo<ReadonlyMap<NotePath, string | null>>(() => {
+    const m = new Map<NotePath, string | null>();
+    if (load.kind !== 'ready') return m;
+    for (const n of load.graph.nodes) m.set(n.path, n.type);
+    return m;
+  }, [load]);
+
   // Degree counts (in + out). Used to scale node radius and decide
   // which nodes get labels at high zoom.
   const degreeMap = useMemo<Map<NotePath, number>>(() => {
@@ -159,6 +211,7 @@ export function GlobalGraph(): JSX.Element {
       nodes.map((n) => n.path),
       CANVAS_W,
       CANVAS_H,
+      typeById,
     );
     runGlobalLayout(
       positioned,
@@ -166,7 +219,7 @@ export function GlobalGraph(): JSX.Element {
       { width: CANVAS_W, height: CANVAS_H },
     );
     return positioned;
-  }, [load]);
+  }, [load, typeById]);
 
   // Build the canvas-level node list. Memoised so the Canvas's
   // `memo()` shallow comparison sees a stable reference unless the
@@ -218,6 +271,37 @@ export function GlobalGraph(): JSX.Element {
     const set = adjacency.get(selectedId);
     return set ?? EMPTY_SET;
   }, [selectedId, adjacency]);
+
+  // Legend data: when a type chip is active show only that type; otherwise all.
+  const legendTypes = useMemo(() => {
+    if (selectedType === null)
+      return typeChips.map((t) => ({ id: t.id, label: t.label, color: t.color }));
+    const active = typeChips.find((t) => t.id === selectedType);
+    if (active === undefined) return [];
+    return [{ id: active.id, label: active.label, color: active.color }];
+  }, [typeChips, selectedType]);
+
+  const legendKinds = useMemo(() => {
+    if (selectedKinds.size === 0) return [];
+    return Array.from(selectedKinds).sort();
+  }, [selectedKinds]);
+
+  // Clear stale selections when a vault switch brings in a new graph that
+  // no longer contains the previously selected type or kinds.
+  useEffect(() => {
+    if (load.kind !== 'ready') return;
+    if (selectedType !== null && !typeChips.some((t) => t.id === selectedType)) {
+      setSelectedType(null);
+    }
+    if (selectedKinds.size > 0) {
+      const validKinds = new Set(kindOptions);
+      const stale = Array.from(selectedKinds).some((k) => !validKinds.has(k));
+      if (stale) {
+        const next = new Set(Array.from(selectedKinds).filter((k) => validKinds.has(k)));
+        setSelectedKinds(next);
+      }
+    }
+  }, [load, typeChips, kindOptions, selectedType, selectedKinds]);
 
   // Compute fit-to-screen view. Called once when the layout is ready
   // and again whenever the user clicks the "fit" button.
@@ -422,56 +506,77 @@ export function GlobalGraph(): JSX.Element {
 
   return (
     <div className="flex h-full w-full flex-col bg-bg">
-      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg-subtle px-3 py-2">
-        <div className="flex min-w-0 items-baseline gap-3">
-          <h1 className="truncate text-sm font-semibold text-fg">Grafo globale</h1>
-          {isReady && (
-            <span className="truncate text-xs text-fg-muted">
-              {nodeCount} {nodeCount === 1 ? 'nodo' : 'nodi'} · {edgeCount}{' '}
-              {edgeCount === 1 ? 'arco' : 'archi'}
-            </span>
-          )}
+      <header className="flex shrink-0 flex-col gap-2 border-b border-border bg-bg-subtle px-3 py-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-baseline gap-3">
+            <h1 className="truncate text-sm font-semibold text-fg">Grafo globale</h1>
+            {isReady && (
+              <span className="truncate text-xs text-fg-muted">
+                {nodeCount} {nodeCount === 1 ? 'nodo' : 'nodi'} · {edgeCount}{' '}
+                {edgeCount === 1 ? 'arco' : 'archi'}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={search}
+              onChange={(e): void => setSearch(e.target.value)}
+              placeholder="Filtra per titolo…"
+              className="w-48 rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none placeholder:text-fg-muted focus:border-fg-muted"
+              spellCheck={false}
+              autoComplete="off"
+              autoCorrect="off"
+              aria-label="Filtra nodi per titolo"
+            />
+            <div className="flex items-center gap-0.5">
+              <button
+                type="button"
+                onClick={(): void => handleZoom(1 / ZOOM_STEP)}
+                className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                title="Zoom out"
+                aria-label="Diminuisci zoom"
+              >
+                −
+              </button>
+              <button
+                type="button"
+                onClick={(): void => handleZoom(ZOOM_STEP)}
+                className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                title="Zoom in"
+                aria-label="Aumenta zoom"
+              >
+                +
+              </button>
+              <button
+                type="button"
+                onClick={fitToScreen}
+                className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                title="Adatta alla finestra"
+                aria-label="Adatta alla finestra"
+              >
+                Adatta
+              </button>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <input
-            type="text"
-            value={search}
-            onChange={(e): void => setSearch(e.target.value)}
-            placeholder="Filtra per titolo…"
-            className="w-48 rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none placeholder:text-fg-muted focus:border-fg-muted"
-            spellCheck={false}
-            autoComplete="off"
-            autoCorrect="off"
-            aria-label="Filtra nodi per titolo"
-          />
-          <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              onClick={(): void => handleZoom(1 / ZOOM_STEP)}
-              className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
-              title="Zoom out"
-              aria-label="Diminuisci zoom"
-            >
-              −
-            </button>
-            <button
-              type="button"
-              onClick={(): void => handleZoom(ZOOM_STEP)}
-              className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
-              title="Zoom in"
-              aria-label="Aumenta zoom"
-            >
-              +
-            </button>
-            <button
-              type="button"
-              onClick={fitToScreen}
-              className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
-              title="Adatta alla finestra"
-              aria-label="Adatta alla finestra"
-            >
-              Adatta
-            </button>
+        <div className="flex items-center justify-between gap-2">
+          <TypeChips types={typeChips} selectedType={selectedType} onChange={setSelectedType} />
+          <div className="flex items-center gap-2">
+            <KindFilterDropdown
+              kinds={kindOptions}
+              selectedKinds={selectedKinds}
+              onChange={setSelectedKinds}
+            />
+            <label className="flex items-center gap-1 text-xs text-fg-subtle">
+              <input
+                type="checkbox"
+                checked={clusterOverlayOn}
+                onChange={(e): void => setClusterOverlayOn(e.target.checked)}
+                className="h-3 w-3"
+              />
+              Mostra cluster
+            </label>
           </div>
         </div>
       </header>
@@ -509,10 +614,13 @@ export function GlobalGraph(): JSX.Element {
             onWheel={handleWheel}
             onBackgroundClick={handleBackgroundClick}
             panning={panning}
-            clusterOverlayOn={false}
-            highlightType={null}
-            highlightKinds={EMPTY_STRING_SET}
+            clusterOverlayOn={clusterOverlayOn}
+            highlightType={selectedType}
+            highlightKinds={selectedKinds}
           />
+        )}
+        {load.kind === 'ready' && nodeCount > 0 && (
+          <Legend visibleTypes={legendTypes} visibleKinds={legendKinds} />
         )}
       </div>
     </div>

--- a/apps/desktop/src/components/GlobalGraph/index.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.tsx
@@ -174,9 +174,14 @@ export function GlobalGraph(): JSX.Element {
   const canvasNodes = useMemo<CanvasNode[]>(() => {
     if (layout === null) return [];
     const maxDegree = Array.from(degreeMap.values()).reduce((acc, v) => (v > acc ? v : acc), 0);
+    const nodeMeta = new Map<NotePath, { type: string | null; color: string | null }>();
+    if (load.kind === 'ready') {
+      for (const n of load.graph.nodes) nodeMeta.set(n.path, { type: n.type, color: n.color });
+    }
     return layout.map((p) => {
       const degree = degreeMap.get(p.id) ?? 0;
       const r = scaleRadius(degree, maxDegree);
+      const meta = nodeMeta.get(p.id);
       return {
         id: p.id,
         x: p.x,
@@ -184,13 +189,15 @@ export function GlobalGraph(): JSX.Element {
         r,
         degree,
         title: titleMap.get(p.id) ?? p.id,
+        type: meta?.type ?? null,
+        color: meta?.color ?? null,
       };
     });
-  }, [layout, degreeMap, titleMap]);
+  }, [layout, degreeMap, titleMap, load]);
 
   const canvasEdges = useMemo<CanvasEdge[]>(() => {
     if (load.kind !== 'ready') return [];
-    return load.graph.edges.map((e) => ({ source: e.source, target: e.target }));
+    return load.graph.edges.map((e) => ({ source: e.source, target: e.target, kind: e.kind }));
   }, [load]);
 
   // Search filter. Empty query disables filtering; otherwise we collect
@@ -502,6 +509,9 @@ export function GlobalGraph(): JSX.Element {
             onWheel={handleWheel}
             onBackgroundClick={handleBackgroundClick}
             panning={panning}
+            clusterOverlayOn={false}
+            highlightType={null}
+            highlightKinds={EMPTY_STRING_SET}
           />
         )}
       </div>
@@ -510,6 +520,7 @@ export function GlobalGraph(): JSX.Element {
 }
 
 const EMPTY_SET: ReadonlySet<NotePath> = new Set<NotePath>();
+const EMPTY_STRING_SET: ReadonlySet<string> = new Set<string>();
 
 function clamp(n: number, lo: number, hi: number): number {
   if (n < lo) return lo;

--- a/apps/desktop/src/components/GlobalGraph/layout.ts
+++ b/apps/desktop/src/components/GlobalGraph/layout.ts
@@ -24,6 +24,7 @@ import {
   type LayoutEdge,
   type LayoutNode,
 } from '../MiniGraph/layout';
+import { GRAPH_CLUSTER_STRENGTH } from '../../lib/graph-tuning';
 
 export type { LayoutEdge, LayoutNode };
 
@@ -81,7 +82,12 @@ function defaultIterations(nodeCount: number): number {
  * "explosion" you sometimes get when two random points start on top of
  * each other.
  */
-export function initializePositions(ids: string[], width: number, height: number): LayoutNode[] {
+export function initializePositions(
+  ids: string[],
+  width: number,
+  height: number,
+  typeById?: ReadonlyMap<string, string | null>,
+): LayoutNode[] {
   // Radius scales with sqrt(n) so a denser graph gets a wider initial
   // ring — keeps the average per-node distance roughly constant at t=0
   // and the simulator doesn't have to spend its first dozen ticks just
@@ -89,7 +95,13 @@ export function initializePositions(ids: string[], width: number, height: number
   const radius = Math.min(width, height) / 2 - 24;
   const seedRadius = Math.max(60, Math.min(radius, 30 + Math.sqrt(ids.length) * 8));
   return miniInitializeOnCircle(
-    ids.map((id) => ({ id, kind: 'outbound' as const })),
+    ids.map((id) => {
+      const t = typeById?.get(id);
+      const base: { id: string; kind: 'outbound' } = { id, kind: 'outbound' };
+      // Only attach nodeType when it's a non-empty string. `exactOptionalPropertyTypes`
+      // forbids `nodeType: undefined`, so we conditionally spread.
+      return t !== undefined && t !== null && t !== '' ? { ...base, nodeType: t } : base;
+    }),
     width,
     height,
     seedRadius,
@@ -120,6 +132,7 @@ export function runGlobalLayout(
     restLen: GLOBAL_DEFAULTS.restLen,
     damping: GLOBAL_DEFAULTS.damping,
     kCenter: GLOBAL_DEFAULTS.kCenter,
+    kClusterStrength: GRAPH_CLUSTER_STRENGTH,
   });
 }
 

--- a/apps/desktop/src/components/MiniGraph/layout.ts
+++ b/apps/desktop/src/components/MiniGraph/layout.ts
@@ -20,6 +20,13 @@ export type LayoutNode = {
   vx: number;
   vy: number;
   kind: LayoutNodeKind;
+  /**
+   * v1.0 Phase 5: optional type slug. When set on a subset of nodes,
+   * `simulateLayout`'s cluster-bias term pulls same-type nodes toward
+   * each other (with weight `kClusterStrength`). Mini-graph callers
+   * don't set this; the cluster term is a no-op for them.
+   */
+  nodeType?: string | null;
 };
 
 export type LayoutEdge = {
@@ -41,6 +48,13 @@ export type LayoutOptions = {
   damping?: number;
   /** Pull strength toward canvas center. Keeps the graph from drifting. */
   kCenter?: number;
+  /**
+   * v1.0 Phase 5: coefficient for the same-type cluster bias. When
+   * `> 0`, pairs of nodes with matching `nodeType` exert a linear
+   * attractive force `f = kClusterStrength * distance`. Default 0 →
+   * loop is skipped → mini-graph behaviour unchanged.
+   */
+  kClusterStrength?: number;
 };
 
 const DEFAULTS = {
@@ -132,6 +146,35 @@ export function simulateLayout(
       b.vy -= fy;
     }
 
+    // Cluster bias: same-type nodes attract each other linearly with
+    // distance. Off by default (kCluster = 0) so mini-graph callers
+    // see no change; global-graph callers opt in via `kClusterStrength`.
+    // Skips nodes whose `nodeType` is undefined or null so untyped
+    // notes float freely between clusters.
+    const kCluster = opts.kClusterStrength ?? 0;
+    if (kCluster > 0) {
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        if (a === undefined || a.nodeType === undefined || a.nodeType === null) continue;
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          if (b === undefined || b.nodeType !== a.nodeType) continue;
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const dist2 = dx * dx + dy * dy;
+          if (dist2 < 0.01) continue;
+          const dist = Math.sqrt(dist2);
+          const f = kCluster * dist;
+          const ux = dx / dist;
+          const uy = dy / dist;
+          a.vx += f * ux;
+          a.vy += f * uy;
+          b.vx -= f * ux;
+          b.vy -= f * uy;
+        }
+      }
+    }
+
     // Centering: gentle pull toward the canvas center for non-self nodes.
     for (const n of nodes) {
       if (n.kind === 'self') continue;
@@ -184,7 +227,7 @@ export function simulateLayout(
  * each other.
  */
 export function initializeOnCircle(
-  ids: { id: string; kind: LayoutNodeKind }[],
+  ids: { id: string; kind: LayoutNodeKind; nodeType?: string | null }[],
   width: number,
   height: number,
   radius: number,
@@ -196,7 +239,12 @@ export function initializeOnCircle(
   const result: LayoutNode[] = [];
 
   if (self !== undefined) {
-    result.push({ id: self.id, kind: 'self', x: cx, y: cy, vx: 0, vy: 0 });
+    const selfBase = { id: self.id, kind: 'self' as const, x: cx, y: cy, vx: 0, vy: 0 };
+    result.push(
+      self.nodeType !== undefined && self.nodeType !== null
+        ? { ...selfBase, nodeType: self.nodeType }
+        : selfBase,
+    );
   }
 
   const n = others.length;
@@ -206,14 +254,17 @@ export function initializeOnCircle(
     // Start at the top (-π/2) and walk clockwise so layouts feel stable
     // when the same node set re-renders.
     const angle = (i / Math.max(n, 1)) * Math.PI * 2 - Math.PI / 2;
-    result.push({
+    const base = {
       id: o.id,
       kind: o.kind,
       x: cx + Math.cos(angle) * radius,
       y: cy + Math.sin(angle) * radius,
       vx: 0,
       vy: 0,
-    });
+    };
+    result.push(
+      o.nodeType !== undefined && o.nodeType !== null ? { ...base, nodeType: o.nodeType } : base,
+    );
   }
 
   return result;

--- a/apps/desktop/src/components/MiniGraph/layout.ts
+++ b/apps/desktop/src/components/MiniGraph/layout.ts
@@ -21,10 +21,10 @@ export type LayoutNode = {
   vy: number;
   kind: LayoutNodeKind;
   /**
-   * v1.0 Phase 5: optional type slug. When set on a subset of nodes,
-   * `simulateLayout`'s cluster-bias term pulls same-type nodes toward
-   * each other (with weight `kClusterStrength`). Mini-graph callers
-   * don't set this; the cluster term is a no-op for them.
+   * Optional type slug for cluster-bias grouping. When set, pairs of
+   * nodes with the same slug attract each other (weight `kClusterStrength`).
+   * Optional so the field is absent rather than null on untyped nodes,
+   * which keeps it out of the cluster loop without an extra runtime check.
    */
   nodeType?: string | null;
 };
@@ -49,10 +49,10 @@ export type LayoutOptions = {
   /** Pull strength toward canvas center. Keeps the graph from drifting. */
   kCenter?: number;
   /**
-   * v1.0 Phase 5: coefficient for the same-type cluster bias. When
-   * `> 0`, pairs of nodes with matching `nodeType` exert a linear
-   * attractive force `f = kClusterStrength * distance`. Default 0 →
-   * loop is skipped → mini-graph behaviour unchanged.
+   * Coefficient for the same-type cluster bias: `f = k * distance`
+   * applied to pairs of matching-type nodes. Defaults to 0 (no
+   * clustering) so the loop is a provable no-op when the caller does
+   * not opt in.
    */
   kClusterStrength?: number;
 };

--- a/apps/desktop/src/lib/graph-tuning.ts
+++ b/apps/desktop/src/lib/graph-tuning.ts
@@ -57,3 +57,12 @@ export const GRAPH_LABEL_TOP_DEGREE_QUANTILE = 0.85;
  * competing with the highlighted neighbours.
  */
 export const GRAPH_DIM_OPACITY = 0.18;
+
+/**
+ * v1.0 Phase 5: same-type cluster bias coefficient for the global
+ * graph. Larger = tighter type clusters, smaller = clusters loosen
+ * and node positions are dominated by edges + repulsion. 0.3 was
+ * tuned against a synthetic 2-type / 20-node graph: visible
+ * clustering without nodes piling on top of each other.
+ */
+export const GRAPH_CLUSTER_STRENGTH = 0.3;

--- a/apps/desktop/src/lib/kind-color.test.ts
+++ b/apps/desktop/src/lib/kind-color.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { kindToHsl } from './kind-color';
+
+describe('kindToHsl', () => {
+  it('returns the same color for the same kind', () => {
+    expect(kindToHsl('author')).toBe(kindToHsl('author'));
+  });
+
+  it('returns different colors for different kinds (high probability)', () => {
+    expect(kindToHsl('author')).not.toBe(kindToHsl('cites'));
+    expect(kindToHsl('author')).not.toBe(kindToHsl('in_series'));
+  });
+
+  it('returns a valid hsl() string with consistent S/L', () => {
+    const re = /^hsl\(\d+(\.\d+)?, \d+%, \d+%\)$/;
+    expect(kindToHsl('author')).toMatch(re);
+    expect(kindToHsl('cites')).toMatch(re);
+  });
+
+  it('returns a neutral grey for the empty-string sentinel (generic body wikilinks)', () => {
+    expect(kindToHsl('')).toBe('hsl(0, 0%, 60%)');
+  });
+});

--- a/apps/desktop/src/lib/kind-color.ts
+++ b/apps/desktop/src/lib/kind-color.ts
@@ -1,0 +1,22 @@
+const SATURATION_PCT = 55;
+const LIGHTNESS_PCT = 55;
+
+/**
+ * Deterministic kind → HSL color. The empty-string sentinel (generic
+ * body wikilink, the `kind = ''` value used throughout the relations
+ * table) maps to a neutral grey so the constellation graph can
+ * distinguish "no kind" from a real relation kind without an extra
+ * branch in the renderer.
+ *
+ * Uses djb2 modulo 360 for the hue. Saturation and lightness are
+ * fixed so the palette stays visually coherent across kinds.
+ */
+export function kindToHsl(kind: string): string {
+  if (kind === '') return 'hsl(0, 0%, 60%)';
+  let hash = 5381;
+  for (let i = 0; i < kind.length; i++) {
+    hash = ((hash << 5) + hash + kind.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, ${SATURATION_PCT}%, ${LIGHTNESS_PCT}%)`;
+}

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -166,12 +166,31 @@ export type DatabaseResult = {
 export type GraphNode = {
   path: NotePath;
   title: string;
+  /**
+   * v1.0 Phase 5: `type:` slug from the note's frontmatter, or null
+   * when the note is untyped. Drives the constellation graph's node
+   * tinting and cluster grouping.
+   */
+  type: string | null;
+  /**
+   * v1.0 Phase 5: hex color from the type's cached schema, when both
+   * the type slug and a matching `object_types` row with a non-null
+   * `color` exist. Null otherwise (no schema, or schema with no color
+   * declared).
+   */
+  color: string | null;
 };
 
 export type GraphEdge = {
   source: NotePath;
   target: NotePath;
   targetTitle: string;
+  /**
+   * v1.0 Phase 5: relation kind. The empty string `''` is the
+   * sentinel for generic body wikilinks; non-empty values match the
+   * frontmatter `relations:<kind>` key.
+   */
+  kind: string;
 };
 
 export type FullGraph = {


### PR DESCRIPTION
## Summary

Phase 5 of v1.0 Object-Relational Foundation — the global graph view becomes type-aware.

- **Core types**: `GraphNode` gains `type: string | null` + `color: string | null`; `GraphEdge` gains `kind: string` (`''` sentinel for generic body wikilinks).
- **Adapter SQL**: `graphNodes` LEFT JOINs `note_properties` (type) and `object_types` (color); `graphEdges` already shipped `kind` (no SQL change there).
- **Cluster-bias force**: same-type nodes attract each other with weight `GRAPH_CLUSTER_STRENGTH = 0.3`. Opt-in via `LayoutOptions.kClusterStrength`; mini-graph callers stay unaffected.
- **Convex hulls overlay**: per type with ≥ 3 visible nodes, semi-transparent SVG `<path>` underneath nodes/edges. Off by default; "Mostra cluster" toggle in the header.
- **Edge color per kind**: deterministic HSL hash via `kindToHsl(kind)`. The empty sentinel maps to neutral grey.
- **Header controls**: `<TypeChips>` single-select chip row, `<KindFilterDropdown>` multi-select with color swatches, `<Legend>` top-right overlay listing active types + kinds with swatches.
- **Stale-state cleanup**: when the active type / kinds disappear from the graph (vault switch, schema deletion), the selection clears automatically.

## Tests

- Adapter SQL: 4 cases (type/color LEFT JOIN behaviour)
- `kindToHsl`: 4 cases (determinism, distinctness, format, sentinel)
- `convexHull`: 6 cases (empty, 1pt, collinear, triangle, interior exclusion, duplicates)
- Cluster bias: 4 cases (synthetic separation, untyped passthrough, mini-graph regression, nodeType stamping)
- `HullsLayer`: 5 cases (gating < 3 nodes, hidden types, null/empty skip, multi-cluster)
- `TypeChips`: 6 cases (render, pressed state, toggle, clear)
- `KindFilterDropdown`: 6 cases (label, list, toggle, clear-all, empty)
- Canvas dim precedence: 2 cases (type filter overrides neighbor highlight)
- **484 total** (318 desktop + 166 core); all green.

## Test plan

- [x] `pnpm typecheck` — 3/3 green
- [x] `pnpm lint` — clean
- [x] `pnpm test` — green
- [ ] Manual smoke: chips narrow the graph, "Mostra cluster" overlays hulls, kind filter highlights selected edges, Legend lists active selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)