### PR TITLE
chore(v1.0.2): polish — data correctness + perf + a11y + release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,121 +6,132 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 
 ## [Unreleased]
 
-### v0.6 Rebrand: synapsium → Ziba
+## [1.0.1] - 2026-05-10
 
-The project is now called **Ziba**. All identifiers updated in lockstep:
+### Phase 2 followups
 
-- Package names: `synapsium` → `ziba`, `@synapsium/core` → `@ziba/core`, `synapsium-desktop` → `ziba-desktop`, `@synapsium/tsconfig` → `@ziba/tsconfig`.
-- IPC bridge: `window.synapsium` → `window.ziba` (`SynapsiumApi` → `ZibaApi`).
-- Vault cache directory: `INDEX_DIR_NAME` `.synapsium` → `.ziba`. Existing vaults will silently rebuild the index on first open under the new name; the old `.synapsium/` directory is left orphan and can be removed manually.
-- CSS class prefix: `.synapsium-*` → `.ziba-*` (math, embed, wikilink styling).
-- markdown-it rule key: `synapsium_math_inline` (registry flag and token name).
+- Cache renderer-side per i tipi degli oggetti (`typedPaths`, `objectTypeSchemas`) — evita round-trip IPC ad ogni render.
+- Hot-reload degli schemi `.ziba/schema/*.yml` senza reindex completo: chokidar notifica solo il file modificato e aggiorna `object_types` in-place.
+- Toggle split centralizzato e derivazione slug centralizzata.
+
+## [1.0.0] - 2026-05-11
+
+### v1.0 Object-Relational Foundation
+
+Ziba evolve da "Obsidian con extras" a object graph tipizzato. Ogni nota può
+dichiararsi un oggetto tipizzato (`type:`) con relazioni tipizzate (`relations:`)
+verso altri oggetti. Cinque fasi:
+
+- **Phase 1 — Schema + indexer + relations table.** Nuova directory
+  `<vault>/.ziba/schema/<type>.yml` per definire tipi (label, icon, color,
+  properties, relations, inverse). Sette schemi seed (`note`, `person`,
+  `book`, `project`, `idea`, `daily`, `meeting`). Tabella SQLite `relations`
+  sostituisce `wikilinks` con `kind` tipizzato. Wikilink generici nel body
+  restano backward-compatible come relazioni untyped (`kind = ''`).
+- **Phase 2 — ObjectPanel + sidebar TypesSection.** Pannello laterale sulla
+  nota corrente mostra properties dello schema + relazioni inverse. Nuova
+  sezione sidebar "Tipi" con counts per tipo. Cache renderer-side
+  (`typedPaths`, `objectTypeSchemas`).
+- **Phase 3 — Editor type-icon + slash relation + PropertyEditor relations.**
+  Icona di tipo decora i wikilink secondo lo schema del target. Slash menu
+  `/relazione` per inserire relazioni tipizzate. PropertyEditor riconosce e
+  gestisce `relations:`.
+- **Phase 4 — Database view type filter + schema-aware columns.** Filtro
+  page-level "Tipo: …" nella DatabaseView; le colonne suggerite seguono lo
+  schema della nota.
+- **Phase 5 — Constellation graph.** Grafo globale: cluster bias per tipo,
+  hull colorati, filtro multi-select per kind di relazione, leggenda
+  in overlay.
+
+### Note d'uso
+
+- **Schema soft, non hard.** Gli schemi sono documentazione + affordance UI,
+  non validazione che rifiuta il salvataggio. Valori out-of-spec renderizzano
+  best-effort.
+- **Backward-compat.** Vault v0.x continuano a funzionare; le wikilink
+  generiche restano nel grafo con `kind = ''`.
+
+### Limitazioni note (da fixare in v1.x)
+
+- Filtri "type" tra Sidebar, DatabaseView e GlobalGraph hanno store
+  indipendenti — possono mostrare valori divergenti tra le view (issue noto;
+  refactor verso uno slice condiviso pianificato per v1.1).
+- Aliased relations (`[[Target|Display]]`) ora supportati a livello di
+  helper ma non ancora esposti nei popup di inserimento. v1.1 aggiungerà
+  i campi.
+
+## [0.6.0] - 2026-04-15
+
+### Rebrand: Synapsium → Ziba
+
+- Nomi package: `synapsium` → `ziba`, `@synapsium/core` → `@ziba/core`, `synapsium-desktop` → `ziba-desktop`, `@synapsium/tsconfig` → `@ziba/tsconfig`.
+- Bridge IPC: `window.synapsium` → `window.ziba` (`SynapsiumApi` → `ZibaApi`).
+- Directory cache vault: `INDEX_DIR_NAME` `.synapsium` → `.ziba`. I vault esistenti ricostruiscono l'index al primo avvio; la vecchia `.synapsium/` rimane orfana e può essere rimossa manualmente.
+- Prefisso CSS: `.synapsium-*` → `.ziba-*` (math, embed, wikilink styling).
+- Chiave markdown-it rule: `synapsium_math_inline` aggiornata.
 - electron-builder: `appId` `com.metaforismo.ziba`, `productName` `Ziba`.
-- Repository URL: `metaforismo/Synapsium` → `metaforismo/Ziba` in `package.json` (`homepage`, `repository.url`).
+- URL repository: `metaforismo/Synapsium` → `metaforismo/Ziba` in `package.json`.
 - README, CHANGELOG, CONTRIBUTING, architecture doc, issue templates.
-
-Tests, typecheck, and lint all clean post-rename. The local working directory keeps its `synapsium` path on disk because changing it isn't part of the codebase.
 
 ### v0.5.2 Fixed (review LOW items)
 
-- **`Fragment` discriminated union** in `index-store-query.ts`: `predicate / always-false / always-true` variants. `buildWhereFragments` short-circuits to `always-false` when any filter (e.g. `in [ ]`) is unsatisfiable, and the SQLite adapter now skips the round-trip entirely. All array fields in the public shapes are `ReadonlyArray`.
-- **`toSerializedError` double-prefix sanitiser**: strips a leading `[XYZ] ` from `IpcError.message` before re-wrapping with `[CODE]`. Without this, a manually-tagged message round-tripped as `[CODE] [XYZ] body` and the renderer's `ipcErrorMessage` only stripped the outer wrapper.
-- **`columnForRhs` docstring** documents that ISO datetime strings (with `T`) route to `text_value`, not `date_value` — matching the indexer's strict 10-character calendar form. Caller's responsibility to trim if comparing against a date-typed property.
+- **`Fragment` discriminated union** in `index-store-query.ts`: `predicate / always-false / always-true` variants. `buildWhereFragments` short-circuits to `always-false` quando un filtro (es. `in [ ]`) è unsatisfiable; il SQLite adapter salta il round-trip interamente. Tutti i campi array nelle forme pubbliche sono `ReadonlyArray`.
+- **`toSerializedError` double-prefix sanitiser**: strip del `[XYZ] ` iniziale da `IpcError.message` prima di ri-wrappare con `[CODE]`. Senza questo, un messaggio tagged round-trippava come `[CODE] [XYZ] body`.
+- **`columnForRhs` docstring** documenta che le stringhe ISO datetime (con `T`) vanno a `text_value`, non `date_value`.
 
 ### v0.5.1 Fixed (post-review hardening)
 
-After v0.5 a parallel review (4 specialised agents on diff 37e22d1) surfaced a handful of real issues. This commit closes them:
-
-- **EmbedNodeView race recovery — null branch** (`EmbedNodeView.tsx`): when the post-ALREADY_EXISTS re-resolve returns `null` (a parallel gesture deleted the just-created note), state now falls back to `not-found` instead of surfacing the stale ALREADY_EXISTS message. When the recovery itself throws, the recovery error is shown — the original is no longer the actionable signal. Logic extracted to pure `attemptCreateNoteForEmbed(target, ipc)` (six new tests).
-- **Sidebar mutations — narrowly-scoped catches** (`useSidebarMutations.ts`): each mutation is now a two-stage flow. Stage 1 (the IPC call) is the one whose failure the user sees as `Impossibile <verb>`. Stage 2 (refresh + follow-up open/close) runs through `runFollowUp(verb, fn)`, which logs and shows a non-blocking "operazione riuscita ma vista non aggiornata" alert on failure. Previously a stuck file watcher would mis-report a successful delete as "Impossibile eliminare la nota".
-- **`clampQueryLimit` against NaN / Infinity** (`index-store-query.ts`): `Number.isFinite` guard prevents `LIMIT NaN` reaching SQLite and silently returning zero rows.
-- **Whitespace-only folder filter** (`index-store-query.ts`): `query.folder = "   "` now treated as "no folder filter" instead of producing an unmatchable `"   /%"` LIKE.
-- **`ipcErrorMessage` / `extractIpcErrorCode` accept plain `{ code, message }` objects**: a future serialization path (e.g. web build over service worker) won't silently degrade to "Errore sconosciuto" because the payload isn't an `Error` instance.
-- **Defensive try/catch around `katex.renderToString`** (`MathRenderer.tsx`): with `throwOnError: false` + `strict: 'ignore'` KaTeX shouldn't throw, but a future major version could. Without the catch a throw escapes `useMemo` and unmounts every formula on the page. Caches an error sentinel so a hot-loop re-throw doesn't peg the renderer. Asserts `KATEX_CACHE_LIMIT > 0` at module load.
-
-### v0.5.1 Changed (post-review hardening)
-
-- **`KNOWN_CODES` derived from the `IpcErrorCode` union** via a const-as-keys table (`shared/ipc.ts` exports both `IpcErrorCode` and `IPC_ERROR_CODES: ReadonlySet<IpcErrorCode>` from one source). Eliminates the lockstep hazard where adding a code to the type but forgetting the set would silently treat the new code as "no code".
-- **`BoardColumn` made `readonly`** with a private `MutableBoardColumn` for the build phase. Aligns with the v0.5 readonly propagation across the database views; the only mutation site (`distributeRows`) keeps its push semantics internally.
-
-### v0.5.1 Tests
-
-- `MathRenderer.test.ts` (5 cases): cache hit / displayMode-keyed / eviction at the 256 boundary / LRU touch reordering.
-- `EmbedNodeView.test.ts` (+6 cases for `attemptCreateNoteForEmbed`): happy path, ALREADY_EXISTS+resolve-hits, ALREADY_EXISTS+resolve-null (race resolved differently), ALREADY_EXISTS+recovery-throws, non-recoverable error, ALREADY_EXISTS+loadNote-throws.
-- `index-store-query.test.ts` (+4 cases): `clampQueryLimit` NaN / Infinity guards, folder whitespace handling.
-- `ipc-error.test.ts` (+3 cases): plain-object inputs for both `extractIpcErrorCode` and `ipcErrorMessage`.
-
-Total tests: **312** (140 core + 172 desktop). Was 294 at v0.5.
+- **EmbedNodeView race recovery — null branch**: quando il re-resolve post-ALREADY_EXISTS ritorna `null`, lo stato ricade su `not-found` invece di mostrare il messaggio stale. Logica estratta in `attemptCreateNoteForEmbed(target, ipc)`.
+- **Sidebar mutations — narrowly-scoped catches**: ogni mutazione è ora un flusso a due stadi. Stage 1 (call IPC) → errore visible. Stage 2 (refresh + follow-up) → log non-blocking.
+- **`clampQueryLimit` contro NaN / Infinity**: guard `Number.isFinite` previene `LIMIT NaN` su SQLite.
+- **Whitespace-only folder filter**: `query.folder = "   "` trattato come "nessun filtro cartella".
+- **`ipcErrorMessage` / `extractIpcErrorCode` accettano plain `{ code, message }`**: path di serializzazione futura non degrada silenziosamente.
+- **Defensive try/catch intorno a `katex.renderToString`**: con `throwOnError: false` KaTeX non dovrebbe lanciare, ma una versione major futura potrebbe. Cache un sentinel di errore per evitare hot-loop.
 
 ### v0.5 Fixed
 
-- **Inline-math currency false positives** (`MathInline.ts`): the parser previously rejected `$5+$10$` only on the close side (`afterClose !== digit`), letting strings like `Pago $5+$10 totale` open a math span when the closer landed before whitespace. Added the symmetric Pandoc guard (`prev !== ASCII digit`) and extracted the scanner into a pure exported function `scanInlineMath(src, start)` for direct unit testing.
-- **CalendarView DST anchor** (`CalendarView/helpers.ts`): every `Date` in `buildMonthGrid` is now anchored at local-noon (12:00). In locales where DST falls back across midnight (historical São Paulo, parts of Argentina/Cuba), `new Date(y, m, d)` with implicit-midnight could shift cells into the previous day; noon is never affected. Defense-in-depth, zero perf cost.
-- **Embed preview rendering** (`EmbedNodeView.tsx`):
-  - `![[Other]]` nested embeds now render as a compact pill (`.ziba-embed-nested`) instead of `!` + wikilink.
-  - `renderPreview` defensively strips a leading `---\n…\n---` (or `...`) frontmatter block. `Note.content` is already body-only via gray-matter, but the function is exported and reachable from other call sites where this guard matters.
-- **`![[]]` and frontmatter** stripping covered by 8 new tests in `EmbedNodeView.test.ts`.
-- **EmbedNodeView ALREADY_EXISTS retry**: the "Crea nota" CTA used to surface the IPC error if a watcher event created the same note between `resolveTitle` returning null and the `createNote` call. Now intercepts `code === 'ALREADY_EXISTS'` and re-resolves + loads the existing note transparently.
-- **IPC error code propagation** (`lib/ipc-error.ts` + IPC wrapper): the wrapper that translates main-process exceptions to the renderer now belt-and-braces the canonical code via two paths — own `code` property and a `[CODE] ` message prefix. Adds `extractIpcErrorCode(err)` and `ipcErrorMessage(err)`; every renderer call site that displays `err.message` now goes through the prefix-stripping helper.
-- **Memo stability in DatabaseView/Board/Calendar**: replaced `result?.rows ?? []` (which allocated a fresh array per render) with frozen module-level `EMPTY_ROWS` / `EMPTY_GROUPS` constants. Public helper signatures (`buildMonthGrid`, `buildColumns`, `detectGroupType`, `detectColumnType`, FilterBar, Table) now accept `readonly DatabaseRow[]` / `readonly DatabaseGroup[]`.
+- **Inline-math currency false positives**: guard Pandoc simmetrico (`prev !== ASCII digit`) estratto in `scanInlineMath(src, start)`.
+- **CalendarView DST anchor**: ogni `Date` in `buildMonthGrid` è ora ancorata a local-noon (12:00).
+- **Embed preview rendering**: `![[Other]]` nested render come pill compatta. `renderPreview` fa strip del frontmatter.
+- **EmbedNodeView ALREADY_EXISTS retry**: intercetta `code === 'ALREADY_EXISTS'` e re-resolve trasparentemente.
+- **IPC error code propagation**: il wrapper traduce eccezioni main-process al renderer con due path indipendenti (own `code` + `[CODE]` message prefix).
+- **Memo stability in DatabaseView/Board/Calendar**: `EMPTY_ROWS` / `EMPTY_GROUPS` frozen const.
 
 ### v0.5 Added
 
-- **KaTeX render cache** (`MathRenderer.tsx`): module-level LRU map (256 entries, keyed on `${displayMode} ${formula}`) memoises `renderToString` output across node-view re-mounts. Vaults with many formulas no longer pay the parse cost on scroll / undo / selection changes.
-- **`scanInlineMath(src, start)`** exported from `MathInline.ts` for direct testing of the inline-math recognition heuristic.
-- **`extractIpcErrorCode(err)` + `ipcErrorMessage(err)`** in `lib/ipc-error.ts` (also exported `IpcErrorCode` from `shared/ipc.ts` as the single source of truth).
+- **KaTeX render cache**: LRU map a 256 entry per `renderToString`.
+- **`scanInlineMath(src, start)`** esportata da `MathInline.ts`.
+- **`extractIpcErrorCode(err)` + `ipcErrorMessage(err)`** in `lib/ipc-error.ts`.
 
 ### v0.5 Changed
 
-- **Sidebar split** (`Sidebar/index.tsx` 553 → 344 lines): CRUD wiring extracted to `useSidebarMutations()` (~160 lines, type `SidebarMutations`); the six dialog flows extracted to `<SidebarDialogs>` keyed on a `DialogState` discriminated union (~140 lines). The orchestrator file now reads top-to-bottom: layout → tree filter → keyboard nav → context menu → dialogs.
-- **index-store query-builder split** (`index-store.sqlite.ts` 882 → 745 lines): all SQL fragment construction extracted to `electron/adapters/index-store-query.ts` — `columnForRhs`, `buildFilterFragment`, `buildWhereFragments`, `buildSortClause`, `clampQueryLimit`, plus `DEFAULT_QUERY_LIMIT` / `MAX_QUERY_LIMIT` constants. The new module is pure (no `better-sqlite3` import) and gets its own test file (27 cases).
-- **Vitest renderer config** now also collects specs from `electron/**/*.test.ts` so pure-logic helpers in the main-process tree (e.g. the query-builder) are covered without spinning up Electron.
-
-Total tests: **294** (140 core + 154 desktop). Was 233 at the close of v0.4.
+- **Sidebar split**: `useSidebarMutations()` hook + `<SidebarDialogs>` component.
+- **index-store query-builder split**: tutto il fragment SQL estratto in `index-store-query.ts` (modulo puro, niente `better-sqlite3`).
 
 ### v0.4 Added
 
-- **Database sub-views** (`databaseViewMode` in `useUiStore`): tabs Tabella / Board / Calendario nel Database header. Stessa query (filtri/sort/groupBy/folder), tre visualizzazioni.
-- **Board view (kanban)** (`components/DatabaseView/BoardView/`) — colonne raggruppate per `groupBy` property, drag-and-drop HTML5 nativo (no nuova dep). Drop su una colonna aggiorna il frontmatter via `ipc.saveNote` (replace per scalari, splice per array). "(senza valore)" column sempre presente per cancellare la property. Multi-select (`string-array`): card appare in tutte le colonne dei suoi tag. +30 unit test in `helpers.test.ts`.
-- **Calendar view** (`components/DatabaseView/CalendarView/`) — griglia mensile Lun-Dom italiano. Buckets le note per ISO date in `properties[groupBy]`. Header con prev/next/Oggi. Each cell up to 3 note pills + "+N altre". Today accent-bordered, out-of-month dimmed. DST-safe + reject calendar-invalid ISO. +12 unit test.
-- **Embed block** (`Editor/extensions/Embed.ts` + `EmbedNodeView.tsx`) — `![[Target]]` Tiptap atomic node con React node view che lazy-loada il target via `ipc.resolveTitle` + `ipc.loadNote`. Markdown roundtrip Obsidian-compatible. Hand-rolled markdown preview renderer (~150 righe, no nuova dep — usa solo escape via React). Stati: loading / not-found (con "Crea nota" CTA) / error (con Riprova). Click → `navigateToNote`. Slash menu entry `↪ Embed nota`.
-- **Math (KaTeX)** (`Editor/extensions/MathBlock.ts` + `MathInline.ts` + `MathRenderer.tsx`) — `$$..$$` block + `$..$` inline. Tiptap atomic nodes con React node view. KaTeX `renderToString` con `throwOnError: false`. Click → live-preview textarea editor (Cmd+Enter commit, Esc revert, blur fallback commit). Markdown roundtrip via markdown-it block + inline rules con guards Pandoc-style anti-currency-falsi-positivi. Slash menu entries `∑ Formula matematica` (block) e `𝑥 Formula inline`. Nuova dep runtime: `katex@^0.16.11` + `@types/katex@^0.16.7`.
-- **`navigateToNote(path)`** in `lib/navigate.ts` — shared switch-view + open helper, riusato da DatabaseView (Table/Board) e GlobalGraph. Uno spot per evolvere a toast-based error surface.
-- **`lib/graph-tuning.ts`** — costanti del global graph estratte (CANVAS_W/H, ZOOM_MIN/MAX, FIT_PADDING, LARGE_THRESHOLD, LABEL_TOP_DEGREE_QUANTILE, DIM_OPACITY) parallela a `lib/timings.ts`.
-
-Total tests: **232** (140 core + 92 desktop). Was 190 in v0.3.
-
-### Added
-
-- **Renderer test suite Vitest + jsdom** in `apps/desktop` (`vitest.config.ts`, `src/test/setup.ts`, `src/test/mock-ipc.ts`). 50 test cases coprono `useSearchStore` (debounce 150ms, coalesce di rapid setQuery, sequence-number guard su risposte out-of-order, chooseSelected che apre nota + chiude palette, errori IPC), `useDatabaseStore` (mutator filtri, debounce 200ms, sequence-number guard, sottoscrizione vault con vault-switch e vault-close), `useTagsStore` (refresh, selectTag con last-click-wins, applyVaultEvent debounced, modulo-level subscription a `useVaultStore`), `useUiStore` (clamping width, toggle persistence, validator `loadPersisted` con localStorage corrotto / type-mismatch / clamp), e `lib/debounce.ts` (cancel/flush/trailing-edge invariants). Mock `window.ziba` via `installMockIpc()` con stub returns + `vi.fn()` spies per ogni canale + simulazione push events. Total project test count: **190** (140 core + 50 desktop).
+- **Database sub-views** (`databaseViewMode`): tab Tabella / Board / Calendario nel Database header.
+- **Board view (kanban)**: colonne raggruppate per `groupBy` property, drag-and-drop HTML5 nativo. Drop aggiorna il frontmatter via `ipc.saveNote`.
+- **Calendar view**: griglia mensile Lun-Dom italiano. Buckets le note per ISO date.
+- **Embed block** (`![[Target]]`): Tiptap atomic node che lazy-carica il target via IPC.
+- **Math (KaTeX)**: `$$..$$` block + `$..$` inline con live-preview editor.
+- **`navigateToNote(path)`** in `lib/navigate.ts`: helper condiviso tra DatabaseView e GlobalGraph.
 
 ### v0.3 Added
 
-- **Database view** (`components/DatabaseView/`) — vista tabellare di tutto il vault triggered dal pulsante "Database" in TopBar. FilterBar tipizzata (eq/contains/has/lacks/lt/gt/lte/gte), sort multi-key, group-by, ColumnPicker, click-row apre nota. Empty states distinti (vault-empty vs filtered-out). Cell rendering type-aware (Italian-locale dates/numbers, ✓/✗ booleans, link URLs, chip arrays).
-- **Grafo globale** (`components/GlobalGraph/`) — vista force-directed dell'intero vault. Riusa il simulatore `MiniGraph/layout.ts` con tuning vault-scale (200/400/600/800 iterations a step da n). Pan/zoom imperativi via `<g transform>` (no React re-render per frame). Click highlight 1-hop neighbors, double-click apre nota, search per titolo, fit-to-screen + zoom buttons. Auto-fit solo al primo settle, preserva pan/zoom su refetch.
-- **Callout block** (`components/Editor/extensions/Callout.ts`) — Tiptap block node proper con 6 kinds (note/info/tip/warning/danger/success). Markdown roundtrip Obsidian-compatible (`> [!kind]`) via custom serialize + markdown-it core ruler. Slash menu ha 6 entries dedicate. Sostituisce l'approssimazione blockquote+emoji di v0.2.
-- **Property index tipizzato** (`packages/core/src/query/`) — ogni frontmatter property estratta in colonne SQLite tipizzate (text/number/boolean/date/array). `detectProperty` + `extractProperties` con stesse regole del PropertyEditor.
-- **Query API** (`packages/core/src/query/index.ts`) — `DatabaseQuery` con filter/sort/group/folder/limit, `ScalarFilter` discriminated union (eq/in/has/lacks/lt/gt/lte/gte/contains), `DatabaseResult` con rows + group counts + totalCount.
-- **IPC channels** `db:query` (`runDatabaseQuery`) e `graph:full` (`getFullGraph`). Validazione: limite query clampato [1, 5000], filter keys non-empty (errore `INVALID_QUERY`).
-- **Stores nuovi**: `database.ts` (query state + auto-debounced re-run + watcher subscription), `mainView` field in `ui.ts` (editor/database/graph routing).
-- **TopBar** con view-switcher tab-style (3 icon buttons).
-- **Layout.tsx** route condizionalmente sulla `mainView`.
-- **30 test Vitest** per `query/index.ts` (detectProperty per ogni tipo, extractProperties, compile-time pattern checks). Totale suite: 140/140.
+- **Database view**: FilterBar tipizzata, sort multi-key, group-by, ColumnPicker.
+- **Grafo globale**: force-directed con pan/zoom imperativo, highlight 1-hop, search.
+- **Callout block**: Tiptap node con 6 kinds. Markdown roundtrip Obsidian-compatible.
+- **Property index tipizzato**: `note_properties` con colonne per tipo.
+- **Query API**: `DatabaseQuery` con filter/sort/group/folder/limit.
 
 ### v0.2 Added
 
-- **Test suite Vitest** in `packages/core` con 85 unit test che coprono `markdown/wikilinks` (parser stato a stati con code-block awareness), `markdown/parse` e `serialize` (round-trip frontmatter/body via gray-matter), `types/frontmatter` (type guards) e `vault/note` (`deriveTitleFromPath`, `loadNote`, `saveNote` con `MockFilesystemAdapter` in-memory). Script `pnpm test` cablato in turbo e nel job CI dopo `Format check`.
-- `apps/desktop/src/lib/timings.ts` raccoglie le costanti di debounce dell'editor (`AUTOSAVE_DEBOUNCE_MS`), del vault store (`VAULT_EVENT_REFRESH_MS`) e del backlinks panel (`BACKLINKS_REFETCH_MS`) con commenti sul perché dei valori scelti.
-- `docs/architecture.md` — overview ad alto livello con diagramma main↔renderer↔core, le tre invarianti del progetto (filesystem source of truth, core platform-agnostic, IPC come confine di sicurezza), flussi chiave (apertura vault, scrittura nota, wikilink autocomplete) e mappa "dove guardare per capire X".
-- Pre-commit hook via husky + lint-staged: ogni commit auto-formatta con Prettier e fixa con ESLint i file staged. Setup automatico via `prepare` script in `pnpm install`.
-- `scripts/seed-vault.mjs` — script Node che genera un vault di esempio con 6 note interconnesse via wikilink (idee, progetti, persone, libri, daily). Utile per primo avvio, demo, e onboarding contributor.
-- `.nvmrc` pinnato a Node 20 per coerenza fra contributor.
-
-### Fixed
-
-- **Slash menu in code block**: `/` all'inizio di una riga in un fenced code block apriva il popup. Fix: `allow({ state, range })` callback rifiuta dentro `codeBlock` ancestor o inline `code` mark.
-- **White screen on launch**: `electron/main.ts` cercava `preload.js` nella stessa directory di `main.js` ma electron-vite emette il preload come `out/preload/preload.mjs`. Senza preload, `window.ziba` era undefined e il primo IPC call schiantava React. Fix: path corretto + relax CSP in dev (Vite inietta inline scripts per React Refresh) tramite plugin Vite condizionale.
-- Aggiunto `<ErrorBoundary>` top-level: errori React in fase di render mostrano un pannello con stack + bottoni Ricarica/Continua invece di blank window.
+- **Search palette `Cmd/Ctrl+K`**: full-text search via SQLite FTS5.
+- **Tag system**: `#tag` nel body o `tags: []` in frontmatter.
+- **Property editor**: frontmatter come property tipizzate.
+- **Slash menu `/`**: popup blocchi inseribili.
+- **Mini-graph** locale (1-hop).
 
 ## [0.1.0] - In sviluppo
 
@@ -128,18 +139,21 @@ Prima release alpha della desktop app.
 
 ### Added
 
-- Monorepo Turborepo + pnpm workspaces con `packages/core` (logica condivisa, TypeScript puro) e `apps/desktop` (Electron + Vite + React)
-- Apertura e cambio di vault (cartella di file `.md` sul disco) con persistenza dell'ultimo vault aperto
-- File tree laterale con cartelle annidate, CRUD via menu contestuale, navigazione tastiera (frecce, Enter, F2, Delete)
-- Editor a blocchi Tiptap con markdown input rules native (`#`, `**`, `>`, `- `, ecc.)
-- Wikilink `[[...]]` con custom Tiptap node, autocomplete su `[[`, click per navigare, link rotti evidenziati, creazione automatica di note mancanti
-- Pannello backlinks che si aggiorna live al variare del vault
-- File watcher chokidar con detection di modifiche esterne e UI di risoluzione conflitto
-- Cache SQLite (`<vault>/.ziba/index.db`) per risoluzione titoli e backlink
-- Adapter pattern in `packages/core` (Filesystem, IndexStore, Watcher) per riusabilità futura su web e mobile
-- Build distributable via electron-builder per macOS (dmg+zip), Windows (NSIS), Linux (AppImage+deb)
-- ESLint + Prettier + EditorConfig per uniformità del codice
-- GitHub Actions CI: typecheck + lint + build su PR
+- Monorepo Turborepo + pnpm workspaces con `packages/core` e `apps/desktop`.
+- Apertura e cambio vault con persistenza dell'ultimo aperto.
+- File tree laterale con CRUD via context menu e navigazione tastiera.
+- Editor Tiptap con markdown shortcut nativi.
+- Wikilink `[[...]]` con autocomplete, navigazione, creazione automatica.
+- Pannello backlinks live.
+- Watcher chokidar con detection conflitti.
+- Cache SQLite in `<vault>/.ziba/index.db`.
+- Adapter pattern in `packages/core`.
+- Build distributable via electron-builder per macOS, Windows, Linux.
+- ESLint + Prettier + EditorConfig.
+- GitHub Actions CI.
 
-[Unreleased]: https://github.com/metaforismo/Ziba/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/metaforismo/Ziba/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/metaforismo/Ziba/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/metaforismo/Ziba/compare/v0.6.0...v1.0.0
+[0.6.0]: https://github.com/metaforismo/Ziba/compare/v0.1.0...v0.6.0
 [0.1.0]: https://github.com/metaforismo/Ziba/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Grazie per l'interesse. Ziba è un progetto open-source in fase **alpha** — og
 - [Setup ambiente](#setup-ambiente)
 - [Workflow di sviluppo](#workflow-di-sviluppo)
 - [Convenzioni di codice](#convenzioni-di-codice)
+- [Convenzioni del progetto](#convenzioni-del-progetto)
 - [Convenzioni dei commit](#convenzioni-dei-commit)
 - [Apertura di una PR](#apertura-di-una-pr)
 - [Decisioni architetturali](#decisioni-architetturali)
@@ -64,7 +65,7 @@ HMR sul renderer è attivo. Modifiche al main process richiedono un reload (elec
 pnpm typecheck   # tipi su tutto il monorepo
 pnpm lint        # ESLint su tutto il codice
 pnpm format:check
-pnpm test        # 85 test su packages/core
+pnpm test        # ~490 test (167 core + 326 desktop)
 pnpm build       # build di produzione
 ```
 
@@ -72,7 +73,7 @@ Tutti devono passare prima di aprire una PR.
 
 ### Pre-commit hook
 
-`pnpm install` configura automaticamente husky. Su ogni commit, lint-staged esegue `eslint --fix` + `prettier --write` solo sui file staged — tipicamente sotto un secondo. Se hai bisogno di skipparlo in un'emergenza: `git commit --no-verify`.
+`pnpm install` configura automaticamente husky. Su ogni commit, lint-staged esegue `eslint --fix` + `prettier --write` solo sui file staged — tipicamente sotto un secondo. Se l'hook fallisce, correggi la causa a monte invece di usare `--no-verify`.
 
 ## Workflow di sviluppo
 
@@ -104,7 +105,12 @@ Per qualsiasi cambiamento UI:
 
 ### 4. Test automatici
 
-Per `packages/core`, scrivi test (Vitest, in arrivo). Per ora siamo prevalentemente type-driven + manual smoke testing. Le PR di test setup sono benvenute.
+La suite usa Vitest in tutto il monorepo. La piramide attuale:
+
+- **Unit test per funzioni pure** (`packages/core`): parser, serializer, extractor frontmatter, helper relazioni, seed schemas. Non dipendono da Electron né da React — veloci, facili da scrivere.
+- **Integration test per adapter e IPC** (`apps/desktop/electron/adapters/`): usano SQLite in-memory (`:memory:`) su SQL puro, senza istanziare `SqliteIndexStore`. Il pattern è deliberato: `SqliteIndexStore` accoppia al path dell'app Electron e renderebbe i test dipendenti dall'ambiente. Vedi il commento di testa in `apps/desktop/electron/adapters/index-store-relations.test.ts` per la rationale documentata.
+- **Component test per React** (`apps/desktop/src/`): Vitest + jsdom + Testing Library. Coprono store Zustand (debounce, sequence-number guard, vault switch), componenti UI (PropertyEditor, RelationPickerPopup, DatabaseView helpers). Mockano `window.ziba` via `installMockIpc()`.
+- **Niente E2E per ora.** I test Playwright arriveranno quando ci sarà un bundle distribuito stabile. Per ora il smoke test manuale è sufficiente (vedi sezione sopra).
 
 ## Convenzioni di codice
 
@@ -137,6 +143,36 @@ Per `packages/core`, scrivi test (Vitest, in arrivo). Per ora siamo prevalenteme
 ### Stile
 
 ESLint + Prettier sono configurati. Esegui `pnpm lint --fix` e `pnpm format` prima di committare.
+
+## Convenzioni del progetto
+
+### Lingua
+
+- **UI in italiano.** Labels, placeholder, messaggi di errore → italiano.
+- **Commenti in inglese** (o italiano nei file `.md`). Il codice sorgente è internazionale; i commenti nel codice sono english per standard open-source.
+- **Commenti solo sul "perché"**, non sul "cosa". Un commento che descrive cosa fa una funzione è ridondante se il codice è leggibile. Documenta l'intenzione, il trade-off scelto, o il caso d'angolo non ovvio. Evita commenti stile "used by X" o "added for Y" — non reggono ai refactor.
+
+### TDD per funzioni pure
+
+Per ogni parser, serializer, extractor, helper frontmatter o funzione pura in `packages/core`: scrivi il test prima dell'implementazione. I test in `packages/core` non dipendono da niente di platform-specific e si scrivono in pochi minuti.
+
+### Adapter test con SQL puro in `:memory:`
+
+I test degli adapter (`apps/desktop/electron/adapters/`) instanziano `better-sqlite3` direttamente con `:memory:`, eseguono lo schema SQL da `packages/core/src/index-store/schema.ts` e poi testano le query SQL a basso livello. **Non** importano `SqliteIndexStore` perché quella classe accoppia ai path dell'app Electron e richiederebbe un ambiente Electron per girare. Il trade-off è documentato nel commento di testa di ogni file `*.test.ts` negli adapter.
+
+### Pre-commit hooks
+
+`pnpm install` configura husky automaticamente. Su ogni commit, `lint-staged` esegue `eslint --fix` + `prettier --write` solo sui file staged. Se un hook fallisce, **si risolve la causa** — non si usa `--no-verify`.
+
+### Phase pattern per feature complesse
+
+Le feature grandi seguono questo ciclo:
+
+1. **Spec** (`docs/superpowers/specs/`) — descrive il "cosa" e il "perché".
+2. **Plan** (`docs/superpowers/plans/`) — suddivide in task implementativi con ordine e dipendenze.
+3. **Implement** — TDD per la logica pura, smoke test manuale per l'UI.
+4. **Review** — almeno un maintainer; le PR che saltano i passaggi 1-2 per feature grandi vengono rispedite indietro.
+5. **Merge** — squash and merge su `main`.
 
 ## Convenzioni dei commit
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 Markdown locale come fonte unica di verità, database strutturati come Notion, grafo di connessioni come Obsidian. In futuro: AI-native (semantic search, auto-link, agent organizzativi).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-alpha%20%E2%80%94%20v0.5-orange)](#stato)
+[![Status](https://img.shields.io/badge/status-v1.0-blue)](#stato)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-[Filosofia](#filosofia--perché-Ziba) ·
+[Filosofia](#filosofia--perché-ziba) ·
 [Funzionalità](#funzionalità) ·
 [Architettura](#architettura) ·
 [Quick start](#quick-start) ·
+[Formato vault](#formato-vault) ·
 [Roadmap](#roadmap) ·
 [Contribuire](CONTRIBUTING.md)
 
@@ -28,10 +29,11 @@ Notion e Obsidian sono entrambi strumenti eccellenti, ma costringono a scegliere
 |  | **Notion** | **Obsidian** | **Ziba** |
 |---|---|---|---|
 | Storage | Cloud proprietario | File markdown locali | File markdown locali |
-| Block editor con `/` menu | ✅ | ❌ | ✅ (in roadmap) |
-| Database con property tipizzate | ✅ | Limitato | ✅ (in roadmap) |
+| Block editor con `/` menu | ✅ | ❌ | ✅ |
+| Database con property tipizzate | ✅ | Limitato | ✅ |
 | Wikilinks `[[...]]` + backlink | Limitato | ✅ | ✅ |
-| Knowledge graph | ❌ | ✅ | ✅ (in roadmap) |
+| Knowledge graph | ❌ | ✅ | ✅ (constellation mode v1.0) |
+| Oggetti tipizzati + relazioni | ❌ | ❌ | ✅ (v1.0) |
 | Lock-in | Sì | No | No |
 | Open source | No | No | ✅ |
 | AI nativa | Limitata | Plugin | In roadmap |
@@ -42,50 +44,59 @@ I tuoi dati restano file `.md` con frontmatter YAML sul tuo disco. Sincronizzabi
 
 ## Stato
 
-> **Alpha — v0.5 shipped, v0.6 in progettazione.** Non è ancora installabile come bundle distribuito. Funziona solo in modalità sviluppo (`pnpm dev`), ma il core è completo end-to-end: vault locale, editor a blocchi con wikilink/backlink, search FTS5, database con vista tabella/kanban/calendario, grafo globale, callout, embed `![[]]`, math LaTeX, IPC error surface tipizzato, toast UI. La base test è 340+ casi (140 core + 200 desktop) con typecheck e lint puliti.
+> **v1.0 — Object-Relational Foundation.** Non è ancora installabile come bundle distribuito; funziona in modalità sviluppo (`pnpm dev`). Il core è completo end-to-end: vault locale, editor a blocchi con wikilink/backlink, search FTS5, database con vista tabella/kanban/calendario, grafo globale con constellation mode (hull colorati per tipo, filtro per kind di relazione), oggetti tipizzati con schemi `.ziba/schema/*.yml`, ObjectPanel, TypesSection sidebar, IPC error surface tipizzato, toast UI.
 
 ## Funzionalità
 
 ### v0.1 — Foundation (✅ shipped)
 
-- 📂 **Vault locale** — scegli una cartella, è il tuo workspace. Source of truth = file `.md` sul disco.
-- 📝 **Editor Tiptap** con markdown shortcut nativi: `# ` → heading, `**testo**` → bold, `> ` → quote, `- ` → lista, ecc.
-- 🔗 **Wikilink `[[Nota]]`** con autocomplete su `[[`, click per navigare, link rotti evidenziati, creazione automatica della nota mancante
-- 🌳 **Sidebar** con file tree annidato, CRUD via context menu, navigazione completa da tastiera
-- 🔄 **Pannello backlink** che si aggiorna live al variare del vault
-- 👀 **Watcher su disco** con detection conflitti (vim, altri editor)
-- 💾 Autosave debounced
+- **Vault locale** — scegli una cartella, è il tuo workspace. Source of truth = file `.md` sul disco.
+- **Editor Tiptap** con markdown shortcut nativi: `# ` → heading, `**testo**` → bold, `> ` → quote, `- ` → lista, ecc.
+- **Wikilink `[[Nota]]`** con autocomplete su `[[`, click per navigare, link rotti evidenziati, creazione automatica della nota mancante.
+- **Sidebar** con file tree annidato, CRUD via context menu, navigazione completa da tastiera.
+- **Pannello backlink** che si aggiorna live al variare del vault.
+- **Watcher su disco** con detection conflitti (vim, altri editor).
+- Autosave debounced.
 
 ### v0.2 — Power editing (✅ shipped)
 
-- 🔍 **Search palette `Cmd/Ctrl+K`** — full-text search via SQLite FTS5 con sintassi booleana (`foo OR bar`, `"frase esatta"`, `-escludi`)
-- 🏷️ **Tag system** — `#tag` nel body o `tags: []` in frontmatter. Sidebar mostra Tag section con count, click filtra il file tree
-- 📊 **Property editor** — frontmatter come property tipizzate (text/number/date/boolean/url/multi-select) sopra l'editor
-- ⚡ **Slash menu `/`** — popup blocchi inseribili (heading, list, quote, code, hr, callout)
-- 🕸️ **Mini-graph** locale alla nota corrente (1-hop) nel right pane (tab "Grafo")
+- **Search palette `Cmd/Ctrl+K`** — full-text search via SQLite FTS5 con sintassi booleana (`foo OR bar`, `"frase esatta"`, `-escludi`).
+- **Tag system** — `#tag` nel body o `tags: []` in frontmatter. Sidebar mostra Tag section con count, click filtra il file tree.
+- **Property editor** — frontmatter come property tipizzate (text/number/date/boolean/url/multi-select) sopra l'editor.
+- **Slash menu `/`** — popup blocchi inseribili (heading, list, quote, code, hr, callout).
+- **Mini-graph** locale alla nota corrente (1-hop) nel right pane.
 
 ### v0.3 — Database & graph (✅ shipped)
 
-- 🗄️ **Database view** — vista tabellare di tutto il vault con FilterBar tipizzata (eq/contains/has/lacks/lt/gt/lte/gte), sort multi-key, group-by su qualsiasi property, ColumnPicker. Triggered dal pulsante "Database" in TopBar.
-- 🌐 **Grafo globale** — vista force-directed dell'intero vault con pan/zoom (anchora sul cursore), search, click highlight 1-hop neighbors, double-click apre. Triggered dal pulsante "Grafo" in TopBar.
-- 💡 **Callout block** — Tiptap node con 6 kinds (note, info, tip, warning, danger, success). Markdown roundtrip Obsidian-compatible (`> [!kind]`).
-- 🔢 **Typed property index** — ogni frontmatter property estratta in colonne SQLite tipizzate per query veloci
+- **Database view** — vista tabellare di tutto il vault con FilterBar tipizzata (eq/contains/has/lacks/lt/gt/lte/gte), sort multi-key, group-by su qualsiasi property, ColumnPicker.
+- **Grafo globale** — vista force-directed con pan/zoom, search, click highlight 1-hop neighbors, double-click apre.
+- **Callout block** — Tiptap node con 6 kinds (note, info, tip, warning, danger, success). Markdown roundtrip Obsidian-compatible (`> [!kind]`).
+- **Typed property index** — ogni frontmatter property estratta in colonne SQLite tipizzate per query veloci.
 
 ### v0.4 — DB sub-views + blocchi avanzati (✅ shipped)
 
-- 📋 **Board view (kanban)** — sub-mode del Database: colonne raggruppate per property, drag-and-drop per spostare le note tra colonne. Aggiorna direttamente il frontmatter sul disco. Multi-select friendly (string-array).
-- 🗓️ **Calendar view** — sub-mode del Database: griglia mensile italiana (Lun-Dom), navigazione prev/next/oggi, note posizionate nel giorno della loro property data. Click → apre.
-- ↪️ **Embed block** — `![[Nota]]` mostra il contenuto di un'altra nota inline (read-only). Markdown roundtrip Obsidian-compatible. Lazy-load del target.
-- ∑ **Math (KaTeX)** — formule LaTeX con `$$..$$` block e `$..$` inline. Click sul rendering → editor LaTeX live preview. Markdown roundtrip nativo.
+- **Board view (kanban)** — colonne raggruppate per property, drag-and-drop per spostare le note tra colonne. Aggiorna direttamente il frontmatter sul disco.
+- **Calendar view** — griglia mensile italiana (Lun-Dom), navigazione prev/next/oggi.
+- **Embed block** — `![[Nota]]` mostra il contenuto inline. Markdown roundtrip Obsidian-compatible.
+- **Math (KaTeX)** — formule LaTeX con `$$..$$` block e `$..$` inline. Click → editor LaTeX live preview.
 
 ### v0.5 — Hardening + UX polish (✅ shipped)
 
-- 🛡️ **IPC error surface tipizzato** — `IpcErrorCode` derivato dal type union, `extractIpcErrorCode` / `ipcErrorMessage` helper round-trippano `code` su due path indipendenti (own property + `[CODE]` message prefix). Defense-in-depth contro structured-clone changes futuri di Electron.
-- 🍞 **Toast surface globale** — sostituisce `window.alert` ovunque. Non-blocking, color-coded per kind (info/success/warning/error), auto-dismiss configurabile, `role="alert"` per gli errori. Tutte le mutazioni della sidebar passano attraverso il toast.
-- ⚙️ **Two-stage error split nelle mutazioni** — IPC failure dice "Impossibile X"; refresh/follow-up failure dice "X riuscito ma aggiornamento fallito" (truthful — l'azione È accaduta sul disco). Pinned da test dedicati.
-- ⌨️ **Keyboard shortcuts** — `Cmd/Ctrl+S` salva, `Cmd/Ctrl+N` apre la prompt nuova nota, `Cmd/Ctrl+K` (già v0.2) apre la search palette.
-- 🏗️ **Refactor**: Sidebar 553 → ~340 righe (`useSidebarMutations` hook + `<SidebarDialogs>` component); `index-store.sqlite.ts` 882 → 745 con query-builder estratto come modulo puro; `Fragment` discriminated union (`predicate / always-false / always-true`) consente short-circuit della query quando un filtro è unsatisfiable.
-- 🎨 **DST anchor**, **KaTeX LRU cache**, **scanInlineMath** Pandoc-style guards, **CalendarView/BoardView memo stability** con `EMPTY_ROWS` frozen const.
+- **IPC error surface tipizzato** — `IpcErrorCode` derivato dal type union, helper `extractIpcErrorCode` / `ipcErrorMessage`.
+- **Toast surface globale** — sostituisce `window.alert`. Non-blocking, color-coded, auto-dismiss.
+- **Two-stage error split nelle mutazioni** — IPC failure vs refresh failure: messaggi distinti e truthful.
+- **Keyboard shortcuts** — `Cmd/Ctrl+S` salva, `Cmd/Ctrl+N` nuova nota.
+- **Refactor**: Sidebar split, query-builder estratto come modulo puro, `Fragment` discriminated union.
+
+### v1.0 — Typed objects + relations (✅ shipped)
+
+Ogni nota può dichiararsi un oggetto tipizzato (`type:`) e dichiarare relazioni tipizzate (`relations:`) verso altri oggetti. Lo schema per ogni tipo vive in `.ziba/schema/<type>.yml`.
+
+- **Schema + indexer + relations table** — sette schemi seed, tabella SQLite `relations` con `kind` tipizzato. Backward-compatible: wikilink generici restano nel grafo come `kind = ''`.
+- **ObjectPanel + sidebar TypesSection** — pannello relazioni sulla nota corrente; contatori per tipo in sidebar.
+- **Editor type-icon + slash relation** — icona di tipo nei wikilink; slash menu `/relazione` per inserire relazioni tipizzate.
+- **Database view type filter** — filtro per tipo; colonne suggerite seguono lo schema.
+- **Constellation graph** — hull colorati per tipo, filtro multi-select per kind di relazione, leggenda in overlay.
 
 ### In arrivo
 
@@ -96,7 +107,7 @@ Vedi la [roadmap](#roadmap).
 ```
 ziba/
 ├── apps/
-│   └── desktop/              # App Electron (l'unica nell'MVP v0.1)
+│   └── desktop/              # App Electron
 │       ├── electron/         # Main process: IPC, fs, SQLite, watcher
 │       ├── src/              # Renderer: React + Tiptap + Tailwind + Zustand
 │       └── shared/           # Contratto IPC tipizzato (main ↔ renderer)
@@ -107,7 +118,8 @@ ziba/
     │       ├── markdown/     # Parser, serializer, wikilink extractor
     │       ├── vault/        # Scan, indicizzazione, load/save note
     │       ├── index-store/  # Schema SQLite condiviso
-    │       └── types/        # Tipi domain (Note, Frontmatter, NotePath)
+    │       ├── seed-schemas/ # Sette schemi seed (note, person, book, …)
+    │       └── types/        # Tipi domain (Note, Frontmatter, ObjectTypeSchema)
     └── tsconfig/             # Config TypeScript condivisa
 ```
 
@@ -179,7 +191,7 @@ Per provare le funzionalità senza preparare un vault da zero:
 node scripts/seed-vault.mjs ./sample-vault
 ```
 
-Genera 6 note interconnesse via wikilink (idee, progetti, persone, libri, daily). Poi apri `./sample-vault` da Ziba e clicca tra le note per vedere il funzionamento di autocomplete, navigazione e backlink.
+Genera 6 note interconnesse via wikilink (idee, progetti, persone, libri, daily). Poi apri `./sample-vault` da Ziba.
 
 ### Verifica
 
@@ -196,23 +208,96 @@ pnpm --filter ziba-desktop run dist:win     # NSIS installer
 pnpm --filter ziba-desktop run dist:linux   # AppImage + .deb
 ```
 
-> ⚠️ Non c'è ancora code signing. Su macOS l'app non firmata richiede "Apri" dal menu contestuale del Finder la prima volta.
+> Non c'è ancora code signing. Su macOS l'app non firmata richiede "Apri" dal menu contestuale del Finder la prima volta.
+
+## Formato vault
+
+Un vault Ziba è una directory di file markdown. Ziba aggiunge una sola sottodirectory `.ziba/` per i propri dati:
+
+```
+my-vault/
+├── tolkien.md
+├── projects/
+│   └── ziba.md
+└── .ziba/
+    ├── index.db          # cache SQLite (rigenerabile, mai autoritativa)
+    └── schema/
+        ├── book.yml
+        ├── person.yml
+        └── note.yml
+```
+
+### Oggetti tipizzati (v1.0)
+
+Aggiungi `type:` al frontmatter di una nota per dichiararla un oggetto tipizzato. Le relazioni verso altri oggetti vanno sotto `relations:`:
+
+```markdown
+---
+type: book
+title: The Hobbit
+year: 1937
+relations:
+  author: "[[Tolkien]]"
+---
+
+Il libro che ha…
+```
+
+Lo schema del tipo — che definisce quali property e relazioni ha senso aspettarsi — vive in `.ziba/schema/book.yml`:
+
+```yaml
+# .ziba/schema/book.yml
+id: book
+label: Libro
+icon: 📖
+color: "#6366f1"
+properties:
+  title:
+    type: text
+    required: true
+  year:
+    type: number
+relations:
+  author:
+    target: person
+    label: Autore
+  in_series:
+    target: book
+    label: Serie
+inverse:
+  cited_by:
+    reverse_of: cites
+    label: Citato da
+```
+
+Gli schemi sono **soft**: documentano l'intenzione + guidano la UI (property panel, relation picker, colori del grafo), ma non bloccano il salvataggio di valori fuori-spec.
+
+I wikilink nel body senza `type:` e `relations:` continuano a funzionare come prima (relazioni untyped, `kind = ''`).
+
+Per la specifica completa del formato vault (layout directory, campi schema, tipi di property, slug convention) vedi [`docs/vault-format.md`](docs/vault-format.md).
 
 ## Roadmap
 
-| Versione | Tema | Funzionalità chiave |
-|---|---|---|
-| ✅ v0.1 | Foundation desktop | Vault + editor + wikilink + backlink + watcher |
-| ✅ v0.2 | Power editing | Search FTS5 (Cmd+K), property editor, tag system, slash menu, mini-graph |
-| ✅ v0.3 | Database & graph | Database table view, grafo globale interattivo, callout block proper |
-| ✅ v0.4 | DB sub-views + blocchi | Kanban view, calendar view, embed `![[...]]`, math (KaTeX) `$$...$$` |
-| ✅ v0.5 | Hardening + UX polish | IPC error surface, toast UI, two-stage error split, Cmd+S/Cmd+N shortcuts, Sidebar refactor, query-builder split |
-| v0.6 (next) | Plugin system foundation | Manifest + capabilities + lifecycle, sandboxed plugin contexts, first-party plugin examples |
-| v1.0 | Web build + sync | Web app via OPFS / remote sync, plugin marketplace, theme switcher, multi-vault |
-| v1.x | AI-native | Semantic search, auto-link, agent organizzativi |
-| v1.0 | Multi-piattaforma | Web app, plugin system, sync via filesystem-cloud (Dropbox/iCloud/Drive) |
-| v1.x | AI native | Embeddings locali, semantic search, auto-link suggestions, Q&A sul vault, agent organizzativi |
-| v1.5+ | Mobile | Expo app (iOS/Android), sync server custom |
+### Fatto
+
+- **v0.x** — vault open, editor, properties, tags, backlinks, full-text search,
+  database view (table/board/calendar), global graph, embed, math (KaTeX),
+  IPC error surface, toast UI, keyboard shortcuts.
+- **v1.0** — typed objects + relations, ObjectPanel, TypesSection sidebar,
+  type-filtered database, constellation graph (hull colorati, kind filter,
+  leggenda).
+
+### Next (v1.x)
+
+- **Filter unification**: un singolo `selectedType` condiviso tra Sidebar,
+  DatabaseView e GlobalGraph (attualmente store indipendenti).
+- **Aliased relations** nei popup di inserimento (`[[Target|Display]]`).
+- **Plugin system foundation** — l'object model offre la base strutturale.
+- **Performance**: Web Worker per il layout del grafo; batch IPC per la
+  risoluzione wikilink.
+- **Web port** — multi-fase; `packages/core` è già pure TS.
+- **Mobile** — read-only client Expo, futuro più lontano.
+- **AI-native** — semantic search, auto-link, agent organizzativi.
 
 Le issue del repository taggano la versione obiettivo. La roadmap è indicativa, non promessa di delivery.
 

--- a/apps/desktop/electron/ipc/notes.ts
+++ b/apps/desktop/electron/ipc/notes.ts
@@ -8,6 +8,7 @@
 
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
+import { BrowserWindow } from 'electron';
 import {
   deriveTitleFromPath,
   extractAllRelations,
@@ -26,8 +27,27 @@ import {
   type ResolvedRelation,
 } from '@ziba/core';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
+import { IpcChannels, type VaultEventPayload } from '../../shared/ipc.js';
 import { assertResolvedWithinVault, assertVaultRelative, IpcError } from '../security.js';
 import { markSelfWrite, requireIndexStore, requireVault } from '../state.js';
+
+/**
+ * Push a synthetic 'change' vault event to the renderer after a
+ * renderer-initiated write. The chokidar watcher suppresses its own echo
+ * for self-writes via `consumeIfSelfWrite`, so without this push the stores
+ * that depend on `onVaultEvent` (typedPaths, tags, database) would stay
+ * stale until the next external filesystem event.
+ */
+function pushSyntheticChangeEvent(notePath: NotePath, mtimeMs: number): void {
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win !== undefined && !win.isDestroyed()) {
+    win.webContents.send(IpcChannels.vaultEvent, {
+      type: 'change',
+      path: notePath,
+      mtimeMs,
+    } satisfies VaultEventPayload);
+  }
+}
 
 const SEARCH_LIMIT_DEFAULT = 20;
 const SEARCH_LIMIT_MAX = 100;
@@ -126,6 +146,11 @@ export async function saveNote(args: {
 
   await reindexSingle(args.path, args.body, args.frontmatter, st.mtimeMs);
 
+  // The watcher suppressed its own echo for this write. Push a synthetic
+  // change event so the renderer's onVaultEvent fires and refreshes
+  // typedPaths, tags, and the database store.
+  pushSyntheticChangeEvent(args.path, st.mtimeMs);
+
   return { mtimeMs: st.mtimeMs };
 }
 
@@ -153,6 +178,10 @@ export async function createNote(args: { path: NotePath; initialBody?: string })
 
   const st = await fs.stat(abs);
   await reindexSingle(args.path, body, frontmatter, st.mtimeMs);
+
+  // Watcher echo suppressed for this write. Push a synthetic add/change
+  // event so the renderer learns about the new file immediately.
+  pushSyntheticChangeEvent(args.path, st.mtimeMs);
 
   const title = parseMarkdown(body).headingTitle ?? deriveTitleFromPath(args.path);
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ziba-desktop",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "out/main/main.js",

--- a/apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx
+++ b/apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx
@@ -25,8 +25,8 @@ describe('<RelationPickerPopup>', () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(screen.getByRole('button', { name: 'author' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'cites' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Usa tipo author' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Usa tipo cites' })).toBeInTheDocument();
   });
 
   it('calls onCancel when Escape is pressed', () => {
@@ -93,7 +93,7 @@ describe('<RelationPickerPopup>', () => {
         onCancel={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'author' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Usa tipo author' }));
     expect((screen.getByPlaceholderText('Tipo di relazione') as HTMLInputElement).value).toBe(
       'author',
     );
@@ -117,5 +117,54 @@ describe('<RelationPickerPopup>', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Inserisci' }));
     expect(onCommit).toHaveBeenCalledWith({ kind: 'author', target: 'Tolkien' });
+  });
+
+  it('does not let Tab escape the dialog forward from the last focusable', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    // With empty fields, Inserisci is disabled; last enabled focusable is Annulla.
+    const annulla = screen.getByRole('button', { name: 'Annulla' });
+    annulla.focus();
+    // Simulate Tab on the last focusable; focus should cycle to the first.
+    fireEvent.keyDown(annulla, { key: 'Tab' });
+    // Focus moves to the first focusable, which is the kind input.
+    const kindInput = screen.getByPlaceholderText('Tipo di relazione');
+    expect(kindInput).toHaveFocus();
+  });
+
+  it('does not let Shift+Tab escape the dialog backward from the first focusable', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const kindInput = screen.getByPlaceholderText('Tipo di relazione');
+    kindInput.focus();
+    fireEvent.keyDown(kindInput, { key: 'Tab', shiftKey: true });
+    // With empty fields, last enabled focusable is Annulla (Inserisci is disabled).
+    const annulla = screen.getByRole('button', { name: 'Annulla' });
+    expect(annulla).toHaveFocus();
+  });
+
+  it('has aria-modal="true"', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Aggiungi relazione' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
   });
 });

--- a/apps/desktop/src/components/Editor/RelationPickerPopup.tsx
+++ b/apps/desktop/src/components/Editor/RelationPickerPopup.tsx
@@ -32,9 +32,35 @@ export function RelationPickerPopup(props: RelationPickerPopupProps): JSX.Elemen
   const [kind, setKind] = useState('');
   const [target, setTarget] = useState('');
   const kindInputRef = useRef<HTMLInputElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     kindInputRef.current?.focus();
+  }, []);
+
+  // Focus trap: cycle Tab/Shift+Tab within the dialog so keyboard focus
+  // never escapes into the editor while the popup is open.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Tab') return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'input:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener('keydown', onKeyDown);
+    return (): void => dialog.removeEventListener('keydown', onKeyDown);
   }, []);
 
   useEffect(() => {
@@ -72,8 +98,10 @@ export function RelationPickerPopup(props: RelationPickerPopupProps): JSX.Elemen
 
   return createPortal(
     <div
+      ref={dialogRef}
       role="dialog"
       aria-label="Aggiungi relazione"
+      aria-modal="true"
       className="fixed z-50 w-72 rounded-md border border-border bg-bg-subtle p-3 shadow-lg"
       style={{ top: placement.top, left: placement.left }}
     >
@@ -100,7 +128,8 @@ export function RelationPickerPopup(props: RelationPickerPopupProps): JSX.Elemen
                 key={k}
                 type="button"
                 onClick={(): void => setKind(k)}
-                className="rounded border border-border bg-bg px-2 py-0.5 text-xs text-fg-subtle hover:bg-accent/10 hover:text-fg"
+                aria-label={`Usa tipo ${k}`}
+                className="rounded border border-border bg-bg px-2 py-0.5 text-xs text-fg-subtle hover:bg-accent/10 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
               >
                 {k}
               </button>

--- a/apps/desktop/src/components/Editor/extensions/Wikilink.ts
+++ b/apps/desktop/src/components/Editor/extensions/Wikilink.ts
@@ -106,23 +106,30 @@ export const Wikilink = Node.create<WikilinkOptions>({
 
     const iconMap = this.storage?.typeIconByPath as Map<string, string> | undefined;
     const icon = resolvedPath !== null ? iconMap?.get(resolvedPath) : undefined;
-    const labelText = icon !== undefined ? `${icon} ${display}` : display;
 
     const baseClass = 'ziba-wikilink';
     const stateClass = isResolved ? 'ziba-wikilink--resolved' : 'ziba-wikilink--broken';
 
-    return [
-      'span',
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        'data-wikilink': '',
-        'data-target': target,
-        class: `${baseClass} ${stateClass}`,
-        // Allow the click handler in <Editor /> to find the node attribute
-        // without inspecting the ProseMirror state. Also useful for
-        // copy-paste fallback: the inner text round-trips as the alias.
-      }),
-      labelText,
-    ];
+    const attrs = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+      'data-wikilink': '',
+      'data-target': target,
+      class: `${baseClass} ${stateClass}`,
+      // Allow the click handler in <Editor /> to find the node attribute
+      // without inspecting the ProseMirror state. Also useful for
+      // copy-paste fallback: the inner text round-trips as the alias.
+    });
+
+    // Render the type icon inside an aria-hidden span so screen readers
+    // announce the link target text without reading out the emoji glyph.
+    if (icon !== undefined) {
+      return [
+        'span',
+        attrs,
+        ['span', { 'aria-hidden': 'true', class: 'ziba-wikilink__icon' }, `${icon} `],
+        display,
+      ];
+    }
+    return ['span', attrs, display];
   },
 
   /**

--- a/apps/desktop/src/components/GlobalGraph/Canvas.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.tsx
@@ -193,6 +193,16 @@ export const Canvas = memo(
       [],
     );
 
+    // O(N) Map built once per nodes reference change. Edges reference nodes
+    // by id for every render; without this Map each edge lookup would be
+    // O(N), making edge rendering O(E·N) — ~5M comparisons at 1000 nodes /
+    // 5000 edges. The Map keeps it O(E).
+    const nodeById = useMemo(() => {
+      const m = new Map<NotePath, CanvasNode>();
+      for (const n of nodes) m.set(n.id, n);
+      return m;
+    }, [nodes]);
+
     // Degree threshold for showing labels. Recomputed on every render but
     // it's a single pass over `nodes` and the parent already memoised the
     // degree value into each CanvasNode.
@@ -271,8 +281,8 @@ export const Canvas = memo(
           {/* Edges first so node circles paint on top. */}
           <g pointerEvents="none">
             {edges.map((e, i) => {
-              const a = nodeIndex(nodes, e.source);
-              const b = nodeIndex(nodes, e.target);
+              const a = nodeById.get(e.source) ?? null;
+              const b = nodeById.get(e.target) ?? null;
               if (a === null || b === null) return null;
               const highlight =
                 hasSelection && (e.source === selectedId || e.target === selectedId);
@@ -377,17 +387,6 @@ export const Canvas = memo(
 
 function nodeMatchesType(n: CanvasNode, type: string): boolean {
   return n.type === type;
-}
-
-// Linear scan because for n < 1000 it is faster than building a Map
-// (the constant factor of the hash function dominates), and we already
-// pay an O(n) reconcile pass over `nodes` in JSX. If we ever push past
-// 5000 we should swap this for a Map computed once per layout settle.
-function nodeIndex(nodes: CanvasNode[], id: NotePath): CanvasNode | null {
-  for (const n of nodes) {
-    if (n.id === id) return n;
-  }
-  return null;
 }
 
 function labelDegreeAtQuantile(nodes: CanvasNode[], q: number): number {

--- a/apps/desktop/src/components/GlobalGraph/HullsLayer.tsx
+++ b/apps/desktop/src/components/GlobalGraph/HullsLayer.tsx
@@ -4,8 +4,8 @@ import { convexHull } from './convexHull';
 import type { CanvasNode } from './Canvas';
 
 const MIN_NODES_FOR_HULL = 3;
-const HULL_FILL_OPACITY = 0.08;
-const HULL_STROKE_OPACITY = 0.25;
+const HULL_FILL_OPACITY = 0.15;
+const HULL_STROKE_OPACITY = 0.5;
 const HULL_PADDING = 24;
 
 type Props = {

--- a/apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx
+++ b/apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx
@@ -68,4 +68,20 @@ describe('<RelationsSection>', () => {
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByText('Tipo e destinazione sono entrambi obbligatori.')).toBeInTheDocument();
   });
+
+  it('the delete button is keyboard-focusable and visible when focused', () => {
+    render(
+      <RelationsSection
+        frontmatter={{ relations: { author: '[[Tolkien]]' } }}
+        suggestedKinds={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Rimuovi relazione author → Tolkien' });
+    btn.focus();
+    expect(btn).toHaveFocus();
+    // Tailwind utilities — we can't trivially inspect computed opacity in jsdom,
+    // but we can assert the class is present so the focus state has its hook.
+    expect(btn.className).toMatch(/focus.*opacity-100/);
+  });
 });

--- a/apps/desktop/src/components/PropertyEditor/RelationsSection.tsx
+++ b/apps/desktop/src/components/PropertyEditor/RelationsSection.tsx
@@ -68,7 +68,7 @@ export function RelationsSection({
             {rows.map((r) => (
               <li
                 key={`${r.kind}|${r.target}`}
-                className="group flex min-h-[28px] items-center gap-2 rounded px-1 hover:bg-bg-subtle"
+                className="group flex min-h-[28px] items-center gap-2 rounded px-1 hover:bg-bg-subtle focus-within:bg-bg-subtle"
               >
                 <span className="shrink-0 font-mono text-xs uppercase tracking-wide text-fg-muted">
                   {r.kind}
@@ -83,7 +83,7 @@ export function RelationsSection({
                   onClick={(): void =>
                     onChange(removeRelationFromFrontmatter(frontmatter, r.kind, r.target))
                   }
-                  className="rounded px-1 text-fg-muted opacity-0 group-hover:opacity-100 hover:bg-bg-muted hover:text-fg"
+                  className="rounded px-1 text-fg-muted opacity-0 transition-opacity group-hover:opacity-100 hover:bg-bg-muted hover:text-fg focus:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
                 >
                   ×
                 </button>

--- a/apps/desktop/src/lib/kind-color.test.ts
+++ b/apps/desktop/src/lib/kind-color.test.ts
@@ -18,6 +18,6 @@ describe('kindToHsl', () => {
   });
 
   it('returns a neutral grey for the empty-string sentinel (generic body wikilinks)', () => {
-    expect(kindToHsl('')).toBe('hsl(0, 0%, 60%)');
+    expect(kindToHsl('')).toBe('hsl(0, 0%, 45%)');
   });
 });

--- a/apps/desktop/src/lib/kind-color.ts
+++ b/apps/desktop/src/lib/kind-color.ts
@@ -1,5 +1,5 @@
-const SATURATION_PCT = 55;
-const LIGHTNESS_PCT = 55;
+const SATURATION_PCT = 60;
+const LIGHTNESS_PCT = 42;
 
 /**
  * Deterministic kind → HSL color. The empty-string sentinel (generic
@@ -12,7 +12,7 @@ const LIGHTNESS_PCT = 55;
  * fixed so the palette stays visually coherent across kinds.
  */
 export function kindToHsl(kind: string): string {
-  if (kind === '') return 'hsl(0, 0%, 60%)';
+  if (kind === '') return 'hsl(0, 0%, 45%)';
   let hash = 5381;
   for (let i = 0; i < kind.length; i++) {
     hash = ((hash << 5) + hash + kind.charCodeAt(i)) | 0;

--- a/apps/desktop/src/lib/relations-frontmatter.test.ts
+++ b/apps/desktop/src/lib/relations-frontmatter.test.ts
@@ -66,6 +66,21 @@ describe('setRelationInFrontmatter', () => {
       cites: '[[A]]',
     });
   });
+
+  it('preserves alias when provided', () => {
+    const result = setRelationInFrontmatter({}, 'author', 'Tolkien', { alias: 'JRR' });
+    expect(result.relations).toEqual({ author: '[[Tolkien|JRR]]' });
+  });
+
+  it('preserves heading when provided', () => {
+    const result = setRelationInFrontmatter({}, 'cites', 'Book', { heading: 'chapter-3' });
+    expect(result.relations).toEqual({ cites: '[[Book#chapter-3]]' });
+  });
+
+  it('preserves both alias and heading', () => {
+    const result = setRelationInFrontmatter({}, 'cites', 'Book', { heading: 'ch3', alias: 'Ch3' });
+    expect(result.relations).toEqual({ cites: '[[Book#ch3|Ch3]]' });
+  });
 });
 
 describe('removeRelationFromFrontmatter', () => {

--- a/apps/desktop/src/lib/relations-frontmatter.ts
+++ b/apps/desktop/src/lib/relations-frontmatter.ts
@@ -52,8 +52,19 @@ export function setRelationInFrontmatter(
   fm: Frontmatter,
   kind: string,
   target: string,
+  options?: { alias?: string | null; heading?: string | null },
 ): Frontmatter {
-  const link = `[[${target}]]`;
+  // Build the wikilink inner text: [[target#heading|alias]] when provided.
+  // Callers that omit `options` get plain [[target]] — backward compatible.
+  const alias = options?.alias ?? null;
+  const heading = options?.heading ?? null;
+  const inner = (() => {
+    let base = target;
+    if (heading !== null && heading !== '') base = `${target}#${heading}`;
+    if (alias !== null && alias !== '') return `${base}|${alias}`;
+    return base;
+  })();
+  const link = `[[${inner}]]`;
   const relsSource = isPlainObject(fm.relations) ? fm.relations : {};
   const existing = relsSource[kind];
 

--- a/apps/desktop/src/stores/database.test.ts
+++ b/apps/desktop/src/stores/database.test.ts
@@ -104,16 +104,16 @@ describe('useDatabaseStore — filter mutators', () => {
 });
 
 describe('useDatabaseStore — debounce + IPC', () => {
-  it('rapid query edits coalesce into a single IPC call', async () => {
+  it('rapid filter edits coalesce into a single debounced IPC call', async () => {
     const { useDatabaseStore, useVaultStore } = await loadStores();
     useVaultStore.setState({ current: FAKE_VAULT });
     vi.useFakeTimers();
     mock.setHandler(IpcChannels.runDatabaseQuery, async () => makeResult([]));
 
-    useDatabaseStore.getState().setSort([{ key: 'title', direction: 'asc' }]);
+    // Text-input style mutations — these go through scheduleRun (debounced).
     useDatabaseStore.getState().setFolder('projects');
-    useDatabaseStore.getState().setGroupBy('status');
     useDatabaseStore.getState().addFilter(EQ_FILTER);
+    useDatabaseStore.getState().addFilter(CONTAINS_FILTER);
     expect(mock.getSpy(IpcChannels.runDatabaseQuery)).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(220);
@@ -121,6 +121,22 @@ describe('useDatabaseStore — debounce + IPC', () => {
 
     // 200ms trailing-edge debounce → exactly one query.
     expect(mock.getSpy(IpcChannels.runDatabaseQuery)).toHaveBeenCalledTimes(1);
+  });
+
+  it('discrete actions (setSort, setGroupBy, setType) bypass the debounce', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    useVaultStore.setState({ current: FAKE_VAULT });
+    mock.setHandler(IpcChannels.runDatabaseQuery, async () => makeResult([]));
+
+    // Each discrete action fires runQuery immediately.
+    await useDatabaseStore.getState().setSort([{ key: 'title', direction: 'asc' }]);
+    expect(mock.getSpy(IpcChannels.runDatabaseQuery)).toHaveBeenCalledTimes(1);
+
+    await useDatabaseStore.getState().setGroupBy('status');
+    expect(mock.getSpy(IpcChannels.runDatabaseQuery)).toHaveBeenCalledTimes(2);
+
+    await useDatabaseStore.getState().setType('book');
+    expect(mock.getSpy(IpcChannels.runDatabaseQuery)).toHaveBeenCalledTimes(3);
   });
 
   it('runQuery populates result and derives availableProperties sorted', async () => {
@@ -250,6 +266,36 @@ describe('useDatabaseStore — vault subscription', () => {
     expect(s.result).toBeNull();
     expect(s.availableProperties).toEqual([]);
     expect(s.error).toBeNull();
+    unsub();
+  });
+
+  it('resets selectedType + query on vault switch (open A → open B)', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    const VAULT_A: VaultInfo = { root: '/tmp/v1', name: 'v1', openedAt: 0 };
+    const VAULT_B: VaultInfo = { root: '/tmp/v2', name: 'v2', openedAt: 1 };
+    useVaultStore.setState({ current: VAULT_A, notes: [] });
+    mock.setHandler(IpcChannels.runDatabaseQuery, async () => ({
+      rows: [],
+      groups: [],
+      totalCount: 0,
+    }));
+
+    const unsub = useDatabaseStore.getState().subscribeToVaultEvents();
+
+    // Simulate: user has set a type filter + custom query in vault A.
+    const userFilter: ScalarFilter = { kind: 'eq', key: 'year', value: 1937 };
+    useDatabaseStore.setState({
+      selectedType: 'book',
+      query: { filters: [userFilter], limit: 1000 },
+    });
+
+    // Switch to vault B.
+    useVaultStore.setState({ current: VAULT_B, notes: [] });
+    // Subscription is sync for the state reset; runQuery is async — yield.
+    await Promise.resolve();
+
+    expect(useDatabaseStore.getState().selectedType).toBeNull();
+    expect(useDatabaseStore.getState().query.filters).toEqual([]);
     unsub();
   });
 });

--- a/apps/desktop/src/stores/database.ts
+++ b/apps/desktop/src/stores/database.ts
@@ -135,7 +135,10 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
         next.sort = sort;
       }
       set({ query: next });
-      scheduleRun();
+      // Discrete action (dropdown / column header click) — run immediately
+      // rather than waiting out the keystroke debounce window.
+      debouncedRun.cancel();
+      void get().runQuery();
     },
 
     setGroupBy(key) {
@@ -146,7 +149,9 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
         next.groupBy = key;
       }
       set({ query: next });
-      scheduleRun();
+      // Discrete action — run immediately, cancel any pending debounced run.
+      debouncedRun.cancel();
+      void get().runQuery();
     },
 
     setFolder(folder) {
@@ -162,7 +167,10 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
 
     setType(type) {
       set({ selectedType: type });
-      scheduleRun();
+      // Discrete action (sidebar / TypeChip click) — run immediately rather
+      // than waiting out the keystroke debounce window.
+      debouncedRun.cancel();
+      void get().runQuery();
     },
 
     async runQuery() {
@@ -238,8 +246,20 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
             });
             return;
           }
-          // Vault opened or switched — fire an immediate query so the
-          // table is populated by the time the user clicks "Database".
+          // Vault switched (A → B) or freshly opened. Reset the page-level
+          // type filter and user filters so they don't bleed across vaults —
+          // the stale scope would silently hide rows in the new vault.
+          debouncedRun.cancel();
+          requestSeq++;
+          set({
+            selectedType: null,
+            query: INITIAL_QUERY,
+            result: null,
+            loading: false,
+            error: null,
+            availableProperties: [],
+            lastUpdatedAt: null,
+          });
           void get().runQuery();
           return;
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,9 +13,10 @@ Documento ad alto livello per chi vuole contribuire o capire come è strutturato
 │   │ Zustand stores     │  ◄── invoke ──►   │ ├─ vault              │       │
 │   │ lib/ipc (typed)    │   contextBridge   │ ├─ notes              │       │
 │   │                    │                   │ ├─ folder             │       │
-│   │ window.ziba   │  ──►  preload  ◄──│ ├─ links              │       │
+│   │ window.ziba        │  ──►  preload  ◄──│ ├─ links              │       │
 │   └────────────────────┘                   │ ├─ search / tags      │       │
 │                                            │ ├─ database / graph   │       │
+│                                            │ ├─ types / relations  │       │
 │                                            │ └─ settings           │       │
 │           ▲                                │                       │       │
 │           │ webContents.send               │ adapters              │       │
@@ -35,8 +36,11 @@ Documento ad alto livello per chi vuole contribuire o capire come è strutturato
             │                              │ Filesystem (vault/)           │
             │                              │  ├─ note1.md                  │
             │                              │  ├─ folder/note2.md           │
-            │                              │  └─ .ziba/index.db       │
-            │                              │     (SQLite cache, ricostr.)  │
+            │                              │  └─ .ziba/                    │
+            │                              │      ├─ index.db  (cache SQL) │
+            │                              │      └─ schema/               │
+            │                              │          ├─ book.yml          │
+            │                              │          └─ person.yml        │
             │                              └───────────────────────────────┘
             │
             │                              ┌───────────────────────────────┐
@@ -47,7 +51,8 @@ Documento ad alto livello per chi vuole contribuire o capire come è strutturato
                                            │  ├─ markdown/ (+ tags)        │
                                            │  ├─ query/ (DB query AST)     │
                                            │  ├─ vault/                    │
-                                           │  └─ index-store/ (schema SQL) │
+                                           │  ├─ index-store/ (schema SQL) │
+                                           │  └─ seed-schemas/             │
                                            └───────────────────────────────┘
 ```
 
@@ -122,11 +127,13 @@ Main: openVault()
    ├─ teardown() del vault precedente (se esiste)
    ├─ stat-check sul path (no filesystem root, deve essere directory)
    ├─ inizializza FilesystemAdapter, IndexStore (apre/crea index.db)
+   ├─ carica schemi da .ziba/schema/*.yml → popola object_types
    ├─ indexVault() ── push progress eventi ──► renderer
    ├─ avvia ChokidarWatcher ── eventi (filtrati per self-write) ──► renderer
    └─ persiste in recent-vaults.json
    ▼
 Renderer riceve VaultInfo, popola sidebar via listNotes()
+Renderer riceve typedPaths + objectTypeSchemas via types:list
 ```
 
 ### Scrittura di una nota
@@ -140,7 +147,7 @@ Main: saveNote()
    ├─ markSelfWrite(path)        ← previene self-watcher echo
    ├─ coreSaveNote() scrive il file (.md) sul disco
    ├─ stat() per leggere il vero mtime
-   └─ reindexSingle() aggiorna l'index (note + wikilinks)
+   └─ reindexSingle() aggiorna l'index (note + relations + object_types)
    ▼
 Watcher emette `change` per il path
 Main: consumeIfSelfWrite(path) → true → evento NON forwardato al renderer
@@ -168,6 +175,7 @@ Tiptap inserisce il custom Wikilink node (target = "Foo")
 useResolvedWikilinks hook: ipc.resolveTitle({ title }) per ogni link
    → aggiorna editor.storage.wikilink.resolved (true | false)
    → renderHTML stila link rotti diversamente
+   → legge editor.storage.wikilink.typeIconByPath per mostrare icona tipo
 ```
 
 ### Database query (v0.3)
@@ -179,7 +187,7 @@ Renderer (DatabaseView)
 useDatabaseStore.{addFilter|setSort|setGroupBy|...}
    │ debounced 200ms
    ▼
-ipc.runDatabaseQuery({ query: { filters, sort, groupBy, folder, limit } })
+ipc.runDatabaseQuery({ query: { filters, sort, groupBy, folder, typeFilter, limit } })
    ▼
 Main: runDatabaseQuery() in electron/ipc/database.ts
    ├─ valida filter keys non-empty (errore INVALID_QUERY)
@@ -187,6 +195,7 @@ Main: runDatabaseQuery() in electron/ipc/database.ts
    └─ store.runQuery(query) → SQL builder
        ├─ EXISTS subquery per ogni filter su note_properties
        ├─ LEFT JOIN per ogni sort key (mixed-type COALESCE)
+       ├─ JOIN su notes.path con relations per typeFilter (v1.0)
        └─ GROUP BY + COUNT su prop_value (se groupBy set)
    ▼
 Renderer riceve DatabaseResult { rows, groups, totalCount }
@@ -194,7 +203,7 @@ Renderer riceve DatabaseResult { rows, groups, totalCount }
 Table.tsx renderizza rows con cell type-aware
 ```
 
-### Grafo globale (v0.3)
+### Grafo globale (v0.3 + constellation mode v1.0)
 
 ```
 Renderer (GlobalGraph), su mount o vault event:
@@ -202,16 +211,20 @@ Renderer (GlobalGraph), su mount o vault event:
    ▼
 Main: getFullGraph()
    └─ store.getFullGraph() →
-       SELECT path, title FROM notes
-       SELECT source_path, target_path, target_title FROM wikilinks
+       SELECT path, title, frontmatter_json FROM notes
+       SELECT source_path, target_path, target_title, kind FROM relations
               WHERE target_path IS NOT NULL    ← solo edge risolti
    ▼
 Renderer riceve { nodes, edges }
    │ runGlobalLayout() — riusa simulateLayout di MiniGraph/layout.ts
-   │   con tuning vault-scale (n→iterations: 200/400/600/800)
+   │   con cluster bias per tipo (v1.0): nodi dello stesso tipo
+   │   partono vicini via forza attrattiva aggiuntiva
    ▼
 Canvas.tsx renderizza SVG con <g transform> imperativo
    pan/zoom non ri-rendera React → 1000+ nodi reggono
+   ▼
+HullsLayer.tsx disegna un convex hull per tipo (colore da schema)
+KindFilterDropdown + Legend filtrano gli edge per kind
 ```
 
 ### Callout block (v0.3)
@@ -247,70 +260,171 @@ type Note = {
   title: string;          // frontmatter.title > primo H1 > basename
   frontmatter: Record<string, unknown>;
   content: string;        // body markdown senza frontmatter
-  wikilinks: string[];    // target raw da [[...]]
+  wikilinks: string[];    // target raw da [[...]] (generico)
   mtimeMs: number;
 };
 ```
+
+### Frontmatter v1.0
+
+Con v1.0 una nota può dichiarare:
+
+```yaml
+---
+type: book          # slug che referenzia .ziba/schema/book.yml
+title: The Hobbit
+year: 1937
+relations:
+  author: "[[Tolkien]]"        # relazione scalare
+  genres:                      # relazione multipla
+    - "[[Fantasy]]"
+    - "[[Adventure]]"
+---
+```
+
+Il campo `type:` è opzionale. Se assente, la nota è indicizzata normalmente e i suoi wikilink nel body diventano relazioni di `kind = ''`.
+
+Il campo `relations:` è opzionale. I wikilink nel body (al di fuori di `relations:`) vengono anch'essi indicizzati come relazioni untyped per mantenere la backward-compat con i vault v0.x.
 
 ### Schema SQLite (cache)
 
 ```sql
 -- v0.1
-CREATE TABLE notes (
-  path TEXT PRIMARY KEY,
-  title TEXT NOT NULL,
+CREATE TABLE IF NOT EXISTS notes (
+  path             TEXT PRIMARY KEY,
+  title            TEXT NOT NULL,
   frontmatter_json TEXT NOT NULL DEFAULT '{}',
-  mtime INTEGER NOT NULL
+  mtime            INTEGER NOT NULL
 );
 
-CREATE TABLE wikilinks (
-  source_path TEXT NOT NULL,
+-- v1.0: sostituisce `wikilinks`. La tabella legacy viene droppata
+-- alla prima apertura di un vault v1.0 (MIGRATION_DROP_SQL).
+-- `kind` è NOT NULL con sentinel '' per wikilink generici del body.
+-- SQLite PRIMARY KEY richiede riferimenti a colonne (non espressioni),
+-- quindi "untyped" è codificato come '' anziché NULL.
+CREATE TABLE IF NOT EXISTS relations (
+  source_path  TEXT NOT NULL,
+  kind         TEXT NOT NULL DEFAULT '',
   target_title TEXT NOT NULL,
-  target_path TEXT,                   -- NULL se "broken" (titolo non trovato)
-  PRIMARY KEY (source_path, target_title)
+  target_path  TEXT,
+  PRIMARY KEY (source_path, kind, target_title),
+  FOREIGN KEY (source_path) REFERENCES notes(path) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_notes_title ON notes(LOWER(title));
-CREATE INDEX idx_wikilinks_target ON wikilinks(LOWER(target_title));
-CREATE INDEX idx_wikilinks_target_path ON wikilinks(target_path);
+CREATE INDEX IF NOT EXISTS idx_relations_target_title ON relations(target_title);
+CREATE INDEX IF NOT EXISTS idx_relations_target_path  ON relations(target_path, kind);
+CREATE INDEX IF NOT EXISTS idx_relations_kind         ON relations(kind) WHERE kind <> '';
 
--- v0.2 — full-text search (FTS5) + tags
-CREATE VIRTUAL TABLE notes_fts USING fts5(
-  path UNINDEXED, title, body,
+CREATE INDEX IF NOT EXISTS idx_notes_title ON notes(title);
+
+-- v1.0: cache degli schemi da <vault>/.ziba/schema/*.yml.
+-- Caricata all'apertura del vault; aggiornata in-place da hot-reload.
+-- Consumata da sidebar TypesSection (counts) e autocomplete editor.
+CREATE TABLE IF NOT EXISTS object_types (
+  id          TEXT PRIMARY KEY,
+  label       TEXT NOT NULL,
+  icon        TEXT,
+  color       TEXT,
+  schema_json TEXT NOT NULL,
+  mtime       INTEGER NOT NULL
+);
+
+-- Full-text search via FTS5
+CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
+  path UNINDEXED,
+  title,
+  body,
   tokenize = 'unicode61 remove_diacritics 2'
 );
 
-CREATE TABLE tags (
+-- Tags (una riga per nota × tag)
+CREATE TABLE IF NOT EXISTS tags (
   source_path TEXT NOT NULL,
-  tag TEXT NOT NULL,                  -- canonical lowercase
+  tag         TEXT NOT NULL,        -- canonical lowercase
   display_tag TEXT NOT NULL,
   PRIMARY KEY (source_path, tag),
   FOREIGN KEY (source_path) REFERENCES notes(path) ON DELETE CASCADE
 );
-CREATE INDEX idx_tags_tag ON tags(tag);
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
 
--- v0.3 — typed property index per query database view
-CREATE TABLE note_properties (
-  source_path TEXT NOT NULL,
-  prop_key TEXT NOT NULL,
-  prop_type TEXT NOT NULL,            -- text|number|boolean|date|url|string-array
-  text_value TEXT,
+-- v0.3: property index tipizzato per query database view
+CREATE TABLE IF NOT EXISTS note_properties (
+  source_path  TEXT NOT NULL,
+  prop_key     TEXT NOT NULL,
+  prop_type    TEXT NOT NULL,       -- text|number|boolean|date|url|string-array
+  text_value   TEXT,
   number_value REAL,
   boolean_value INTEGER,
-  date_value TEXT,                    -- ISO YYYY-MM-DD
-  array_value TEXT,                   -- JSON-encoded string[]
+  date_value   TEXT,               -- ISO YYYY-MM-DD
+  array_value  TEXT,               -- JSON-encoded string[]
   PRIMARY KEY (source_path, prop_key),
   FOREIGN KEY (source_path) REFERENCES notes(path) ON DELETE CASCADE
 );
-CREATE INDEX idx_note_props_key    ON note_properties(prop_key);
-CREATE INDEX idx_note_props_text   ON note_properties(prop_key, text_value);
-CREATE INDEX idx_note_props_number ON note_properties(prop_key, number_value);
-CREATE INDEX idx_note_props_date   ON note_properties(prop_key, date_value);
+CREATE INDEX IF NOT EXISTS idx_note_props_key    ON note_properties(prop_key);
+CREATE INDEX IF NOT EXISTS idx_note_props_text   ON note_properties(prop_key, text_value);
+CREATE INDEX IF NOT EXISTS idx_note_props_number ON note_properties(prop_key, number_value);
+CREATE INDEX IF NOT EXISTS idx_note_props_date   ON note_properties(prop_key, date_value);
 ```
 
-Tutti gli statement usano `IF NOT EXISTS` (omesso sopra per leggibilità) — vault esistenti aggiungono le nuove tabelle on-open senza migration script. La popolazione iniziale di `notes_fts`/`tags`/`note_properties` per vault già aperti avviene lazy: la prossima save di una nota popola la sua riga, oppure si esegue `vault:reindex` (IPC esistente) per ricostruire tutto.
+Tutti gli statement usano `IF NOT EXISTS` (omesso sopra per leggibilità) — vault esistenti aggiungono le nuove tabelle on-open senza migration script esplicito. Quando la versione dello schema (`EXPECTED_USER_VERSION`) sale, `MIGRATION_DROP_SQL` droppa e ricostruisce le tabelle cache — i file `.md` sul disco sono l'autorità, quindi nessun dato viene perso.
 
 Lo schema è in `packages/core/src/index-store/schema.ts` come stringa SQL pura — `packages/core` non importa `better-sqlite3`. Il binding al driver vive in `apps/desktop/electron/adapters/index-store.sqlite.ts`.
+
+## Schema files (.ziba/schema/*.yml)
+
+Ogni tipo di oggetto è descritto da un file YAML in `<vault>/.ziba/schema/<id>.yml`. Il ciclo di vita è:
+
+1. **Vault open**: il main process legge tutti i file `.yml` in `.ziba/schema/`, li parsa con `parseSchemaYaml` (da `packages/core/src/types/schema.ts`), e fa upsert in `object_types`.
+2. **Hot-reload**: chokidar watch su `.ziba/schema/`. Quando un file cambia, solo quel tipo viene ricaricato e `object_types` aggiornato in-place — niente full reindex.
+3. **Vault nuovo / schema assenti**: se `.ziba/schema/` è vuota, i sette seed schemas vengono copiati dal bundle (`packages/core/src/seed-schemas/`).
+4. **Errori**: `parseSchemaYaml` restituisce `{ ok: false, errors }` invece di lanciare — il loader segnala ogni schema rotto in un singolo pass invece di fermarsi al primo.
+
+La forma YAML valida:
+
+```yaml
+id: book            # slug ^[a-z][a-z0-9-]*$, obbligatorio
+label: Libro        # display name, obbligatorio
+icon: 📖            # emoji o stringa ≤ 2 char, opzionale
+color: "#6366f1"    # hex CSS #RRGGBB, opzionale
+properties:
+  year:
+    type: number    # text|number|boolean|date|url|string-array
+    required: true  # opzionale — avvisa ma non blocca il salvataggio
+    label: Anno     # opzionale — label nell'ObjectPanel
+relations:
+  author:
+    target: person  # id del tipo atteso (soft — non validato a salvataggio)
+    multiple: false # default false — accetta lista se true
+    label: Autore
+inverse:
+  cited_by:
+    reverse_of: cites  # kind su cui fare la join inversa
+    label: Citato da
+```
+
+## Renderer caches (v1.0)
+
+Tre cache nel renderer evitano round-trip IPC ridondanti:
+
+| Cache | Dove vive | Cosa contiene | Quando si aggiorna |
+|---|---|---|---|
+| `useVaultStore.typedPaths` | `stores/vault.ts` | Set di `NotePath` per le note che hanno `type:` | Al vault open via `notes:typedPaths`; su vault event debounced |
+| `useTagsStore.objectTypeSchemas` | `stores/tags.ts` | `Map<id, ObjectTypeSchema>` di tutti i tipi caricati | Al vault open via `types:list`; su hot-reload schema (vault event) |
+| `editor.storage.wikilink.typeIconByPath` | Tiptap extension `Wikilink.ts` | `Map<NotePath, string>` path → icona tipo | Aggiornato dalla extension dopo ogni risoluzione wikilink |
+
+## Canali IPC (v1.0 additions)
+
+Oltre ai canali esistenti (vault/notes/folder/links/search/tags/database/graph), v1.0 aggiunge:
+
+| Canale | Direzione | Descrizione |
+|---|---|---|
+| `notes:typedPaths` | main → renderer | Array di `NotePath` per le note con `type:` nel frontmatter |
+| `types:list` | renderer → main | Ritorna tutti gli `ObjectTypeSchema` caricati |
+| `types:counts` | renderer → main | Mappa `id → count` delle note per tipo |
+| `types:upsert` | renderer → main | Salva o aggiorna uno schema (interno, usato da hot-reload) |
+| `types:delete` | renderer → main | Rimuove un tipo dall'index (quando il file schema viene cancellato) |
+| `relations:bySource` | renderer → main | Tutte le relazioni partenti da `source_path` |
+| `relations:byTarget` | renderer → main | Tutte le relazioni in arrivo su `target_path` (backlinks tipizzati) |
 
 ## State management nel renderer
 
@@ -318,14 +432,26 @@ Sei store Zustand, ognuno con una sola responsabilità:
 
 | Store | File | Cosa contiene |
 |---|---|---|
-| `useVaultStore` | `stores/vault.ts` | Vault corrente, lista note, recent vaults, progresso indicizzazione. Coalesce gli eventi watcher in refresh debouncing (`VAULT_EVENT_REFRESH_MS`). |
+| `useVaultStore` | `stores/vault.ts` | Vault corrente, lista note, recent vaults, progresso indicizzazione, `typedPaths`. Coalesce gli eventi watcher in refresh debouncing (`VAULT_EVENT_REFRESH_MS`). |
 | `useEditorStore` | `stores/editor.ts` | Path/Note correnti aperti, dirty flag, errore di save. Gestisce l'apply degli external change. |
 | `useUiStore` | `stores/ui.ts` | Larghezza pannelli, backlinks aperto/chiuso, cartelle espanse, `mainView` (editor/database/graph), `rightPaneTab`, `tagsExpanded`. Persistito in localStorage chiave `ziba.ui.v1`. |
 | `useSearchStore` | `stores/search.ts` | Cmd+K palette: open/query/results/selectedIndex/loading. Debounce 150ms (`SEARCH_DEBOUNCE_MS`), sequence-number guard. |
-| `useTagsStore` | `stores/tags.ts` | Lista tag + count, tag selezionato, note del tag. Module-level subscribe a `useVaultStore` per refresh on vault switch e watcher events. |
-| `useDatabaseStore` | `stores/database.ts` | DatabaseView: query state (filters/sort/groupBy/folder), `result`, `loading`, `error`, `availableProperties`. Auto-debounced run su ogni mutation (`DATABASE_QUERY_DEBOUNCE_MS=200`). |
+| `useTagsStore` | `stores/tags.ts` | Lista tag + count, tag selezionato, note del tag, `objectTypeSchemas`. Module-level subscribe a `useVaultStore` per refresh on vault switch e watcher events. |
+| `useDatabaseStore` | `stores/database.ts` | DatabaseView: query state (filters/sort/groupBy/folder/typeFilter), `result`, `loading`, `error`, `availableProperties`. Auto-debounced run su ogni mutation (`DATABASE_QUERY_DEBOUNCE_MS=200`). |
 
 Niente Redux, niente Context grandi. Un componente che ha bisogno di stato ne sottoscrive un selettore preciso e si re-renderizza solo quando quel pezzo cambia.
+
+## Superfici UI aggiunte in v1.0
+
+| Componente | Dove | Cosa fa |
+|---|---|---|
+| `ObjectPanel` | Right pane, tab "Oggetto" | Mostra properties schema + relazioni inverse della nota corrente |
+| `TypesSection` | Sidebar | Sezione collapsible con counts per tipo; click filtra la file tree |
+| `TypeFilterDropdown` | DatabaseView header | Filtro per `type:` applicato prima della query |
+| `TypeChips` | GlobalGraph overlay | Chips per tipo visibile; toggle per mostrare/nascondere gli hull |
+| `KindFilterDropdown` | GlobalGraph toolbar | Multi-select per kind di relazione nel grafo |
+| `Legend` | GlobalGraph overlay | Legenda colori tipo + kind |
+| `HullsLayer` | GlobalGraph canvas | Convex hull SVG colorati per tipo, disegnati sotto i nodi |
 
 ## Fonti di verità per le timing constants
 
@@ -334,14 +460,15 @@ Tutti i debounce / throttle UI vivono in `apps/desktop/src/lib/timings.ts` con u
 ## Cosa NON c'è (per ora)
 
 Per evitare di reinventare la ruota:
-- **Niente plugin system.** v1.0+. Per estendere ora, fork.
-- **Niente sync server.** v1.0+. Per ora si usa Dropbox/iCloud/Drive sopra il vault.
-- **Niente AI nativa.** v1.x. La struttura `packages/core` è pronta a ospitare embeddings, ma non li implementiamo finché v0.3 non è stabile.
+- **Niente plugin system.** v1.x. L'object model fornisce ora la base strutturale.
+- **Niente sync server.** v1.x. Per ora si usa Dropbox/iCloud/Drive sopra il vault.
+- **Niente AI nativa.** v1.x. La struttura `packages/core` è pronta a ospitare embeddings.
 - **Niente i18n.** L'app parla italiano. Quando serve i18n, apriamo una Discussion.
+- **Niente filter unification.** v1.1. Sidebar, DatabaseView e GlobalGraph hanno `selectedType` store indipendenti — refactor pianificato.
 
 ## Decision log riassunto
 
-Le decisioni grosse vissute durante v0.1-v0.3, riassunte:
+Le decisioni grosse vissute durante v0.1-v1.0, riassunte:
 
 **v0.1**
 - **Electron, non Tauri.** Ecosistema npm completo, AI futura facile via Node, contributor pool ampio. Costo accettato: binary più grande.
@@ -356,9 +483,16 @@ Le decisioni grosse vissute durante v0.1-v0.3, riassunte:
 
 **v0.3**
 - **Property index in colonne tipizzate, non JSON.** `note_properties` ha `text_value`/`number_value`/`boolean_value`/`date_value`/`array_value` separate. Permette query veloci tramite indici dedicati per tipo. JSON sarebbe più flessibile ma forzerebbe scan O(n) su query range.
-- **Database view come overlay sul mainView, non come "view file".** Niente file `.ziba/views/*.json` — la query è in-memory nel renderer. Più semplice per v0.3; salvabili come "saved queries" in v0.4 se serve.
+- **Database view come overlay sul mainView, non come "view file".** Niente file `.ziba/views/*.json` — la query è in-memory nel renderer. Più semplice per v0.3; salvabili come "saved queries" in v1.x se serve.
 - **Global graph riusa MiniGraph layout, non Barnes-Hut.** Il simulatore O(n²) basta fino a ~1000 nodi. Sopra emette `console.warn`. Quando un vault reale lo richiede, sostituiamo con BH dietro la stessa interfaccia `simulateLayout`.
 - **Callout markdown roundtrip via markdown-it core ruler.** Convertiamo `> [!kind]\n> body` ↔ Tiptap node senza modificare il body markdown stesso. Compatibilità completa con Obsidian e GitHub (entrambi rendono `> [!tip]`).
+
+**v1.0**
+- **`relations` sostituisce `wikilinks`, non la affianca.** Un'unica tabella con `kind = ''` per i wikilink generici è più pulita di due tabelle + join. La migration è uno drop + reindex — la cache è ricostruibile, nessun dato perso.
+- **Schema soft, non hard.** Gli schemi descrivono l'intenzione + guidano la UI ma non bloccano il salvataggio. Rifiutare un salvataggio per schema invalido romperebbe il principio "source of truth = filesystem".
+- **Object types come YAML, non come note speciali.** `.ziba/schema/book.yml` è separato dal vault content — un file `.md` con `type: schema` avrebbe creato ambiguità nell'indexer e nella search.
+- **Seed schemas copiati su prima apertura, non hardcoded nel binary.** L'utente può editarli, cancellarli o sostituirli liberamente. Il binary non li "sa" — li legge da disco come qualsiasi altro schema.
+- **Hull convex nel grafo, non clustering algoritmico.** Il convex hull sui nodi dello stesso tipo è O(n log n) e visivamente chiaro. Un clustering algoritmico (k-means, DBSCAN) aggiungerebbe complessità senza benefici apprezzabili a scala vault.
 
 Per un decision log strutturato (ADR style) potremmo aggiungere `docs/adr/` se la complessità cresce.
 
@@ -376,5 +510,8 @@ Quando devi capire come funziona qualcosa, parti da questi file:
 - "Come funziona la query database (v0.3)?" → `packages/core/src/query/index.ts` (AST + detectProperty) + SQL builder in `apps/desktop/electron/adapters/index-store.sqlite.ts:runQuery`
 - "Come renderizza il grafo globale (v0.3)?" → `apps/desktop/src/components/GlobalGraph/index.tsx` (orchestration) + `Canvas.tsx` (SVG + pan/zoom imperativo) + `layout.ts` (riusa MiniGraph simulator)
 - "Come fa il callout markdown roundtrip (v0.3)?" → `apps/desktop/src/components/Editor/extensions/Callout.ts` (markdown-it core ruler + custom serialize)
+- "Come funzionano gli oggetti tipizzati (v1.0)?" → `packages/core/src/types/schema.ts` (forma YAML) + `apps/desktop/electron/ipc/types.ts` (IPC handlers) + `stores/tags.ts` (cache renderer)
+- "Come si popola la tabella relations?" → `apps/desktop/electron/adapters/index-store-relations.ts` + `packages/core/src/markdown/relations.ts` (extractor)
+- "Come funziona il grafo constellation (v1.0)?" → `apps/desktop/src/components/GlobalGraph/HullsLayer.tsx` (hull SVG) + `Canvas.tsx` (cluster bias nel layout) + `KindFilterDropdown.tsx`
 - "Dove vivono le decisioni di sicurezza?" → `apps/desktop/electron/security.ts`
 - "Dove sono i tipi del contratto IPC?" → `apps/desktop/shared/ipc.ts`

--- a/docs/superpowers/plans/2026-05-10-v1.0-phase3-editor-relations.md
+++ b/docs/superpowers/plans/2026-05-10-v1.0-phase3-editor-relations.md
@@ -1,0 +1,2222 @@
+# Ziba v1.0 Phase 3 — Editor decoration + slash relation + PropertyEditor
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface typed-relation affordances inside the editor — wikilinks gain a type-icon decoration, a new slash menu entry opens a relation picker, and the PropertyEditor learns to edit `frontmatter.relations` directly.
+
+**Architecture:** Three loosely-coupled subsystems share one foundation. Foundation: a renderer-side cache `Map<NotePath, type>` for every typed note in the vault, fetched once via a new IPC and updated on watcher events. Subsystem 1: Wikilink Tiptap node reads the cache through a per-editor `pathByTitle` map and prepends the type's icon to the display text at `renderHTML` time. Subsystem 2: a new `/relazione` slash item invokes a callback the React layer wires to a popover that writes into `frontmatter.relations`. Subsystem 3: PropertyEditor renders a parallel "Relazioni" section above the body, with an "Aggiungi relazione" affordance and per-row kind / target editing.
+
+**Tech Stack:** TypeScript, Tiptap 3, ProseMirror, React 18, Zustand, better-sqlite3, Vitest, @testing-library/react.
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md` §5.4 (Editor — inline type indicator + relation slash entry), §8 Phase 3 deliverables, §9 wikilink-decoration cost note.
+
+## File structure
+
+### Created
+
+- `apps/desktop/src/components/Editor/useWikilinkTypes.ts` — populates `editor.storage.wikilink.pathByTitle` from the vault store and the resolution cache; triggers a re-render when the type icon for a target changes.
+- `apps/desktop/src/components/Editor/RelationPickerPopup.tsx` — floating popover for `/relazione`: kind selector (schema-aware), wikilink autocomplete, commit button.
+- `apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx` — render + interaction tests.
+- `apps/desktop/src/components/PropertyEditor/RelationsSection.tsx` — new section sibling to the existing "Proprietà" block, renders one row per `(kind, target)` pair.
+- `apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx` — interaction tests for add / edit / remove.
+- `apps/desktop/src/lib/relations-frontmatter.ts` — pure helpers: `setRelationInFrontmatter`, `removeRelationFromFrontmatter`, `relationsFromFrontmatter`. No React, easy unit test.
+- `apps/desktop/src/lib/relations-frontmatter.test.ts` — pure-function tests.
+
+### Modified
+
+- `packages/core/src/adapters/index-store.ts` — add `getTypedPaths(): Promise<Map<NotePath, string>>` to the IndexStore interface.
+- `apps/desktop/electron/adapters/index-store.sqlite.ts` — SQLite implementation: `SELECT path, text_value FROM note_properties WHERE prop_key = 'type'`.
+- `apps/desktop/electron/adapters/index-store.sqlite.test.ts` — adapter test for the new method.
+- `apps/desktop/shared/ipc.ts` — new channel `notes:typedPaths`; request `void`; response `Array<[NotePath, string]>` (tuples so the contextBridge serializer doesn't drop the Map).
+- `apps/desktop/electron/ipc/notes.ts` — new IPC handler `getTypedPaths`.
+- `apps/desktop/src/lib/ipc.ts` — typed client wrapper.
+- `apps/desktop/src/stores/vault.ts` — store a `typedPaths: ReadonlyMap<NotePath, string>` slice; fetch alongside `notes` on refresh; emit the new slice from watcher / vault-event paths.
+- `apps/desktop/src/stores/vault.test.ts` — extend tests for the new slice.
+- `apps/desktop/src/components/Editor/extensions/Wikilink.ts` — `addStorage` now exposes `pathByTitle: Map<string, NotePath>` (replaces the boolean `resolved` map, see migration note below); `renderHTML` prepends the type icon when one resolves through the editor's shared `typeIconByPath` map.
+- `apps/desktop/src/components/Editor/useResolvedWikilinks.ts` — store the path string (not a bool), so a single map serves both "broken?" and "resolves to path"; preserves backward-compat by treating absent/null entries as broken.
+- `apps/desktop/src/components/Editor/index.tsx` — wire the new `useWikilinkTypes` hook; manage relation-picker state and the `onRelationPick` callback consumed by SlashCommand.
+- `apps/desktop/src/components/Editor/extensions/SlashCommand.ts` — new menu entry `relation`; the entry doesn't insert content directly — it invokes a renderer-side `onRelationRequested` callback supplied through options, mirroring the existing `createRenderer` factory pattern.
+- `apps/desktop/src/components/Editor/EditorExtensions.ts` — surface the new `onRelationRequested` option on `buildEditorExtensions`.
+- `apps/desktop/src/components/PropertyEditor/index.tsx` — render `<RelationsSection>` below the property list; pass `onChange` through unchanged.
+- `apps/desktop/src/components/PropertyEditor/index.test.tsx` — extend smoke tests for the new section's presence on typed notes.
+
+### Tests (new files only — modifications listed above)
+
+- `apps/desktop/src/lib/relations-frontmatter.test.ts`
+- `apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx`
+- `apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx`
+
+## Migration notes — `WikilinkResolutionMap`
+
+The Wikilink storage `resolved: Map<string, boolean>` is widened to `Map<string, NotePath | false>`. Existing consumers branch only on `=== false` (broken) vs anything else (resolved); replacing `true` with the actual path is **backward compatible** because:
+
+- `renderHTML` reads `resolvedMap.get(target) !== false` — unchanged.
+- `useResolvedWikilinks` is the only writer — we update it to store the path.
+
+We rename the type to `WikilinkResolution = NotePath | false` and the map to `WikilinkResolutionMap = Map<string, WikilinkResolution>`. The diff is small and localized.
+
+---
+
+## Task 1: Adapter — `getTypedPaths()`
+
+**Files:**
+- Modify: `packages/core/src/adapters/index-store.ts:208` (add method to the interface, just before `clear()`)
+- Modify: `apps/desktop/electron/adapters/index-store.sqlite.ts:413` (impl, alongside `listNotes`)
+- Modify: `apps/desktop/electron/adapters/index-store.sqlite.test.ts` (new test case)
+
+- [ ] **Step 1: Write the failing adapter test**
+
+Edit `apps/desktop/electron/adapters/index-store.sqlite.test.ts`. Add this test near the other `getTypeCounts` / property tests:
+
+```ts
+describe('getTypedPaths', () => {
+  it('returns one entry per typed note, mapping path → type slug', async () => {
+    const adapter = await makeAdapter();
+    await adapter.upsertNote({
+      path: 'books/hobbit.md',
+      title: 'The Hobbit',
+      frontmatter: { type: 'book' },
+      mtimeMs: 1,
+      body: '',
+    });
+    await adapter.replaceProperties('books/hobbit.md', [
+      { key: 'type', type: 'text', textValue: 'book' },
+    ]);
+    await adapter.upsertNote({
+      path: 'people/tolkien.md',
+      title: 'Tolkien',
+      frontmatter: { type: 'person' },
+      mtimeMs: 1,
+      body: '',
+    });
+    await adapter.replaceProperties('people/tolkien.md', [
+      { key: 'type', type: 'text', textValue: 'person' },
+    ]);
+    await adapter.upsertNote({
+      path: 'untyped.md',
+      title: 'Untyped',
+      frontmatter: {},
+      mtimeMs: 1,
+      body: '',
+    });
+
+    const got = await adapter.getTypedPaths();
+
+    expect(got).toBeInstanceOf(Map);
+    expect(got.size).toBe(2);
+    expect(got.get('books/hobbit.md')).toBe('book');
+    expect(got.get('people/tolkien.md')).toBe('person');
+    expect(got.has('untyped.md')).toBe(false);
+  });
+
+  it('returns an empty map on a fresh vault', async () => {
+    const adapter = await makeAdapter();
+    const got = await adapter.getTypedPaths();
+    expect(got.size).toBe(0);
+  });
+});
+```
+
+> Note: `makeAdapter` already exists in this test file as the `:memory:` factory. Reuse it verbatim. If the helper signature differs, mirror exactly what the surrounding tests call.
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+pnpm --filter ziba-desktop test -- index-store.sqlite.test.ts
+```
+
+Expected: failure with "adapter.getTypedPaths is not a function".
+
+- [ ] **Step 3: Extend the IndexStore interface**
+
+Edit `packages/core/src/adapters/index-store.ts`. Just before `clear()` add:
+
+```ts
+  /**
+   * v1.0: all notes carrying a `type:` slug, returned as a path → type
+   * map. Reads from `note_properties` so the cost is one indexed scan
+   * on `prop_key = 'type'`. Untyped notes are absent from the map.
+   *
+   * The renderer keeps this map for the editor's wikilink decoration
+   * (per-link `path → type → icon` lookup) and refreshes on vault /
+   * schema events. Bounded cost: typed notes are a fraction of total
+   * notes for realistic vaults.
+   */
+  getTypedPaths(): Promise<Map<NotePath, string>>;
+```
+
+- [ ] **Step 4: Implement on the SQLite adapter**
+
+In `apps/desktop/electron/adapters/index-store.sqlite.ts`, prepare a statement alongside the others (search for `listNotes: db.prepare` and add nearby):
+
+```ts
+      // v1.0: scan the property index for the `type:` slug. The
+      // sentinel value `''` (empty string) is excluded by the
+      // `text_value IS NOT NULL AND text_value <> ''` clause so notes
+      // that wrote `type:` then cleared it don't surface as typed.
+      getTypedPaths: db.prepare(`
+        SELECT path, text_value AS type
+        FROM note_properties
+        WHERE prop_key = 'type'
+          AND text_value IS NOT NULL
+          AND text_value <> ''
+      `),
+```
+
+Add the method (alongside `getTypeCounts` so the v1.0 cluster stays together):
+
+```ts
+  async getTypedPaths(): Promise<Map<NotePath, string>> {
+    const s = this.statements;
+    const rows = s.getTypedPaths.all() as Array<{ path: string; type: string }>;
+    const out = new Map<NotePath, string>();
+    for (const r of rows) out.set(r.path, r.type);
+    return out;
+  }
+```
+
+Also add `getTypedPaths: Database.Statement;` to the `statements` type declaration near `listNotes`.
+
+- [ ] **Step 5: Run the test, confirm it passes**
+
+```bash
+pnpm --filter ziba-desktop test -- index-store.sqlite.test.ts
+```
+
+Expected: both `getTypedPaths` tests pass; existing tests still pass.
+
+- [ ] **Step 6: Run a wider sanity check**
+
+```bash
+pnpm typecheck && pnpm --filter ziba-desktop test -- --run --reporter=basic
+```
+
+Expected: 3/3 typecheck passes; full test suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/adapters/index-store.ts \
+        apps/desktop/electron/adapters/index-store.sqlite.ts \
+        apps/desktop/electron/adapters/index-store.sqlite.test.ts
+git commit -m "feat(v1.0 phase3): adapter getTypedPaths() — path → type slug map"
+```
+
+---
+
+## Task 2: IPC — `notes:typedPaths` channel
+
+**Files:**
+- Modify: `apps/desktop/shared/ipc.ts:53` (add channel constant), `:147` (request), `:209` (response)
+- Modify: `apps/desktop/electron/ipc/notes.ts` (handler)
+- Modify: `apps/desktop/src/lib/ipc.ts` (typed client method)
+- Modify: `apps/desktop/electron/ipc/notes.test.ts` (handler test, if it exists; otherwise create)
+
+- [ ] **Step 1: Locate the existing notes-IPC test file**
+
+```bash
+ls apps/desktop/electron/ipc/notes.test.ts 2>/dev/null || echo "MISSING — create it"
+```
+
+If missing, mirror the structure of any other `electron/ipc/*.test.ts` file (e.g. `tags.test.ts`).
+
+- [ ] **Step 2: Write the failing IPC handler test**
+
+Add to `apps/desktop/electron/ipc/notes.test.ts`:
+
+```ts
+describe('getTypedPaths IPC', () => {
+  it('returns tuples [path, type] for every typed note', async () => {
+    const adapter = await makeAdapterWithTypedNote('books/hobbit.md', 'book');
+    setActiveAdapter(adapter);
+    const result = await getTypedPaths();
+    expect(result).toEqual([['books/hobbit.md', 'book']]);
+  });
+
+  it('returns an empty array when no notes are typed', async () => {
+    setActiveAdapter(await makeEmptyAdapter());
+    expect(await getTypedPaths()).toEqual([]);
+  });
+});
+```
+
+> `makeAdapterWithTypedNote`, `setActiveAdapter`, `makeEmptyAdapter` should mirror the helpers already used by sibling tests — read the existing `notes.test.ts` (or `tags.test.ts`) opening lines to copy their shape. If the helpers don't exist, define them inline at the top of this `describe`.
+
+- [ ] **Step 3: Run the test, confirm it fails**
+
+```bash
+pnpm --filter ziba-desktop test -- notes.test.ts
+```
+
+Expected: "getTypedPaths is not a function" or "channel not registered".
+
+- [ ] **Step 4: Add the channel + request/response types**
+
+In `apps/desktop/shared/ipc.ts`:
+
+```ts
+// In IpcChannels:
+  listNotes: 'notes:list',
+  loadNote: 'notes:load',
++ getTypedPaths: 'notes:typedPaths',
+  saveNote: 'notes:save',
+```
+
+Then in `IpcRequests`:
+
+```ts
+  [IpcChannels.listNotes]: void;
++ [IpcChannels.getTypedPaths]: void;
+  [IpcChannels.loadNote]: { path: NotePath };
+```
+
+And in `IpcResponses`:
+
+```ts
+  [IpcChannels.listNotes]: NoteSummary[];
++ // Tuples (not Map) so the contextBridge serializer round-trips cleanly.
++ // Renderer rebuilds the Map at the boundary.
++ [IpcChannels.getTypedPaths]: Array<[NotePath, string]>;
+  [IpcChannels.loadNote]: Note;
+```
+
+- [ ] **Step 5: Add the IPC handler**
+
+In `apps/desktop/electron/ipc/notes.ts`, add the handler near `listNotes`:
+
+```ts
+export async function getTypedPaths(): Promise<Array<[NotePath, string]>> {
+  const adapter = requireAdapter();
+  const map = await adapter.getTypedPaths();
+  return Array.from(map.entries());
+}
+```
+
+> `requireAdapter` is whatever existing helper the surrounding handlers use to grab the active adapter (commonly `getActiveAdapter()` or similar) — match the existing pattern.
+
+Register the handler — look in `apps/desktop/electron/main.ts` (or wherever `ipcMain.handle` calls are registered) and add an entry for the new channel. The pattern should mirror the entry for `listNotes`.
+
+- [ ] **Step 6: Add the typed client wrapper**
+
+In `apps/desktop/src/lib/ipc.ts`, find the existing `listNotes` wrapper and add:
+
+```ts
+async getTypedPaths(): Promise<Map<NotePath, string>> {
+  const tuples = await window.ziba.invoke(IpcChannels.getTypedPaths);
+  return new Map(tuples);
+},
+```
+
+- [ ] **Step 7: Run the test, confirm it passes**
+
+```bash
+pnpm --filter ziba-desktop test -- notes.test.ts
+```
+
+Expected: green.
+
+- [ ] **Step 8: Wider sanity check**
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/shared/ipc.ts \
+        apps/desktop/electron/ipc/notes.ts \
+        apps/desktop/electron/main.ts \
+        apps/desktop/src/lib/ipc.ts \
+        apps/desktop/electron/ipc/notes.test.ts
+git commit -m "feat(v1.0 phase3): IPC notes:typedPaths — bulk path→type map"
+```
+
+---
+
+## Task 3: Vault store — `typedPaths` slice
+
+**Files:**
+- Modify: `apps/desktop/src/stores/vault.ts`
+- Modify: `apps/desktop/src/stores/vault.test.ts`
+
+- [ ] **Step 1: Write the failing store test**
+
+Add to `apps/desktop/src/stores/vault.test.ts`:
+
+```ts
+describe('typedPaths slice', () => {
+  it('populates typedPaths on openVault → refreshNotes', async () => {
+    mockIpc.listNotes.mockResolvedValue([
+      { path: 'books/hobbit.md', title: 'The Hobbit', mtimeMs: 1 },
+    ]);
+    mockIpc.getTypedPaths.mockResolvedValue(new Map([['books/hobbit.md', 'book']]));
+    await useVaultStore.getState().openVault('/vault');
+    expect(useVaultStore.getState().typedPaths.get('books/hobbit.md')).toBe('book');
+  });
+
+  it('resets typedPaths to empty on closeVault', async () => {
+    useVaultStore.setState({ typedPaths: new Map([['x.md', 'book']]) });
+    await useVaultStore.getState().closeVault();
+    expect(useVaultStore.getState().typedPaths.size).toBe(0);
+  });
+
+  it('refreshes typedPaths when a watcher event triggers refreshNotes', async () => {
+    mockIpc.listNotes.mockResolvedValue([
+      { path: 'books/hobbit.md', title: 'The Hobbit', mtimeMs: 2 },
+    ]);
+    mockIpc.getTypedPaths.mockResolvedValue(new Map([['books/hobbit.md', 'book']]));
+    await useVaultStore.getState().refreshNotes();
+    expect(useVaultStore.getState().typedPaths.size).toBe(1);
+  });
+});
+```
+
+> Mirror the existing `mockIpc` setup at the top of the test file — extend it with a `getTypedPaths: vi.fn()` mock entry.
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+pnpm --filter ziba-desktop test -- vault.test.ts
+```
+
+Expected: failure ("Cannot read property 'typedPaths'…").
+
+- [ ] **Step 3: Extend the store shape**
+
+In `apps/desktop/src/stores/vault.ts`, update `VaultState`:
+
+```ts
+type VaultState = {
+  current: VaultInfo | null;
+  notes: NoteSummary[];
++ /**
++  * v1.0 Phase 3: path → type slug for every note that declares `type:`
++  * in its frontmatter. Used by the wikilink decoration (per-target type
++  * icon prefix) and surfaceable to any other renderer that needs to
++  * branch on object type without round-tripping IPC.
++  *
++  * Populated alongside `notes` on every refresh; updated on watcher
++  * bursts via the same debounced refresh as the notes list.
++  */
++ typedPaths: ReadonlyMap<NotePath, string>;
+  recentVaults: VaultInfo[];
+  ...
+```
+
+And the initial state + reset paths:
+
+```ts
+  return {
+    current: null,
+    notes: [],
++   typedPaths: new Map(),
+    recentVaults: [],
+    indexProgress: null,
+    ...
+```
+
+Update `refreshNotes`:
+
+```ts
+    async refreshNotes() {
+      const current = get().current;
+      if (current === null) return;
+-     const notes = await ipc.listNotes();
+-     set({ notes });
++     const [notes, typedPaths] = await Promise.all([ipc.listNotes(), ipc.getTypedPaths()]);
++     set({ notes, typedPaths });
+    },
+```
+
+Update `closeVault` to also reset `typedPaths`:
+
+```ts
+    async closeVault() {
+      await ipc.closeVault();
+-     set({ current: null, notes: [], indexProgress: null });
++     set({ current: null, notes: [], typedPaths: new Map(), indexProgress: null });
+    },
+```
+
+Update `openVault` to clear the previous map before the first refresh:
+
+```ts
+    async openVault(root) {
+      const info = await ipc.openVault({ root });
+-     set({ current: info, notes: [] });
++     set({ current: info, notes: [], typedPaths: new Map() });
+      await get().refreshNotes();
+      await get().loadRecentVaults();
+    },
+```
+
+- [ ] **Step 4: Run the store tests**
+
+```bash
+pnpm --filter ziba-desktop test -- vault.test.ts
+```
+
+Expected: all three new tests pass; existing tests still pass.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/stores/vault.ts apps/desktop/src/stores/vault.test.ts
+git commit -m "feat(v1.0 phase3): vault store — typedPaths slice"
+```
+
+---
+
+## Task 4: Widen `WikilinkResolutionMap` to store the resolved path
+
+**Files:**
+- Modify: `apps/desktop/src/components/Editor/extensions/Wikilink.ts` (type definition + storage init)
+- Modify: `apps/desktop/src/components/Editor/useResolvedWikilinks.ts` (store path instead of bool)
+
+- [ ] **Step 1: Update the type alias**
+
+In `apps/desktop/src/components/Editor/extensions/Wikilink.ts`:
+
+```ts
+-export type WikilinkResolutionMap = Map<string, boolean>;
++/**
++ * Each entry maps a wikilink target title → either `false` (the title
++ * could not be resolved to a note) OR the resolved note's path. The
++ * widened shape (vs. the v0.x `boolean`) lets the renderer chain
++ * `title → path → type` lookups without re-IPCing.
++ */
++export type WikilinkResolution = string | false;
++export type WikilinkResolutionMap = Map<string, WikilinkResolution>;
+```
+
+Then update `renderHTML`. The branch `resolvedMap.get(target) !== false` still works — anything-not-`false` (including the path string and `undefined`) is treated as resolved/optimistic.
+
+- [ ] **Step 2: Update the writer**
+
+In `apps/desktop/src/components/Editor/useResolvedWikilinks.ts`:
+
+```ts
+-      let changed = false;
+-      for (const r of results) {
+-        if (r.status !== 'fulfilled') continue;
+-        const exists = r.value.path !== null;
+-        if (resolvedMap.get(r.value.title) !== exists) {
+-          resolvedMap.set(r.value.title, exists);
+-          changed = true;
+-        }
+-      }
++      let changed = false;
++      for (const r of results) {
++        if (r.status !== 'fulfilled') continue;
++        const next: WikilinkResolution = r.value.path ?? false;
++        if (resolvedMap.get(r.value.title) !== next) {
++          resolvedMap.set(r.value.title, next);
++          changed = true;
++        }
++      }
+```
+
+- [ ] **Step 3: Check no other consumers branch on the old boolean shape**
+
+```bash
+grep -rn "WikilinkResolutionMap\|resolved\.get" apps/desktop/src --include="*.ts" --include="*.tsx"
+```
+
+Read each hit. Confirm they only check `=== false` or `!== false`. If any compare against `true` explicitly, fix to use `=== false` inversely.
+
+- [ ] **Step 4: Run editor-related tests**
+
+```bash
+pnpm --filter ziba-desktop test -- Wikilink useResolvedWikilinks
+```
+
+Expected: green.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/components/Editor/extensions/Wikilink.ts \
+        apps/desktop/src/components/Editor/useResolvedWikilinks.ts
+git commit -m "refactor(v1.0 phase3): WikilinkResolutionMap stores path|false"
+```
+
+---
+
+## Task 5: Wikilink decoration — render type icon prefix
+
+**Files:**
+- Modify: `apps/desktop/src/components/Editor/extensions/Wikilink.ts` (renderHTML + storage)
+- Create: `apps/desktop/src/components/Editor/extensions/Wikilink.test.ts`
+- Create: `apps/desktop/src/components/Editor/useWikilinkTypes.ts`
+
+- [ ] **Step 1: Write the failing renderHTML test**
+
+Create `apps/desktop/src/components/Editor/extensions/Wikilink.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { Wikilink } from './Wikilink';
+
+function makeEditor(): Editor {
+  return new Editor({
+    extensions: [Wikilink],
+    content: { type: 'doc', content: [{ type: 'paragraph' }] },
+  });
+}
+
+describe('Wikilink renderHTML', () => {
+  it('prefixes the display text with the type icon when the target resolves to a typed note', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    const typeIconByPath = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    resolved.set('Tolkien', 'people/tolkien.md');
+    typeIconByPath.set('people/tolkien.md', '👤');
+    editor.commands.insertWikilink({ target: 'Tolkien' });
+    expect(editor.view.dom.textContent).toContain('👤 Tolkien');
+    editor.destroy();
+  });
+
+  it('omits the icon when the target is broken', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    resolved.set('UnknownPlace', false);
+    editor.commands.insertWikilink({ target: 'UnknownPlace' });
+    expect(editor.view.dom.textContent).toBe('UnknownPlace');
+    editor.destroy();
+  });
+
+  it('omits the icon when the target resolves to an untyped note', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    resolved.set('Plain', 'plain.md');
+    // typeIconByPath has no entry for plain.md
+    editor.commands.insertWikilink({ target: 'Plain' });
+    expect(editor.view.dom.textContent).toBe('Plain');
+    editor.destroy();
+  });
+
+  it('uses the alias as the display text and still prefixes the icon', () => {
+    const editor = makeEditor();
+    const resolved = editor.storage.wikilink.resolved as Map<string, string | false>;
+    const typeIconByPath = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    resolved.set('John Ronald Reuel Tolkien', 'people/tolkien.md');
+    typeIconByPath.set('people/tolkien.md', '👤');
+    editor.commands.insertWikilink({ target: 'John Ronald Reuel Tolkien', alias: 'JRR' });
+    expect(editor.view.dom.textContent).toContain('👤 JRR');
+    editor.destroy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+pnpm --filter ziba-desktop test -- Wikilink.test
+```
+
+Expected: failures around missing storage entries / missing icon prefix.
+
+- [ ] **Step 3: Extend the Wikilink storage**
+
+In `apps/desktop/src/components/Editor/extensions/Wikilink.ts`, edit `addStorage`:
+
+```ts
+  addStorage() {
+    const resolved: WikilinkResolutionMap = new Map();
++   // path → icon, populated by `useWikilinkTypes` from the vault
++   // store's `typedPaths` + the cached object-type schemas. The
++   // renderHTML branch is purely local — no IPC at render time.
++   const typeIconByPath: Map<string, string> = new Map();
+    return {
+      resolved,
++     typeIconByPath,
+      markdown: { /* unchanged */ },
+    };
+  },
+```
+
+Modify `renderHTML`:
+
+```ts
+  renderHTML({ node, HTMLAttributes }) {
+    const target = String(node.attrs.target ?? '');
+    const alias =
+      node.attrs.alias !== null && node.attrs.alias !== undefined ? String(node.attrs.alias) : '';
+    const display = alias.length > 0 ? alias : target;
+
+    const resolvedMap = this.storage?.resolved as WikilinkResolutionMap | undefined;
+    const rawResolution = resolvedMap?.get(target);
+    const isResolved = rawResolution !== false; // undefined = optimistic
+    const resolvedPath = typeof rawResolution === 'string' ? rawResolution : null;
+
++   const iconMap = this.storage?.typeIconByPath as Map<string, string> | undefined;
++   const icon = resolvedPath !== null ? iconMap?.get(resolvedPath) : undefined;
++   const labelText = icon !== undefined ? `${icon} ${display}` : display;
+
+    const baseClass = 'ziba-wikilink';
+    const stateClass = isResolved ? 'ziba-wikilink--resolved' : 'ziba-wikilink--broken';
+
+    return [
+      'span',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-wikilink': '',
+        'data-target': target,
+        class: `${baseClass} ${stateClass}`,
+      }),
+-     display,
++     labelText,
+    ];
+  },
+```
+
+> The `renderText` method (for plain-text copy) stays as today — copying a wikilink should preserve the markdown form, not the decorated display.
+
+- [ ] **Step 4: Run the renderHTML test, confirm it passes**
+
+```bash
+pnpm --filter ziba-desktop test -- Wikilink.test
+```
+
+Expected: all 4 cases pass.
+
+- [ ] **Step 5: Create `useWikilinkTypes`**
+
+`apps/desktop/src/components/Editor/useWikilinkTypes.ts`:
+
+```ts
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/core';
+import { useTagsStore } from '../../stores/tags';
+import { useVaultStore } from '../../stores/vault';
+
+/**
+ * Populates `editor.storage.wikilink.typeIconByPath` from the vault
+ * store's `typedPaths` slice + the cached object-type schemas. Forces
+ * a no-op transaction when the map changes so the Wikilink renderHTML
+ * picks up the new prefix without a full doc recompute.
+ *
+ * Re-keyed on `noteKey` to mirror `useResolvedWikilinks`: when the
+ * user opens a different note, we don't need to clear anything (the
+ * map is keyed by path, not by editor session) — the resolution map
+ * is what resets per-note.
+ */
+export function useWikilinkTypes(editor: Editor | null): void {
+  const typedPaths = useVaultStore((s) => s.typedPaths);
+  const schemas = useTagsStore((s) => s.objectTypeSchemas);
+
+  useEffect(() => {
+    if (editor === null || editor.isDestroyed) return;
+    const iconMap = editor.storage.wikilink?.typeIconByPath as Map<string, string> | undefined;
+    if (iconMap === undefined) return;
+
+    const schemaIconById = new Map<string, string>();
+    for (const s of schemas) {
+      if (s.icon !== null && s.icon !== undefined && s.icon !== '') {
+        schemaIconById.set(s.id, s.icon);
+      }
+    }
+
+    let changed = false;
+    const nextKeys = new Set<string>();
+    for (const [path, type] of typedPaths) {
+      const icon = schemaIconById.get(type);
+      if (icon === undefined) continue;
+      nextKeys.add(path);
+      if (iconMap.get(path) !== icon) {
+        iconMap.set(path, icon);
+        changed = true;
+      }
+    }
+    // Drop entries whose path is no longer typed or whose schema lost
+    // its icon.
+    for (const k of Array.from(iconMap.keys())) {
+      if (!nextKeys.has(k)) {
+        iconMap.delete(k);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      const tr = editor.state.tr.setMeta('zibaWikilinkTypes', true);
+      editor.view.dispatch(tr);
+    }
+  }, [editor, typedPaths, schemas]);
+}
+```
+
+- [ ] **Step 6: Wire `useWikilinkTypes` into the Editor**
+
+In `apps/desktop/src/components/Editor/index.tsx`, find the line:
+
+```ts
+  useResolvedWikilinks(editor, currentNote?.path ?? null);
+```
+
+Add right after:
+
+```ts
+  useWikilinkTypes(editor);
+```
+
+And import it at the top alongside `useResolvedWikilinks`.
+
+- [ ] **Step 7: Add a smoke test for the hook**
+
+Create `apps/desktop/src/components/Editor/useWikilinkTypes.test.tsx` with a single integration test:
+
+```tsx
+import { describe, expect, it, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import { Wikilink } from './extensions/Wikilink';
+import { useWikilinkTypes } from './useWikilinkTypes';
+import { useVaultStore } from '../../stores/vault';
+import { useTagsStore } from '../../stores/tags';
+
+describe('useWikilinkTypes', () => {
+  beforeEach(() => {
+    useVaultStore.setState({ typedPaths: new Map() });
+    useTagsStore.setState({ objectTypeSchemas: [] });
+  });
+
+  it('writes path → icon into editor.storage.wikilink.typeIconByPath', () => {
+    const editor = new Editor({
+      extensions: [Wikilink],
+      content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    });
+    useVaultStore.setState({ typedPaths: new Map([['people/tolkien.md', 'person']]) });
+    useTagsStore.setState({
+      objectTypeSchemas: [
+        {
+          id: 'person',
+          label: 'Person',
+          icon: '👤',
+          color: null,
+          schema: { id: 'person', label: 'Person', properties: {}, relations: {}, inverse: {} },
+          mtime: 0,
+        },
+      ],
+    });
+    renderHook(() => useWikilinkTypes(editor));
+    const iconMap = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    expect(iconMap.get('people/tolkien.md')).toBe('👤');
+    editor.destroy();
+  });
+
+  it('removes entries whose path lost its type', () => {
+    const editor = new Editor({
+      extensions: [Wikilink],
+      content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    });
+    const iconMap = editor.storage.wikilink.typeIconByPath as Map<string, string>;
+    iconMap.set('people/tolkien.md', '👤');
+    useVaultStore.setState({ typedPaths: new Map() });
+    useTagsStore.setState({ objectTypeSchemas: [] });
+    renderHook(() => useWikilinkTypes(editor));
+    expect(iconMap.has('people/tolkien.md')).toBe(false);
+    editor.destroy();
+  });
+});
+```
+
+- [ ] **Step 8: Run the hook test**
+
+```bash
+pnpm --filter ziba-desktop test -- useWikilinkTypes
+```
+
+Expected: green.
+
+- [ ] **Step 9: Full sanity check**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/desktop/src/components/Editor/extensions/Wikilink.ts \
+        apps/desktop/src/components/Editor/extensions/Wikilink.test.ts \
+        apps/desktop/src/components/Editor/useWikilinkTypes.ts \
+        apps/desktop/src/components/Editor/useWikilinkTypes.test.tsx \
+        apps/desktop/src/components/Editor/index.tsx
+git commit -m "feat(v1.0 phase3): wikilink type-icon decoration + useWikilinkTypes hook"
+```
+
+---
+
+## Task 6: `relations-frontmatter.ts` helpers
+
+These are pure, side-effect-free, easy to test. Building this slab first means subsequent UI tasks can call into a known-good API.
+
+**Files:**
+- Create: `apps/desktop/src/lib/relations-frontmatter.ts`
+- Create: `apps/desktop/src/lib/relations-frontmatter.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/desktop/src/lib/relations-frontmatter.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  relationsFromFrontmatter,
+  setRelationInFrontmatter,
+  removeRelationFromFrontmatter,
+} from './relations-frontmatter';
+
+describe('relationsFromFrontmatter', () => {
+  it('returns [] when no relations field is present', () => {
+    expect(relationsFromFrontmatter({})).toEqual([]);
+    expect(relationsFromFrontmatter({ relations: null })).toEqual([]);
+  });
+
+  it('flattens scalars and lists into a single ordered array', () => {
+    const fm = { relations: { author: '[[Tolkien]]', cites: ['[[A]]', '[[B]]'] } };
+    expect(relationsFromFrontmatter(fm)).toEqual([
+      { kind: 'author', target: 'Tolkien' },
+      { kind: 'cites', target: 'A' },
+      { kind: 'cites', target: 'B' },
+    ]);
+  });
+
+  it('skips non-wikilink scalar values and non-string list entries', () => {
+    const fm = {
+      relations: {
+        author: 'not a wikilink',
+        cites: ['[[A]]', 42, null, '[[B]]'],
+      },
+    };
+    expect(relationsFromFrontmatter(fm)).toEqual([
+      { kind: 'cites', target: 'A' },
+      { kind: 'cites', target: 'B' },
+    ]);
+  });
+});
+
+describe('setRelationInFrontmatter', () => {
+  it('creates the relations map if absent and stores a scalar wikilink for a single target', () => {
+    const result = setRelationInFrontmatter({}, 'author', 'Tolkien');
+    expect(result.relations).toEqual({ author: '[[Tolkien]]' });
+  });
+
+  it('upgrades to a list when adding a second target of the same kind', () => {
+    const start = { relations: { cites: '[[A]]' } };
+    const result = setRelationInFrontmatter(start, 'cites', 'B');
+    expect(result.relations).toEqual({ cites: ['[[A]]', '[[B]]'] });
+  });
+
+  it('is idempotent — adding the same (kind, target) does not duplicate', () => {
+    const start = { relations: { cites: ['[[A]]', '[[B]]'] } };
+    const result = setRelationInFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({ cites: ['[[A]]', '[[B]]'] });
+  });
+
+  it('keeps other relations untouched', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = setRelationInFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({
+      author: '[[Tolkien]]',
+      cites: '[[A]]',
+    });
+  });
+});
+
+describe('removeRelationFromFrontmatter', () => {
+  it('drops the scalar when its target matches', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = removeRelationFromFrontmatter(start, 'author', 'Tolkien');
+    expect(result.relations).toEqual({});
+  });
+
+  it('drops the kind entirely when its only list entry was removed', () => {
+    const start = { relations: { cites: ['[[A]]'] } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({});
+  });
+
+  it('collapses a one-entry list into a scalar', () => {
+    const start = { relations: { cites: ['[[A]]', '[[B]]'] } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'A');
+    expect(result.relations).toEqual({ cites: '[[B]]' });
+  });
+
+  it('removes the relations field entirely when empty', () => {
+    const start = { relations: { author: '[[Tolkien]]' } };
+    const result = removeRelationFromFrontmatter(start, 'author', 'Tolkien');
+    expect(result).not.toHaveProperty('relations');
+  });
+
+  it('is a no-op when (kind, target) was not present', () => {
+    const start = { relations: { cites: '[[A]]' } };
+    const result = removeRelationFromFrontmatter(start, 'cites', 'Z');
+    expect(result.relations).toEqual({ cites: '[[A]]' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, confirm failure**
+
+```bash
+pnpm --filter ziba-desktop test -- relations-frontmatter
+```
+
+Expected: module-not-found errors.
+
+- [ ] **Step 3: Implement**
+
+`apps/desktop/src/lib/relations-frontmatter.ts`:
+
+```ts
+import type { Frontmatter } from '@ziba/core';
+
+/**
+ * Parsed relation entry — kind + the resolved-to title (already
+ * stripped of `[[...]]`, alias, heading ref). Mirrors the core
+ * `RelationEntry` but stays renderer-local so the PropertyEditor
+ * doesn't have to import core for one type.
+ */
+export type FrontmatterRelation = { kind: string; target: string };
+
+const WIKILINK_VALUE_RE = /^\[\[([^\]]+)\]\]$/;
+
+/**
+ * Parse a single `[[Target]]` / `[[Target|Alias]]` / `[[Target#heading]]`
+ * value and return the canonical target title (pre-pipe, pre-hash).
+ * Returns null for anything that doesn't match.
+ */
+function parseWikilinkValue(raw: string): string | null {
+  const trimmed = raw.trim();
+  const m = trimmed.match(WIKILINK_VALUE_RE);
+  if (m === null) return null;
+  const inner = m[1] ?? '';
+  const pipe = inner.indexOf('|');
+  const beforePipe = pipe === -1 ? inner : inner.slice(0, pipe);
+  const hash = beforePipe.indexOf('#');
+  const target = (hash === -1 ? beforePipe : beforePipe.slice(0, hash)).trim();
+  return target.length === 0 ? null : target;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Flatten `frontmatter.relations` (a map of kind → wikilink scalar |
+ * list) into a single ordered array of `(kind, target)` pairs. Non-
+ * wikilink values are silently skipped — the editor surfaces them via
+ * the raw frontmatter rather than the relations section.
+ */
+export function relationsFromFrontmatter(fm: Frontmatter): FrontmatterRelation[] {
+  const rels = fm.relations;
+  if (!isPlainObject(rels)) return [];
+  const out: FrontmatterRelation[] = [];
+  for (const [kind, value] of Object.entries(rels)) {
+    if (typeof value === 'string') {
+      const target = parseWikilinkValue(value);
+      if (target !== null) out.push({ kind, target });
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item !== 'string') continue;
+        const target = parseWikilinkValue(item);
+        if (target !== null) out.push({ kind, target });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a new frontmatter with `(kind, target)` added. Scalar value
+ * upgrades to a list on second insert; idempotent on duplicate inserts.
+ */
+export function setRelationInFrontmatter(
+  fm: Frontmatter,
+  kind: string,
+  target: string,
+): Frontmatter {
+  const link = `[[${target}]]`;
+  const relsSource = isPlainObject(fm.relations) ? fm.relations : {};
+  const existing = relsSource[kind];
+
+  const collectExisting = (): string[] => {
+    if (typeof existing === 'string') return [existing];
+    if (Array.isArray(existing)) {
+      return existing.filter((v): v is string => typeof v === 'string');
+    }
+    return [];
+  };
+
+  const current = collectExisting();
+  const currentTargets = new Set(current.map((s) => parseWikilinkValue(s)).filter((t) => t !== null));
+  if (currentTargets.has(target)) {
+    return { ...fm, relations: { ...relsSource } };
+  }
+  const nextList = [...current, link];
+  const nextValue: string | string[] = nextList.length === 1 ? nextList[0]! : nextList;
+  return {
+    ...fm,
+    relations: { ...relsSource, [kind]: nextValue },
+  };
+}
+
+/**
+ * Return a new frontmatter with `(kind, target)` removed. Lists with
+ * one remaining entry collapse to a scalar; emptying the last kind
+ * removes the `relations` field entirely.
+ */
+export function removeRelationFromFrontmatter(
+  fm: Frontmatter,
+  kind: string,
+  target: string,
+): Frontmatter {
+  if (!isPlainObject(fm.relations)) return fm;
+  const rels = { ...fm.relations };
+  const existing = rels[kind];
+
+  const filterOut = (xs: string[]): string[] =>
+    xs.filter((s) => {
+      const parsed = parseWikilinkValue(s);
+      return parsed !== target;
+    });
+
+  if (typeof existing === 'string') {
+    const parsed = parseWikilinkValue(existing);
+    if (parsed === target) {
+      delete rels[kind];
+    }
+  } else if (Array.isArray(existing)) {
+    const filtered = filterOut(existing.filter((v): v is string => typeof v === 'string'));
+    if (filtered.length === 0) {
+      delete rels[kind];
+    } else if (filtered.length === 1) {
+      rels[kind] = filtered[0]!;
+    } else {
+      rels[kind] = filtered;
+    }
+  }
+
+  if (Object.keys(rels).length === 0) {
+    const next = { ...fm };
+    delete next.relations;
+    return next;
+  }
+  return { ...fm, relations: rels };
+}
+```
+
+- [ ] **Step 4: Run the tests, confirm green**
+
+```bash
+pnpm --filter ziba-desktop test -- relations-frontmatter
+```
+
+Expected: all 13 cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/lib/relations-frontmatter.ts apps/desktop/src/lib/relations-frontmatter.test.ts
+git commit -m "feat(v1.0 phase3): relations-frontmatter pure helpers (read/set/remove)"
+```
+
+---
+
+## Task 7: RelationPickerPopup component
+
+**Files:**
+- Create: `apps/desktop/src/components/Editor/RelationPickerPopup.tsx`
+- Create: `apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx`
+
+- [ ] **Step 1: Write the failing component tests**
+
+`apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RelationPickerPopup } from './RelationPickerPopup';
+
+describe('<RelationPickerPopup>', () => {
+  it('renders a kind input pre-filled with the first suggested kind for the current type', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={['author', 'cites']}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const kindInput = screen.getByPlaceholderText('Tipo di relazione');
+    expect((kindInput as HTMLInputElement).value).toBe('');
+    // Suggested kinds are shown as quick-pick chips.
+    expect(screen.getByRole('button', { name: 'author' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'cites' })).toBeInTheDocument();
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onCancel = vi.fn();
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCommit({kind, target}) when both fields have values and the user submits', () => {
+    const onCommit = vi.fn();
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('Tipo di relazione'), {
+      target: { value: 'author' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Nota di destinazione'), {
+      target: { value: 'Tolkien' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Inserisci' }));
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'author', target: 'Tolkien' });
+  });
+
+  it('disables the commit button when either field is empty', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={[]}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const commit = screen.getByRole('button', { name: 'Inserisci' });
+    expect(commit).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('Tipo di relazione'), {
+      target: { value: 'author' },
+    });
+    expect(commit).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('Nota di destinazione'), {
+      target: { value: 'Tolkien' },
+    });
+    expect(commit).not.toBeDisabled();
+  });
+
+  it('clicking a suggested-kind chip populates the kind input', () => {
+    render(
+      <RelationPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        suggestedKinds={['author']}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'author' }));
+    expect((screen.getByPlaceholderText('Tipo di relazione') as HTMLInputElement).value).toBe(
+      'author',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, confirm failure**
+
+```bash
+pnpm --filter ziba-desktop test -- RelationPickerPopup
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 3: Implement the popup**
+
+`apps/desktop/src/components/Editor/RelationPickerPopup.tsx`:
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export type RelationPickerPopupProps = {
+  /** Page-coordinate anchor for the popup (same shape as SlashMenuPopup). */
+  position: { top: number; left: number; bottom: number };
+  /**
+   * Relation kinds suggested for the current note's type — populated
+   * from the type schema's `relations` map. Empty array is fine: the
+   * user can free-type a kind.
+   */
+  suggestedKinds: ReadonlyArray<string>;
+  /** Fires when the user commits a (kind, target) pair. */
+  onCommit(args: { kind: string; target: string }): void;
+  /** Fires on Escape or backdrop click. */
+  onCancel(): void;
+};
+
+const POPUP_HEIGHT_ESTIMATE = 260;
+
+/**
+ * Floating popover triggered by the `/relazione` slash command. Two
+ * fields (kind + target title) and a commit button. Layout mirrors
+ * `SlashMenuPopup` for visual consistency — fixed positioning, portal
+ * to body, flip-above when the trigger is near the bottom of the
+ * viewport.
+ *
+ * Kind input is intentionally a free-text field with quick-pick chips
+ * for schema-suggested kinds, so vault authors aren't constrained to
+ * what their current schema knows about. Target field is also free-text
+ * for v1.0 — the wikilink autocomplete that powers `[[ ]]` is a v1.1
+ * upgrade once we know whether users actually want it here.
+ */
+export function RelationPickerPopup(props: RelationPickerPopupProps): JSX.Element | null {
+  const { position, suggestedKinds, onCommit, onCancel } = props;
+
+  const [kind, setKind] = useState('');
+  const [target, setTarget] = useState('');
+  const kindInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    kindInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  const placement = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { top: position.bottom + 4, left: position.left };
+    }
+    const wouldOverflow = position.bottom + POPUP_HEIGHT_ESTIMATE > window.innerHeight;
+    if (wouldOverflow && position.top - POPUP_HEIGHT_ESTIMATE > 0) {
+      return { top: position.top - POPUP_HEIGHT_ESTIMATE - 4, left: position.left };
+    }
+    return { top: position.bottom + 4, left: position.left };
+  }, [position.top, position.bottom, position.left]);
+
+  if (typeof document === 'undefined') return null;
+
+  const canCommit = kind.trim().length > 0 && target.trim().length > 0;
+
+  const commit = (): void => {
+    if (!canCommit) return;
+    onCommit({ kind: kind.trim(), target: target.trim() });
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label="Aggiungi relazione"
+      className="fixed z-50 w-72 rounded-md border border-border bg-bg-subtle p-3 shadow-lg"
+      style={{ top: placement.top, left: placement.left }}
+    >
+      <div className="flex flex-col gap-2">
+        <input
+          ref={kindInputRef}
+          type="text"
+          value={kind}
+          placeholder="Tipo di relazione"
+          onChange={(e): void => setKind(e.target.value)}
+          onKeyDown={(e): void => {
+            if (e.key === 'Enter' && canCommit) {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+        />
+
+        {suggestedKinds.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {suggestedKinds.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={(): void => setKind(k)}
+                className="rounded border border-border bg-bg px-2 py-0.5 text-xs text-fg-subtle hover:bg-accent/10 hover:text-fg"
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <input
+          type="text"
+          value={target}
+          placeholder="Nota di destinazione"
+          onChange={(e): void => setTarget(e.target.value)}
+          onKeyDown={(e): void => {
+            if (e.key === 'Enter' && canCommit) {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+        />
+
+        <div className="mt-1 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+          >
+            Annulla
+          </button>
+          <button
+            type="button"
+            onClick={commit}
+            disabled={!canCommit}
+            className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90 disabled:opacity-50"
+          >
+            Inserisci
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests, confirm green**
+
+```bash
+pnpm --filter ziba-desktop test -- RelationPickerPopup
+```
+
+Expected: all 5 cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/components/Editor/RelationPickerPopup.tsx \
+        apps/desktop/src/components/Editor/RelationPickerPopup.test.tsx
+git commit -m "feat(v1.0 phase3): RelationPickerPopup — kind + target picker"
+```
+
+---
+
+## Task 8: Slash menu `/relazione` entry
+
+**Files:**
+- Modify: `apps/desktop/src/components/Editor/extensions/SlashCommand.ts`
+- Modify: `apps/desktop/src/components/Editor/EditorExtensions.ts`
+- Modify: `apps/desktop/src/components/Editor/index.tsx`
+
+- [ ] **Step 1: Extend the SlashCommand options + catalog**
+
+In `apps/desktop/src/components/Editor/extensions/SlashCommand.ts`:
+
+```ts
+export type SlashCommandOptions = {
+  createRenderer(): SlashCommandRenderer;
++ /**
++  * Callback invoked when the user picks the `relation` entry. The
++  * renderer is expected to surface a relation-picker popover anchored
++  * at `position`, then call `editor.commands.focus()` and write into
++  * `frontmatter.relations` on commit. Passing `undefined` keeps the
++  * extension a no-op for that entry (default behaviour).
++  */
++ onRelationRequested?: (args: {
++   editor: Editor;
++   range: Range;
++   position: { top: number; left: number; bottom: number };
++ }) => void;
+};
+```
+
+Add the entry to the catalog (alongside the others, ideally near the wikilink-flavour entries — we don't have one yet, so place it after `embed`):
+
+```ts
+  {
+    id: 'relation',
+    title: 'Aggiungi relazione',
+    description: 'Crea una relazione tipizzata nel frontmatter',
+    keywords: ['relation', 'relazione', 'rel', 'link'],
+    icon: '↗',
+  },
+```
+
+Extend `runSlashCommand` — but for `relation` we delegate to the option callback, not to a Tiptap command chain. Add a parameter to the signature:
+
+```ts
+-function runSlashCommand(editor: Editor, id: string): void {
++function runSlashCommand(
++  editor: Editor,
++  id: string,
++  context: {
++    range: Range;
++    position: { top: number; left: number; bottom: number };
++    onRelationRequested?: SlashCommandOptions['onRelationRequested'];
++  },
++): void {
+```
+
+Add the new case before the default:
+
+```ts
+    case 'relation':
+      // Renderer handles the popover; the suggestion plugin has
+      // already deleted the slash + query above us, so no further
+      // doc mutation is needed here.
+      context.onRelationRequested?.({
+        editor,
+        range: context.range,
+        position: context.position,
+      });
+      return;
+```
+
+Then update the `command` callback inside `Suggestion<SlashMenuItem>` to pass the new context. The challenge: we need the position at command time. The `command` callback runs after the user selects — by then the popup is already known to the renderer, but the position rect isn't in the command's scope.
+
+Solution: stash the latest rect in the options object. The renderer's `onUpdate` reliably updates it. Add to `SlashCommandOptions`:
+
+```ts
+- onRelationRequested?: (...) => void;
++ onRelationRequested?: (...) => void;
++ /**
++  * The latest trigger-anchor rect, set by the renderer on every
++  * `onStart` / `onUpdate`. We use it inside `command` to anchor the
++  * relation popover. A ref-like object is mutated in place by the
++  * renderer; cheap and avoids round-tripping through React state.
++  */
++ latestRect?: { current: { top: number; left: number; bottom: number } | null };
+```
+
+And use it in `command`:
+
+```ts
+        command: ({ editor, range, props }) => {
+          editor.chain().focus().deleteRange(range).run();
+-         runSlashCommand(editor, props.id);
++         runSlashCommand(editor, props.id, {
++           range,
++           position: options.latestRect?.current ?? { top: 0, left: 0, bottom: 0 },
++           onRelationRequested: options.onRelationRequested,
++         });
+        },
+```
+
+- [ ] **Step 2: Plumb the option through EditorExtensions**
+
+In `apps/desktop/src/components/Editor/EditorExtensions.ts`:
+
+```ts
+export type BuildExtensionsOptions = {
+  createSuggestionRenderer(): WikilinkSuggestionRenderer;
+  createSlashRenderer?: () => SlashCommandRenderer;
++ /** v1.0 Phase 3: see SlashCommandOptions['onRelationRequested']. */
++ onSlashRelationRequested?: SlashCommandOptions['onRelationRequested'];
++ slashLatestRect?: SlashCommandOptions['latestRect'];
+};
+```
+
+Update the `SlashCommandExtension.configure` call:
+
+```ts
+    SlashCommandExtension.configure({
+      createRenderer:
+        options.createSlashRenderer ?? ((): SlashCommandRenderer => ({
+          onStart(): void {},
+          onUpdate(): void {},
+          onKeyDown(): boolean { return false; },
+          onExit(): void {},
+        })),
++     onRelationRequested: options.onSlashRelationRequested,
++     latestRect: options.slashLatestRect,
+    }),
+```
+
+Add the import for `SlashCommandOptions` next to the existing `SlashCommandRenderer` import.
+
+- [ ] **Step 3: Wire renderer-side state in Editor index**
+
+In `apps/desktop/src/components/Editor/index.tsx`:
+
+Add state for the picker:
+
+```ts
+type RelationPickerState = {
+  open: boolean;
+  position: { top: number; left: number; bottom: number };
+  suggestedKinds: string[];
+};
+
+const INITIAL_RELATION_PICKER_STATE: RelationPickerState = {
+  open: false,
+  position: { top: 0, left: 0, bottom: 0 },
+  suggestedKinds: [],
+};
+```
+
+Inside the component, add:
+
+```ts
+  const [relationPicker, setRelationPicker] = useState<RelationPickerState>(
+    INITIAL_RELATION_PICKER_STATE,
+  );
+
+  // Mutable ref shared with the SlashCommand extension so we always
+  // anchor the popover at the latest slash position the renderer saw,
+  // rather than wherever the cursor was when the command callback
+  // closed over its arguments.
+  const slashLatestRect = useRef<{ top: number; left: number; bottom: number } | null>(null);
+```
+
+Update `createSlashRenderer` to also push into the ref:
+
+```ts
+      onStart: (props) => {
+        slashCommandRef.current = (item): void => { props.command(item); };
+        const rect = props.clientRect?.();
++       if (rect) slashLatestRect.current = { top: rect.top, left: rect.left, bottom: rect.bottom };
+        setSlash({ ... });
+      },
+      onUpdate: (props) => {
+        slashCommandRef.current = (item): void => { props.command(item); };
+        const rect = props.clientRect?.();
++       if (rect) slashLatestRect.current = { top: rect.top, left: rect.left, bottom: rect.bottom };
+        setSlash((prev) => ({ ... }));
+      },
+```
+
+Provide the relation handler. Compute suggested kinds from the current note's type's schema:
+
+```ts
+  const objectTypeSchemas = useTagsStore((s) => s.objectTypeSchemas);
+  const currentNoteType = useMemo(() => {
+    if (currentNote === null) return null;
+    const t = currentNote.frontmatter.type;
+    return typeof t === 'string' ? t : null;
+  }, [currentNote]);
+  const suggestedRelationKinds = useMemo(() => {
+    if (currentNoteType === null) return [];
+    const schema = objectTypeSchemas.find((s) => s.id === currentNoteType);
+    if (schema === undefined) return [];
+    return Object.keys(schema.schema.relations);
+  }, [currentNoteType, objectTypeSchemas]);
+
+  const handleRelationRequested = useCallback<NonNullable<BuildExtensionsOptions['onSlashRelationRequested']>>(
+    ({ position }) => {
+      setRelationPicker({
+        open: true,
+        position,
+        suggestedKinds: suggestedRelationKinds,
+      });
+    },
+    [suggestedRelationKinds],
+  );
+```
+
+Pass into `buildEditorExtensions`:
+
+```ts
+  const extensions = useMemo(
+    () => buildEditorExtensions({
+      createSuggestionRenderer,
+      createSlashRenderer,
++     onSlashRelationRequested: handleRelationRequested,
++     slashLatestRect,
+    }),
+-   [createSuggestionRenderer, createSlashRenderer],
++   [createSuggestionRenderer, createSlashRenderer, handleRelationRequested],
+  );
+```
+
+> Note: rebuilding extensions on `handleRelationRequested` change will remount the editor. Avoid that by using a ref pattern instead — store `handleRelationRequested` in a ref and pass a stable wrapper through `buildEditorExtensions`. Apply this fix:
+
+```ts
+  const handleRelationRequestedRef = useRef(handleRelationRequested);
+  useEffect(() => {
+    handleRelationRequestedRef.current = handleRelationRequested;
+  });
+
+  const extensions = useMemo(
+    () => buildEditorExtensions({
+      createSuggestionRenderer,
+      createSlashRenderer,
+      onSlashRelationRequested: (args) => handleRelationRequestedRef.current(args),
+      slashLatestRect,
+    }),
+    [createSuggestionRenderer, createSlashRenderer],
+  );
+```
+
+Render the popup near the slash popup:
+
+```tsx
+      {relationPicker.open && (
+        <RelationPickerPopup
+          position={relationPicker.position}
+          suggestedKinds={relationPicker.suggestedKinds}
+          onCommit={({ kind, target }): void => {
+            if (currentNote === null) {
+              setRelationPicker(INITIAL_RELATION_PICKER_STATE);
+              return;
+            }
+            const next = setRelationInFrontmatter(currentNote.frontmatter, kind, target);
+            setFrontmatterRef.current(next);
+            debouncedPropertySave();
+            setRelationPicker(INITIAL_RELATION_PICKER_STATE);
+          }}
+          onCancel={(): void => setRelationPicker(INITIAL_RELATION_PICKER_STATE)}
+        />
+      )}
+```
+
+Imports at the top:
+
+```ts
+import { RelationPickerPopup } from './RelationPickerPopup';
+import { setRelationInFrontmatter } from '../../lib/relations-frontmatter';
+import { useTagsStore } from '../../stores/tags';
+```
+
+- [ ] **Step 4: Run the editor tests**
+
+```bash
+pnpm --filter ziba-desktop test -- Editor
+```
+
+Expected: green (the existing editor tests should not regress).
+
+- [ ] **Step 5: Write an integration test for the slash → relation flow**
+
+Add to `apps/desktop/src/components/Editor/index.test.tsx` (create if it doesn't exist; otherwise extend). Mock the IPC and verify that selecting the slash `relation` item opens the popup, and committing writes into the frontmatter via `setFrontmatter`.
+
+If `index.test.tsx` doesn't exist, create a minimal one:
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Editor } from './index';
+import { useEditorStore } from '../../stores/editor';
+
+beforeEach(() => {
+  useEditorStore.setState({
+    currentNote: {
+      path: 'books/hobbit.md',
+      title: 'The Hobbit',
+      mtimeMs: 1,
+      frontmatter: { type: 'book' },
+      content: '',
+      wikilinks: [],
+    },
+    dirty: false,
+    lastSaveError: null,
+  });
+});
+
+describe('Editor — slash relation entry', () => {
+  it('opens the RelationPickerPopup when the user picks `Aggiungi relazione`', async () => {
+    render(<Editor />);
+    // Simulate slash menu open + select. Easier to drive at the
+    // component level via the underlying setter — but Tiptap's
+    // ProseMirror simulation makes a direct keyboard path brittle.
+    // Approach: import the popup catalog and verify the entry exists;
+    // a fuller e2e is left to playwright.
+    // For now, smoke-check that the popup component renders given
+    // open=true state — see below.
+    expect(true).toBe(true);
+  });
+});
+```
+
+> A full integration covering "user types `/`, selects the entry, popup opens" is heavy in jsdom + Tiptap. The unit tests on `RelationPickerPopup` + `relations-frontmatter` already cover the commit logic; we add a follow-up Playwright e2e in a later phase.
+
+- [ ] **Step 6: Run typecheck, lint, and full tests**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/components/Editor/extensions/SlashCommand.ts \
+        apps/desktop/src/components/Editor/EditorExtensions.ts \
+        apps/desktop/src/components/Editor/index.tsx \
+        apps/desktop/src/components/Editor/index.test.tsx
+git commit -m "feat(v1.0 phase3): slash '/relazione' opens RelationPickerPopup"
+```
+
+---
+
+## Task 9: PropertyEditor RelationsSection
+
+**Files:**
+- Create: `apps/desktop/src/components/PropertyEditor/RelationsSection.tsx`
+- Create: `apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx`
+- Modify: `apps/desktop/src/components/PropertyEditor/index.tsx`
+
+- [ ] **Step 1: Write the failing component tests**
+
+`apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RelationsSection } from './RelationsSection';
+
+describe('<RelationsSection>', () => {
+  it('renders an empty state with an add button when no relations exist', () => {
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={vi.fn()} />);
+    expect(screen.getByText('Nessuna relazione dichiarata.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Aggiungi relazione' })).toBeInTheDocument();
+  });
+
+  it('renders one row per (kind, target) pair, flattening lists', () => {
+    render(
+      <RelationsSection
+        frontmatter={{ relations: { author: '[[Tolkien]]', cites: ['[[A]]', '[[B]]'] } }}
+        suggestedKinds={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('author')).toBeInTheDocument();
+    expect(screen.getByText('Tolkien')).toBeInTheDocument();
+    expect(screen.getAllByText('cites').length).toBe(2);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the relation removed when the user clicks the row delete button', () => {
+    const onChange = vi.fn();
+    render(
+      <RelationsSection
+        frontmatter={{ relations: { author: '[[Tolkien]]' } }}
+        suggestedKinds={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Rimuovi relazione author → Tolkien' }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('clicking the add button reveals an inline form; commit calls onChange with the new relation', () => {
+    const onChange = vi.fn();
+    render(<RelationsSection frontmatter={{}} suggestedKinds={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi relazione' }));
+
+    fireEvent.change(screen.getByPlaceholderText('Tipo'), { target: { value: 'author' } });
+    fireEvent.change(screen.getByPlaceholderText('Destinazione'), { target: { value: 'Tolkien' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Aggiungi' }));
+
+    expect(onChange).toHaveBeenCalledWith({ relations: { author: '[[Tolkien]]' } });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, confirm failure**
+
+```bash
+pnpm --filter ziba-desktop test -- RelationsSection
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 3: Implement**
+
+`apps/desktop/src/components/PropertyEditor/RelationsSection.tsx`:
+
+```tsx
+import { useMemo, useState } from 'react';
+import type { Frontmatter } from '@ziba/core';
+import {
+  relationsFromFrontmatter,
+  setRelationInFrontmatter,
+  removeRelationFromFrontmatter,
+} from '../../lib/relations-frontmatter';
+
+export type RelationsSectionProps = {
+  frontmatter: Frontmatter;
+  /**
+   * Kind suggestions derived from the current note's type schema.
+   * Empty array is fine; the user can free-type a kind.
+   */
+  suggestedKinds: ReadonlyArray<string>;
+  onChange(next: Frontmatter): void;
+};
+
+/**
+ * Section sibling to the existing "Proprietà" block, dedicated to
+ * `frontmatter.relations`. Each row shows `kind → target` with an
+ * inline delete affordance; "Aggiungi relazione" reveals a kind+target
+ * form. Edit-in-place is intentionally not supported in v1.0 — to
+ * change a relation the user removes and re-adds it. Keeps the
+ * surface narrow until we have user signal on the right ergonomics.
+ */
+export function RelationsSection({
+  frontmatter,
+  suggestedKinds,
+  onChange,
+}: RelationsSectionProps): JSX.Element {
+  const rows = useMemo(() => relationsFromFrontmatter(frontmatter), [frontmatter]);
+
+  const [adding, setAdding] = useState(false);
+  const [kindDraft, setKindDraft] = useState('');
+  const [targetDraft, setTargetDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const cancelAdd = (): void => {
+    setAdding(false);
+    setKindDraft('');
+    setTargetDraft('');
+    setError(null);
+  };
+
+  const commitAdd = (): void => {
+    const kind = kindDraft.trim();
+    const target = targetDraft.trim();
+    if (kind.length === 0 || target.length === 0) {
+      setError('Tipo e destinazione sono entrambi obbligatori.');
+      return;
+    }
+    onChange(setRelationInFrontmatter(frontmatter, kind, target));
+    cancelAdd();
+  };
+
+  return (
+    <section className="shrink-0 border-b border-border bg-bg px-4 py-2">
+      <div className="mx-auto max-w-[720px]">
+        <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
+          Relazioni{rows.length > 0 ? ` (${rows.length})` : ''}
+        </h3>
+
+        {rows.length === 0 ? (
+          <p className="px-1 py-1 text-xs italic text-fg-muted">Nessuna relazione dichiarata.</p>
+        ) : (
+          <ul role="list" className="flex flex-col gap-0.5">
+            {rows.map((r) => (
+              <li
+                key={`${r.kind}|${r.target}`}
+                className="group flex min-h-[28px] items-center gap-2 rounded px-1 hover:bg-bg-subtle"
+              >
+                <span className="shrink-0 font-mono text-xs uppercase tracking-wide text-fg-muted">
+                  {r.kind}
+                </span>
+                <span aria-hidden="true" className="text-fg-muted">
+                  →
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm text-fg">{r.target}</span>
+                <button
+                  type="button"
+                  aria-label={`Rimuovi relazione ${r.kind} → ${r.target}`}
+                  onClick={(): void => onChange(removeRelationFromFrontmatter(frontmatter, r.kind, r.target))}
+                  className="rounded px-1 text-fg-muted opacity-0 group-hover:opacity-100 hover:bg-bg-muted hover:text-fg"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {adding ? (
+          <div className="mt-1 flex flex-col gap-1 rounded border border-border bg-bg-subtle p-2">
+            <input
+              autoFocus
+              type="text"
+              value={kindDraft}
+              placeholder="Tipo"
+              list="ziba-relation-kinds"
+              onChange={(e): void => {
+                setKindDraft(e.target.value);
+                setError(null);
+              }}
+              className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+            />
+            {suggestedKinds.length > 0 && (
+              <datalist id="ziba-relation-kinds">
+                {suggestedKinds.map((k) => (
+                  <option key={k} value={k} />
+                ))}
+              </datalist>
+            )}
+            <input
+              type="text"
+              value={targetDraft}
+              placeholder="Destinazione"
+              onChange={(e): void => {
+                setTargetDraft(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e): void => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitAdd();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelAdd();
+                }
+              }}
+              className="rounded border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent"
+            />
+            {error !== null && <span className="text-xs text-red-500">{error}</span>}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={cancelAdd}
+                className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+              >
+                Annulla
+              </button>
+              <button
+                type="button"
+                onClick={commitAdd}
+                className="rounded bg-accent px-2 py-1 text-xs font-medium text-accent-fg hover:opacity-90"
+              >
+                Aggiungi
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={(): void => setAdding(true)}
+            className="mt-1 self-start rounded px-2 py-1 text-xs text-fg-muted hover:bg-bg-muted hover:text-fg"
+          >
+            + Aggiungi relazione
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests, confirm green**
+
+```bash
+pnpm --filter ziba-desktop test -- RelationsSection
+```
+
+Expected: all 4 cases pass.
+
+- [ ] **Step 5: Wire RelationsSection into PropertyEditor**
+
+In `apps/desktop/src/components/PropertyEditor/index.tsx`, at the top of the file:
+
+```ts
+import { RelationsSection } from './RelationsSection';
+import { useTagsStore } from '../../stores/tags';
+import { useEditorStore } from '../../stores/editor';
+```
+
+> The current `PropertyEditor` is purely controlled by its `frontmatter` + `onChange` props. We resist coupling it directly to the editor store — instead, we wire the suggested kinds at the call site. Two options:
+> - **A**: extend `PropertyEditorProps` with `suggestedRelationKinds: ReadonlyArray<string>`.
+> - **B**: compute inside `PropertyEditor` by reading `useTagsStore` + a current-type prop.
+> 
+> Prefer **A** — keeps PropertyEditor a pure controlled component.
+
+Update `PropertyEditorProps`:
+
+```ts
+export type PropertyEditorProps = {
+  frontmatter: Frontmatter;
+  onChange: (next: Frontmatter) => void;
++ /**
++  * Relation kinds suggested for the current type, surfaced as
++  * autocomplete in the "Aggiungi relazione" form. Empty array =
++  * untyped note or schema-less type.
++  */
++ suggestedRelationKinds?: ReadonlyArray<string>;
+};
+```
+
+Render `<RelationsSection>` immediately after the properties block (still inside the outer `<section>` so the visual rhythm matches):
+
+```tsx
+        )}
+      </div>
++   </section>
++   <RelationsSection
++     frontmatter={frontmatter}
++     suggestedKinds={suggestedRelationKinds ?? []}
++     onChange={onChange}
++   />
++ </>
+```
+
+Wrap the existing `<section>` and the new one in a `<></>` fragment. Restructure carefully — the existing component returns one `<section>`, so the smallest change is:
+
+```tsx
+return (
+  <>
+    <section className="shrink-0 border-b border-border bg-bg px-4 py-2">
+      <div className="mx-auto max-w-[720px]">
+        {/* ...existing properties UI... */}
+      </div>
+    </section>
+    <RelationsSection
+      frontmatter={frontmatter}
+      suggestedKinds={suggestedRelationKinds ?? []}
+      onChange={onChange}
+    />
+  </>
+);
+```
+
+Update the call site in `apps/desktop/src/components/Editor/index.tsx`:
+
+```tsx
+        <PropertyEditor
+          frontmatter={currentNote.frontmatter}
+          onChange={handleFrontmatterChange}
++         suggestedRelationKinds={suggestedRelationKinds}
+        />
+```
+
+Where `suggestedRelationKinds` is the same memo computed for the slash relation flow (rename `suggestedRelationKinds` consistently across the file — Task 8 already introduced `suggestedRelationKinds`, reuse it).
+
+- [ ] **Step 6: Run the PropertyEditor tests**
+
+```bash
+pnpm --filter ziba-desktop test -- PropertyEditor
+```
+
+Expected: existing tests still green; the RelationsSection tests already pass.
+
+- [ ] **Step 7: Run a wider sanity check**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/components/PropertyEditor/RelationsSection.tsx \
+        apps/desktop/src/components/PropertyEditor/RelationsSection.test.tsx \
+        apps/desktop/src/components/PropertyEditor/index.tsx \
+        apps/desktop/src/components/Editor/index.tsx
+git commit -m "feat(v1.0 phase3): PropertyEditor RelationsSection — add/remove typed relations"
+```
+
+---
+
+## Task 10: End-to-end smoke + open the PR
+
+**Files:**
+- Manual verification (no code changes expected unless a bug surfaces).
+
+- [ ] **Step 1: Launch the desktop app against a real vault**
+
+```bash
+pnpm --filter ziba-desktop run dev
+```
+
+In the running app:
+- Open the seed vault (`pnpm seed-vault` if you haven't already; the script writes a sample vault to a known path printed at the end).
+- Open a typed note (e.g. a `book` note).
+- Verify the wikilink in the body that points to a `person` note shows the person icon prefix (e.g. `👤 Tolkien`).
+- Verify the wikilink to an untyped note has no prefix.
+- Click into the body. Type `/` at the start of an empty line — confirm "Aggiungi relazione" appears in the menu.
+- Select it. The RelationPickerPopup opens anchored at the slash position.
+- Type `author` into the kind field, `Tolkien` into the target. Click "Inserisci".
+- Confirm the PropertyEditor's "Relazioni" section now lists `author → Tolkien` and the markdown file on disk has the relation in its frontmatter.
+- Click the `×` next to the row. Confirm removal.
+
+- [ ] **Step 2: Cross-platform sanity — windows path separators (optional, if time)**
+
+If you have access to a Windows checkout, run the same smoke. The renderer uses POSIX paths internally; no expected divergence, but worth one pass.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/v1.0-phase3-editor-relations
+gh pr create --base main --title "feat(v1.0 phase 3): editor type-icon + slash relation + PropertyEditor relations" --body "$(cat <<'EOF'
+## Summary
+- Adapter `getTypedPaths()` + IPC `notes:typedPaths` returning `Map<NotePath, type>`.
+- Vault store gains a `typedPaths` slice fetched alongside notes.
+- Wikilink Tiptap node prepends the type icon at render time via a per-editor `pathByTitle` + `typeIconByPath` cache; widened `WikilinkResolutionMap` to store the resolved path.
+- New `useWikilinkTypes` hook populates the cache from vault + schemas.
+- New `/relazione` slash entry opens `RelationPickerPopup` and writes into `frontmatter.relations` via pure `relations-frontmatter` helpers.
+- PropertyEditor gains a `RelationsSection` with add/remove affordances.
+- 30+ new tests across adapter, IPC handler, vault store, Wikilink renderHTML, useWikilinkTypes, relations-frontmatter, RelationPickerPopup, RelationsSection.
+
+## Test plan
+- [x] Adapter and IPC unit tests
+- [x] Vault store slice tests
+- [x] Wikilink renderHTML edge cases (broken, untyped, aliased)
+- [x] relations-frontmatter pure helpers (scalar↔list upgrades, idempotent set, collapsing remove)
+- [x] RelationPickerPopup keyboard + suggested-kind chips
+- [x] RelationsSection add/remove
+- [x] Manual smoke on a seeded vault — type icons render, slash flow commits, frontmatter round-trips
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Merge once CI is green**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git fetch origin && git reset --hard origin/main
+```
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage**:
+   - §5.4.1 wikilink decoration with type icon — Tasks 4–5.
+   - §5.4.2 slash menu `/relazione` — Tasks 6–8.
+   - PropertyEditor relations — Task 9.
+   - §9 wikilink cache from renderer-side store (no per-render IPC) — Task 2 (vault store) + Task 5 (`useWikilinkTypes`).
+   - §8 tests: extractor / renderer / popover tests — Tasks 5–9 each include a TDD step.
+   - §11 sequencing — foundation (adapter / IPC / store) precedes UI; UI is split per surface.
+
+2. **Placeholder scan**: every step shows code; no TBD / TODO. The integration-test step (Task 8 Step 5) is intentionally a smoke stub with a comment justifying the deferral — full Tiptap integration testing requires Playwright, scoped for a separate phase.
+
+3. **Type consistency**:
+   - `WikilinkResolutionMap` = `Map<string, NotePath | false>` everywhere after Task 4.
+   - `FrontmatterRelation = { kind: string; target: string }` — used identically in helpers, RelationsSection, and (with `position`) in RelationPickerPopup.
+   - `getTypedPaths` returns `Map<NotePath, string>` on adapter, `Array<[NotePath, string]>` over IPC, `Map` again on the renderer (rebuilt at the boundary).
+   - `suggestedRelationKinds`/`suggestedKinds` — single name `suggestedKinds` in components, `suggestedRelationKinds` for the parent-level memo.

--- a/docs/superpowers/plans/2026-05-11-v1.0-phase4-database-type-filter.md
+++ b/docs/superpowers/plans/2026-05-11-v1.0-phase4-database-type-filter.md
@@ -1,0 +1,864 @@
+# Ziba v1.0 Phase 4 — Database view type filter
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A page-level "Tipo" dropdown in the DatabaseView header that scopes the table to one object type at a time, with schema-aware column suggestions surfacing the type's declared properties + relation kinds.
+
+**Architecture:** Renderer-only feature on top of the existing `useDatabaseStore` query pipeline. A new `selectedType` slice in the database store filters the query at IPC build time (the slice is silently merged into `query.filters` as a `{ kind: 'eq', key: 'type', value }` filter before sending). The user-visible FilterBar stays in sync with `query.filters` and shows no chip for the page-level filter. A new `TypeFilterDropdown` component reads `objectTypeSchemas + types` from `useTagsStore` to render the option list. `ColumnPicker` gains a `suggestedKeys` prop that renders schema-derived property + relation keys at the top of the menu.
+
+**Tech Stack:** TypeScript, React 18, Zustand, Vitest, @testing-library/react.
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md` §5.3 (Database view — type dropdown), §8 Phase 4 deliverables.
+
+## File structure
+
+### Created
+
+- `apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx` — header dropdown listing "Tutti" + every typed type with its icon and count.
+- `apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx` — interaction tests.
+
+### Modified
+
+- `apps/desktop/src/stores/database.ts` — adds `selectedType: string | null` slice + `setType(type | null)` action; runQuery merges the implicit type filter into the outgoing IPC payload.
+- `apps/desktop/src/stores/database.test.ts` — tests for the new slice + filter-merge behaviour.
+- `apps/desktop/src/components/DatabaseView/index.tsx` — mounts `<TypeFilterDropdown>`, threads `selectedType` + `suggestedColumnKeys` through to `<ColumnPicker>`.
+- `apps/desktop/src/components/DatabaseView/ColumnPicker.tsx` — accepts an optional `suggestedKeys` prop and renders those keys at the top of the menu (separated from the rest by a divider when both groups are non-empty).
+- `apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx` — new file if it doesn't already exist; otherwise extended with suggested-keys cases.
+
+---
+
+## Task 1: Database store — `selectedType` slice
+
+**Files:**
+- Modify: `apps/desktop/src/stores/database.ts`
+- Modify: `apps/desktop/src/stores/database.test.ts`
+
+- [ ] **Step 1: Read the existing store + test file end-to-end**
+
+The store currently exposes `query`, `result`, `loading`, `error`, `availableProperties`, `lastUpdatedAt`, plus mutators for `filters`, `sort`, `groupBy`, `folder`. `runQuery` calls `ipc.runDatabaseQuery({ query })` and merges results.
+
+The test file uses the pattern: `vi.resetModules()` + `installMockIpc` + `loadStore()`. Mirror it.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `apps/desktop/src/stores/database.test.ts`:
+
+```ts
+describe('useDatabaseStore — selectedType slice', () => {
+  it('initial state is null', async () => {
+    const { useDatabaseStore } = await loadStore();
+    expect(useDatabaseStore.getState().selectedType).toBeNull();
+  });
+
+  it('setType(value) stores the slug', async () => {
+    const { useDatabaseStore } = await loadStore();
+    mock.setHandler(IpcChannels.runDatabaseQuery, async () => ({
+      rows: [],
+      groups: [],
+      totalCount: 0,
+    }));
+    useVaultStore.setState({ current: VAULT_A });
+    useDatabaseStore.getState().setType('book');
+    expect(useDatabaseStore.getState().selectedType).toBe('book');
+  });
+
+  it('setType(null) clears the slug', async () => {
+    const { useDatabaseStore } = await loadStore();
+    useDatabaseStore.setState({ selectedType: 'book' });
+    useDatabaseStore.getState().setType(null);
+    expect(useDatabaseStore.getState().selectedType).toBeNull();
+  });
+
+  it('runQuery merges a {type=value} eq filter into the outgoing query when selectedType is set', async () => {
+    const { useDatabaseStore } = await loadStore();
+    useVaultStore.setState({ current: VAULT_A });
+    useDatabaseStore.setState({ selectedType: 'book' });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed).not.toBeNull();
+    expect(observed!.filters).toEqual([{ kind: 'eq', key: 'type', value: 'book' }]);
+  });
+
+  it('runQuery preserves user filters AND prepends the type filter', async () => {
+    const { useDatabaseStore } = await loadStore();
+    useVaultStore.setState({ current: VAULT_A });
+    const userFilter: ScalarFilter = { kind: 'eq', key: 'year', value: 1937 };
+    useDatabaseStore.setState({
+      selectedType: 'book',
+      query: { filters: [userFilter], limit: 1000 },
+    });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed!.filters).toEqual([
+      { kind: 'eq', key: 'type', value: 'book' },
+      userFilter,
+    ]);
+  });
+
+  it('runQuery does NOT include a type filter when selectedType is null', async () => {
+    const { useDatabaseStore } = await loadStore();
+    useVaultStore.setState({ current: VAULT_A });
+    useDatabaseStore.setState({ selectedType: null });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().runQuery();
+
+    expect(observed!.filters?.some((f) => f.key === 'type')).toBe(false);
+  });
+
+  it('setType(value) schedules a re-run', async () => {
+    const { useDatabaseStore } = await loadStore();
+    useVaultStore.setState({ current: VAULT_A });
+    const spy = vi.fn(async () => ({ rows: [], groups: [], totalCount: 0 }));
+    mock.setHandler(IpcChannels.runDatabaseQuery, spy);
+    useDatabaseStore.getState().setType('book');
+    // Wait for the debounced run.
+    await vi.waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+Use the existing `VAULT_A`, `useVaultStore`, `mock`, `loadStore`, `IpcChannels`, `ScalarFilter`, `DatabaseQuery` imports — check the top of `database.test.ts` to confirm the exact import names; if any is missing, add it. The `vi.waitFor` import comes from `vitest`.
+
+- [ ] **Step 3: Run tests, expect failure**
+
+```bash
+pnpm --filter ziba-desktop test -- database.test
+```
+
+Expected: `setType is not a function`, `selectedType` undefined, type-filter merge missing.
+
+- [ ] **Step 4: Implement the slice**
+
+In `apps/desktop/src/stores/database.ts`:
+
+a. Extend `DatabaseState`:
+
+```ts
+type DatabaseState = {
+  query: DatabaseQuery;
+  result: DatabaseResult | null;
+  loading: boolean;
+  error: string | null;
+  availableProperties: string[];
+  lastUpdatedAt: number | null;
+  /**
+   * v1.0 Phase 4: page-level type filter. When non-null, runQuery
+   * prepends `{ kind: 'eq', key: 'type', value: selectedType }` to
+   * the outgoing IPC filter list. Kept out of `query.filters` so the
+   * FilterBar doesn't render a redundant chip for the page-level
+   * scope.
+   */
+  selectedType: string | null;
+
+  // ...rest unchanged
+  setFilters(filters: ScalarFilter[]): void;
+  // ...
+  setType(type: string | null): void;
+  // ...
+};
+```
+
+b. Initial state:
+
+```ts
+    selectedType: null,
+```
+
+c. `setType` action (near `setFolder`):
+
+```ts
+    setType(type) {
+      set({ selectedType: type });
+      scheduleRun();
+    },
+```
+
+d. Modify `runQuery` to build the outgoing query. Find the line where it calls `ipc.runDatabaseQuery({ query })`. Replace with:
+
+```ts
+    async runQuery() {
+      // Skip if no vault open — same guard as before.
+      if (useVaultStore.getState().current === null) {
+        debouncedRun.cancel();
+        set({
+          result: null,
+          loading: false,
+          error: null,
+          availableProperties: [],
+        });
+        return;
+      }
+      const seq = ++requestSeq;
+      set({ loading: true });
+      try {
+        const baseQuery = get().query;
+        const selectedType = get().selectedType;
+        const outgoingFilters: ScalarFilter[] =
+          selectedType === null
+            ? baseQuery.filters ?? []
+            : [
+                { kind: 'eq', key: 'type', value: selectedType },
+                ...(baseQuery.filters ?? []),
+              ];
+        const outgoing: DatabaseQuery = { ...baseQuery, filters: outgoingFilters };
+        const result = await ipc.runDatabaseQuery({ query: outgoing });
+        if (seq !== requestSeq) return;
+        set({
+          result,
+          availableProperties: deriveAvailableProperties(result),
+          loading: false,
+          error: null,
+          lastUpdatedAt: Date.now(),
+        });
+      } catch (err) {
+        if (seq !== requestSeq) return;
+        set({ loading: false, error: ipcErrorMessage(err) });
+      }
+    },
+```
+
+(Read the existing `runQuery` first to confirm the seq-tracking pattern; mirror it. Only the filter-merge step is new.)
+
+- [ ] **Step 5: Run tests, expect pass**
+
+```bash
+pnpm --filter ziba-desktop test -- database.test
+```
+
+Expected: all new cases green; existing tests still pass.
+
+- [ ] **Step 6: Full sanity**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: all green. Test count delta: +7 (or +6 if you find a cleaner test merge).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/stores/database.ts apps/desktop/src/stores/database.test.ts
+git commit -m "feat(v1.0 phase4): database store — selectedType slice + filter merge"
+```
+
+---
+
+## Task 2: `TypeFilterDropdown` component
+
+**Files:**
+- Create: `apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx`
+- Create: `apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TypeFilterDropdown } from './TypeFilterDropdown';
+
+const TYPES = [
+  { id: 'book', label: 'Libro', icon: '📖', color: null, count: 12 },
+  { id: 'person', label: 'Persona', icon: '👤', color: null, count: 8 },
+];
+
+describe('<TypeFilterDropdown>', () => {
+  it('shows "Tutti" when selectedType is null', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Tipo: Tutti/i })).toBeInTheDocument();
+  });
+
+  it('shows the selected type label when one is selected', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType="book" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Tipo: 📖 Libro/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the type slug when no schema label is available', () => {
+    render(
+      <TypeFilterDropdown
+        types={[]}
+        selectedType="custom"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Tipo: custom/i })).toBeInTheDocument();
+  });
+
+  it('opening the dropdown lists Tutti + every type with its count', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByRole('menuitemradio', { name: /Tutti/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /📖 Libro \(12\)/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /👤 Persona \(8\)/ })).toBeInTheDocument();
+  });
+
+  it('selecting "Tutti" calls onChange(null) and closes the menu', () => {
+    const onChange = vi.fn();
+    render(<TypeFilterDropdown types={TYPES} selectedType="book" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Tutti/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
+  });
+
+  it('selecting a type calls onChange with its id', () => {
+    const onChange = vi.fn();
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /📖 Libro/i }));
+    expect(onChange).toHaveBeenCalledWith('book');
+  });
+
+  it('closes on outside click', () => {
+    render(
+      <div>
+        <TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />
+        <button type="button">elsewhere</button>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByRole('menuitemradio', { name: /Tutti/i })).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'elsewhere' }));
+    expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+pnpm --filter ziba-desktop test -- TypeFilterDropdown
+```
+
+Expected: module not found.
+
+- [ ] **Step 3: Implement the dropdown**
+
+`apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
+
+export type TypeFilterOption = {
+  /** Type slug (e.g. `book`). */
+  id: string;
+  /** Display label — usually the schema's `label`, falls back to the id. */
+  label: string;
+  /** Optional emoji / glyph. */
+  icon: string | null;
+  /** Optional color (currently unused in the dropdown but kept for parity with `useTagsStore.types`). */
+  color: string | null;
+  /** Number of notes carrying this type. */
+  count: number;
+};
+
+type Props = {
+  /** Every typed type currently in the vault, with metadata. */
+  types: ReadonlyArray<TypeFilterOption>;
+  /** Active filter slug, or null when "Tutti" is selected. */
+  selectedType: string | null;
+  onChange(type: string | null): void;
+};
+
+/**
+ * Page-level type filter in the DatabaseView header. Mirrors the
+ * ColumnPicker dropdown architecture: local open/closed state, close
+ * on outside-click via `mousedown`, no portal (the header has enough
+ * room for an absolute-positioned menu).
+ */
+export function TypeFilterDropdown({
+  types,
+  selectedType,
+  onChange,
+}: Props): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent): void => {
+      const node = containerRef.current;
+      if (node === null) return;
+      if (e.target instanceof Node && !node.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    return () => window.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  const activeOption = selectedType === null ? null : types.find((t) => t.id === selectedType);
+  const buttonLabel = (() => {
+    if (selectedType === null) return 'Tipo: Tutti';
+    if (activeOption === undefined || activeOption === null) return `Tipo: ${selectedType}`;
+    const icon = activeOption.icon !== null && activeOption.icon !== '' ? `${activeOption.icon} ` : '';
+    return `Tipo: ${icon}${activeOption.label}`;
+  })();
+
+  const choose = (next: string | null): void => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={(): void => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+      >
+        {buttonLabel}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Filtra per tipo"
+          className="absolute left-0 top-[calc(100%+4px)] z-20 max-h-72 w-56 overflow-auto rounded-md border border-border bg-bg-subtle p-1 shadow-lg"
+        >
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={selectedType === null}
+            onClick={(): void => choose(null)}
+            className={[
+              'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
+              selectedType === null ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+            ].join(' ')}
+          >
+            <span className="flex-1 truncate">Tutti</span>
+          </button>
+          {types.length === 0 && (
+            <p className="px-2 py-1.5 text-xs italic text-fg-muted">Nessun tipo nel vault.</p>
+          )}
+          {types.map((t) => {
+            const isActive = t.id === selectedType;
+            const iconPrefix = t.icon !== null && t.icon !== '' ? `${t.icon} ` : '';
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={isActive}
+                onClick={(): void => choose(t.id)}
+                className={[
+                  'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
+                  isActive ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+                ].join(' ')}
+              >
+                <span className="flex-1 truncate">{`${iconPrefix}${t.label}`}</span>
+                <span className="tabular-nums text-fg-muted">{`(${t.count})`}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests, expect green**
+
+```bash
+pnpm --filter ziba-desktop test -- TypeFilterDropdown
+```
+
+Expected: 7 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx \
+        apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
+git commit -m "feat(v1.0 phase4): TypeFilterDropdown — page-level type filter"
+```
+
+---
+
+## Task 3: ColumnPicker — schema-aware suggestions
+
+**Files:**
+- Modify: `apps/desktop/src/components/DatabaseView/ColumnPicker.tsx`
+- Create or modify: `apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx`
+
+- [ ] **Step 1: Inspect for an existing test file**
+
+```bash
+ls apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx 2>/dev/null || echo "MISSING"
+```
+
+If missing, create with full coverage of existing behaviour + the new prop. If present, extend.
+
+- [ ] **Step 2: Write the failing tests**
+
+For the new prop, add (or as a fresh file):
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ColumnPicker } from './ColumnPicker';
+
+describe('<ColumnPicker> — suggestedKeys', () => {
+  it('renders suggested keys in a dedicated group at the top of the menu', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        suggestedKeys={['author', 'isbn']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+
+    expect(screen.getByText('author')).toBeInTheDocument();
+    expect(screen.getByText('isbn')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('year')).toBeInTheDocument();
+    // Suggested-group heading is visible.
+    expect(screen.getByText('Suggerite')).toBeInTheDocument();
+  });
+
+  it('does not render a suggested group when the prop is empty', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        suggestedKeys={[]}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.queryByText('Suggerite')).not.toBeInTheDocument();
+  });
+
+  it('clicking a suggested key adds it to visibleColumns even if not in availableProperties', () => {
+    const onChange = vi.fn();
+    render(
+      <ColumnPicker
+        availableProperties={['title']}
+        suggestedKeys={['author']}
+        visibleColumns={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    fireEvent.click(screen.getByLabelText('author'));
+    expect(onChange).toHaveBeenCalledWith(['author']);
+  });
+
+  it('deduplicates keys that appear in both suggested and available lists', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'author']}
+        suggestedKeys={['author']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    // `author` should appear once — in the suggested group.
+    const authorMatches = screen.getAllByText('author');
+    expect(authorMatches.length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests, expect failure**
+
+```bash
+pnpm --filter ziba-desktop test -- ColumnPicker
+```
+
+Expected: type errors around `suggestedKeys` prop missing, or behaviour mismatch.
+
+- [ ] **Step 4: Extend ColumnPicker**
+
+In `apps/desktop/src/components/DatabaseView/ColumnPicker.tsx`:
+
+a. Add `suggestedKeys` to the props:
+
+```ts
+type Props = {
+  availableProperties: string[];
+  /**
+   * Schema-derived keys to surface at the top of the menu, separated
+   * from the discovered-from-rows keys. Sourced from the active type's
+   * properties + relation kinds. Optional; empty array suppresses the
+   * suggested group.
+   */
+  suggestedKeys?: ReadonlyArray<string>;
+  visibleColumns: string[];
+  onChange(next: string[]): void;
+};
+```
+
+b. Compute the deduplicated lists at the top of the component body:
+
+```ts
+  const suggested = props.suggestedKeys ?? [];
+  const suggestedSet = new Set(suggested);
+  const restProperties = props.availableProperties.filter((k) => !suggestedSet.has(k));
+```
+
+c. In the toggle function, when a key is added but not in `availableProperties`, just append it to the end (it'll get picked up by the existing alphabetical-then-append logic — but since suggested keys may not be in availableProperties at all, the sort would put them at `-1` index → first position. Adjust the comparator to fall back to "append at end" for unknown keys):
+
+```ts
+  const toggle = (key: string): void => {
+    if (visibleSet.has(key)) {
+      props.onChange(props.visibleColumns.filter((k) => k !== key));
+      return;
+    }
+    // Keep stable column order. For keys that exist in availableProperties,
+    // slot them into their alphabetical position; for schema-suggested
+    // keys absent from availableProperties (yet — the user is adding it
+    // ahead of any row having a value), append at the end.
+    const next = [...props.visibleColumns, key].sort((a, b) => {
+      const ai = props.availableProperties.indexOf(a);
+      const bi = props.availableProperties.indexOf(b);
+      if (ai === -1 && bi === -1) return 0;
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    props.onChange(next);
+  };
+```
+
+d. Render the menu with the suggested group + a divider + the rest:
+
+```tsx
+      {open && (
+        <div
+          role="menu"
+          aria-label="Colonne visibili"
+          className="absolute right-0 top-[calc(100%+4px)] z-20 max-h-72 w-56 overflow-auto rounded-md border border-border bg-bg-subtle p-1 shadow-lg"
+        >
+          {suggested.length > 0 && (
+            <>
+              <p className="px-2 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-fg-muted">
+                Suggerite
+              </p>
+              {suggested.map((key) => renderRow(key))}
+              {restProperties.length > 0 && (
+                <div role="separator" className="my-1 border-t border-border" />
+              )}
+            </>
+          )}
+          {restProperties.length === 0 && suggested.length === 0 && (
+            <p className="px-2 py-1.5 text-xs text-fg-muted">Nessuna proprietà rilevata.</p>
+          )}
+          {restProperties.map((key) => renderRow(key))}
+        </div>
+      )}
+```
+
+Extract `renderRow` as a local helper that produces the `<label>` + checkbox block (existing JSX), keyed on `key`.
+
+> Don't update the props signature beyond `suggestedKeys` — keep the destructuring (or change to `props.foo` access) consistent.
+
+- [ ] **Step 5: Run tests, expect green**
+
+```bash
+pnpm --filter ziba-desktop test -- ColumnPicker
+```
+
+Expected: 4 cases green; existing behaviour preserved.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/components/DatabaseView/ColumnPicker.tsx \
+        apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx
+git commit -m "feat(v1.0 phase4): ColumnPicker — schema-aware suggested keys group"
+```
+
+---
+
+## Task 4: Wire `TypeFilterDropdown` into DatabaseView header
+
+**Files:**
+- Modify: `apps/desktop/src/components/DatabaseView/index.tsx`
+
+- [ ] **Step 1: Read the existing header markup**
+
+The header in `index.tsx` has three rows: title row (with `ColumnPicker`), `FilterBar` row, and the bottom controls row. The TypeFilterDropdown should sit in the bottom controls row, BEFORE `SortControls`, so the visual flow is "filter → sort → group → folder → view".
+
+Actually, on reflection: the dropdown is a primary scope, not a secondary control. Better placement: in the title row, between the metadata and `ColumnPicker`. Use that location.
+
+- [ ] **Step 2: Wire reads from the stores**
+
+At the top of the component:
+
+```ts
+  const selectedType = useDatabaseStore((s) => s.selectedType);
+  const setType = useDatabaseStore((s) => s.setType);
+  const tagTypes = useTagsStore((s) => s.types);
+  const tagSchemas = useTagsStore((s) => s.objectTypeSchemas);
+```
+
+Build the option list. The store already aggregates count + label + icon via `useTagsStore.types`, but only includes types that have count > 0. That's exactly what we want — types declared in a schema but unused in the vault shouldn't appear in the dropdown.
+
+```ts
+  const typeOptions = tagTypes; // already { id, label, icon, color, count }[]
+```
+
+Build the suggested-keys list for ColumnPicker:
+
+```ts
+  const suggestedColumnKeys = useMemo<string[]>(() => {
+    if (selectedType === null) return [];
+    const schema = tagSchemas.find((s) => s.id === selectedType);
+    if (schema === undefined) return [];
+    const propKeys = Object.keys(schema.schema.properties);
+    const relKeys = Object.keys(schema.schema.relations);
+    // Stable order: properties first, then relations. Dedup against
+    // themselves only — overlap with availableProperties is handled in
+    // ColumnPicker.
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const k of [...propKeys, ...relKeys]) {
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(k);
+    }
+    return out;
+  }, [selectedType, tagSchemas]);
+```
+
+- [ ] **Step 3: Mount the dropdown + pass suggestedKeys to ColumnPicker**
+
+In the title row of the header:
+
+```tsx
+          <div className="flex items-baseline gap-3">
+            <h1 className="text-base font-semibold text-fg">Database</h1>
+            <span className="text-xs text-fg-muted">{noteCountLabel}</span>
+            {/* ...existing loading / lastUpdatedLabel spans... */}
+          </div>
++         <div className="flex items-center gap-2">
++           <TypeFilterDropdown
++             types={typeOptions}
++             selectedType={selectedType}
++             onChange={setType}
++           />
+            <ColumnPicker
+              availableProperties={availableProperties}
++             suggestedKeys={suggestedColumnKeys}
+              visibleColumns={visibleColumns}
+              onChange={setVisibleColumns}
+            />
++         </div>
+```
+
+Make sure `<ColumnPicker>` and `<TypeFilterDropdown>` are on the same flex row and not pushed apart — the existing `justify-between` on the outer flex row achieves this naturally if we wrap both in one container.
+
+- [ ] **Step 4: Imports**
+
+```ts
+import { TypeFilterDropdown } from './TypeFilterDropdown';
+import { useTagsStore } from '../../stores/tags';
+```
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: green, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/components/DatabaseView/index.tsx
+git commit -m "feat(v1.0 phase4): mount TypeFilterDropdown + thread schema-suggested columns"
+```
+
+---
+
+## Task 5: E2E smoke + open the PR
+
+**Files:** Manual verification — code changes only if a bug surfaces.
+
+- [ ] **Step 1: Manual smoke**
+
+Open the desktop app, switch to the Database view. Verify:
+- "Tipo: Tutti" appears in the header.
+- Opening the dropdown lists every typed type in the vault with `icon label (count)`.
+- Selecting a type narrows the table to that type and the "Suggerite" group appears at the top of the ColumnPicker dropdown listing the schema's property + relation keys.
+- "Tutti" clears the filter.
+- The FilterBar does NOT show a `type = book` chip when the page-level filter is active.
+
+If you can't run the app in the current environment, say so explicitly — don't claim success.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+git push -u origin feat/v1.0-phase4-database-type-filter
+gh pr create --base main --title "feat(v1.0 phase 4): database view type filter + schema-aware columns" --body "$(cat <<'EOF'
+## Summary
+- New `selectedType` slice in the database store. `runQuery` merges `{ kind: 'eq', key: 'type', value: <type> }` into the outgoing IPC filters without exposing a FilterBar chip.
+- New `<TypeFilterDropdown>` in the DatabaseView header. Reads `types` + `objectTypeSchemas` from `useTagsStore`; emits `string | null` on change.
+- `<ColumnPicker>` learns a `suggestedKeys` prop — schema-derived properties + relation kinds rendered above the available-from-rows list with a "Suggerite" header.
+
+## Test plan
+- [x] Database store: selectedType slice, setType action, runQuery filter merge, debounced re-run
+- [x] TypeFilterDropdown: empty selected state, schema-decorated active state, list, outside-click close
+- [x] ColumnPicker: suggested group rendering, dedup against availableProperties, adding a not-yet-present key
+- [ ] Manual smoke
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge after CI green**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git fetch origin && git reset --hard origin/main
+```
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage**:
+   - §5.3 dropdown — Task 2 + Task 4
+   - §5.3 implicit `type=value` filter — Task 1
+   - §5.3 column suggestions from schema — Task 3 + Task 4 wiring
+   - §8 Phase 4 deliverables — all four bullets covered
+
+2. **Placeholder scan**: every step has actual code; no TBD/TODO; the manual smoke is the only step without a code block, and that's intentional.
+
+3. **Type consistency**:
+   - `TypeFilterOption` matches the shape returned by `useTagsStore.types` (already `{ id, label, icon: string | null, color: string | null, count }`).
+   - `suggestedKeys: ReadonlyArray<string>` everywhere (prop + memo + Set).
+   - `selectedType: string | null` everywhere (store, prop, callback).

--- a/docs/superpowers/plans/2026-05-11-v1.0-phase5-constellation-graph.md
+++ b/docs/superpowers/plans/2026-05-11-v1.0-phase5-constellation-graph.md
@@ -1,0 +1,1043 @@
+# Ziba v1.0 Phase 5 — Constellation graph
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the global graph view type-aware: nodes cluster by `type:`, optional convex-hull overlays make clusters visible at a glance, edges color by relation `kind`, a header row of type chips + kind filter dropdown + legend lets the user focus on a slice.
+
+**Architecture:** Renderer-side feature on top of the existing `getFullGraph()` IPC. The adapter is extended to emit `type` + `color` per node and `kind` per edge. The hand-rolled force simulator gains a same-type bias pulling nodes of the same type slightly together (additive force; no API change to consumers). A new pure `convexHull` module computes the polygon for each visible type with ≥ 3 nodes. The `Canvas` component accepts the new per-node / per-edge metadata and renders a hulls layer underneath the existing nodes/edges, plus edge color from a deterministic kind→HSL hash. The `GlobalGraph` header gains a chip row (type filter), a kind multi-select dropdown, a legend overlay, and a "Mostra cluster" toggle.
+
+**Tech Stack:** TypeScript, React 18, SVG (no canvas/WebGL), Vitest. No new dependencies — the convex hull is a small Andrew's monotone-chain implementation.
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-10-v1.0-object-relational-design.md` §4.3 (extended `getFullGraph()`), §6 (Constellation graph: cluster bias, hulls, edge styling, type chips, legend), §8 Phase 5 deliverables, §10 success criterion 3.
+
+## File structure
+
+### Created
+
+- `apps/desktop/src/components/GlobalGraph/convexHull.ts` — pure Andrew's monotone-chain implementation. `convexHull(points: { x: number; y: number }[]): { x: number; y: number }[]`.
+- `apps/desktop/src/components/GlobalGraph/convexHull.test.ts` — unit tests.
+- `apps/desktop/src/components/GlobalGraph/HullsLayer.tsx` — SVG `<g>` rendering one `<path>` per type with ≥ 3 nodes.
+- `apps/desktop/src/components/GlobalGraph/HullsLayer.test.tsx` — render tests (Vitest + jsdom + @testing-library/react).
+- `apps/desktop/src/components/GlobalGraph/TypeChips.tsx` — header chip row with single-select type filter + "Tutti" reset.
+- `apps/desktop/src/components/GlobalGraph/TypeChips.test.tsx` — interaction tests.
+- `apps/desktop/src/components/GlobalGraph/KindFilterDropdown.tsx` — multi-select dropdown for relation kinds.
+- `apps/desktop/src/components/GlobalGraph/KindFilterDropdown.test.tsx` — interaction tests.
+- `apps/desktop/src/components/GlobalGraph/Legend.tsx` — top-right floating panel listing active type colors + active relation kinds.
+- `apps/desktop/src/lib/kind-color.ts` — pure `kindToHsl(kind: string): string` deterministic hash; reusable in Canvas + Legend.
+- `apps/desktop/src/lib/kind-color.test.ts` — unit tests.
+
+### Modified
+
+- `packages/core/src/query/index.ts` — extend `GraphNode` with optional `type?: string | null` and `color?: string | null`; extend `GraphEdge` with `kind: string` (`''` sentinel for generic body wikilinks; never null on the wire so consumers don't have to branch on it).
+- `apps/desktop/electron/adapters/index-store.sqlite.ts` — extend `graphNodes` SQL to LEFT JOIN `note_properties` for `type` + LEFT JOIN `object_types` for `color`; extend `graphEdges` SQL to already-present `kind` field (no SQL change) and update the JS to thread it through; update the `getFullGraph` method body to map the new columns. New `graph_nodes_idx` consideration if perf needs it (skip for v1.0 — the join is on indexed columns).
+- `apps/desktop/electron/adapters/index-store.sqlite.test.ts` — extend `getFullGraph` adapter tests to cover the new columns.
+- `apps/desktop/shared/ipc.ts` — re-exports stay automatic via `@ziba/core`; no shared-type changes here.
+- `apps/desktop/src/components/MiniGraph/layout.ts` — add an optional `kClusterStrength` constant + `nodeType` field on `LayoutNode` so the cluster bias is opt-in; when both are absent (mini-graph case) the loop is a no-op. Mini-graph callers don't pass them — backward-compat.
+- `apps/desktop/src/components/MiniGraph/layout.test.ts` — extend with a 2-cluster synthetic graph test (only if a test file exists; if not, add tests for the new bias force in a dedicated `cluster-bias.test.ts` next to `layout.ts`).
+- `apps/desktop/src/components/GlobalGraph/layout.ts` — pass `nodeType` through `initializePositions`; expose `CLUSTER_STRENGTH` constant; thread to the simulator.
+- `apps/desktop/src/components/GlobalGraph/Canvas.tsx` — accept `CanvasNode { type, color }` (optional) + `CanvasEdge { kind }`; render hulls underneath; tint edge per kind; tint node fill via type color when known.
+- `apps/desktop/src/components/GlobalGraph/index.tsx` — wire `useTagsStore.objectTypeSchemas` for color lookups; build the canvas nodes/edges with type/color/kind; manage `selectedType: string | null`, `selectedKinds: Set<string>` (multi), `clusterOverlayOn: boolean` state; mount `<TypeChips>`, `<KindFilterDropdown>`, `<Legend>`, "Mostra cluster" toggle in the header.
+- `apps/desktop/src/lib/graph-tuning.ts` — new `GRAPH_CLUSTER_STRENGTH = 0.3` constant.
+
+---
+
+## Task 1: Core types + adapter SQL
+
+**Files:**
+- Modify: `packages/core/src/query/index.ts`
+- Modify: `apps/desktop/electron/adapters/index-store.sqlite.ts`
+- Modify: `apps/desktop/electron/adapters/index-store.sqlite.test.ts`
+
+- [ ] **Step 1: Extend core types**
+
+In `packages/core/src/query/index.ts`, change:
+
+```ts
+export type GraphNode = {
+  path: NotePath;
+  title: string;
+};
+
+export type GraphEdge = {
+  source: NotePath;
+  target: NotePath;
+  targetTitle: string;
+};
+```
+
+to:
+
+```ts
+export type GraphNode = {
+  path: NotePath;
+  title: string;
+  /** v1.0 Phase 5: type slug from the note's frontmatter, when present. */
+  type: string | null;
+  /** v1.0 Phase 5: hex color from the type's schema, when both are known. */
+  color: string | null;
+};
+
+export type GraphEdge = {
+  source: NotePath;
+  target: NotePath;
+  targetTitle: string;
+  /** v1.0 Phase 5: relation kind. `''` (sentinel) = generic body wikilink. */
+  kind: string;
+};
+```
+
+> Decision: `type` / `color` are `string | null` (not `undefined`) so the wire shape stays serializable and matches the rest of the IPC contract. `kind` is `string` with `''` sentinel for generic body wikilinks — matches the relations table semantics from Phase 1.
+
+- [ ] **Step 2: Extend the adapter SQL**
+
+In `apps/desktop/electron/adapters/index-store.sqlite.ts`, update the `graphNodes` prepared statement (around line 312):
+
+```ts
+      graphNodes: db.prepare(`
+        SELECT
+          n.path  AS path,
+          n.title AS title,
+          np.text_value AS type,
+          ot.color      AS color
+        FROM notes n
+        LEFT JOIN note_properties np
+          ON np.source_path = n.path
+         AND np.prop_key = 'type'
+         AND np.prop_type = 'text'
+         AND np.text_value IS NOT NULL
+         AND np.text_value <> ''
+        LEFT JOIN object_types ot ON ot.id = np.text_value
+      `),
+```
+
+> The `graphEdges` SQL already includes `r.kind AS kind`; no SQL change there. The change is in the JS mapping below.
+
+Update the `getFullGraph` method body:
+
+```ts
+  async getFullGraph(): Promise<FullGraph> {
+    const s = this.require();
+    type NodeRow = {
+      path: string;
+      title: string;
+      type: string | null;
+      color: string | null;
+    };
+    type EdgeRow = {
+      source: string;
+      target: string;
+      target_title: string;
+      kind: string;
+    };
+    const nodes = (s.graphNodes.all() as NodeRow[]).map((r) => ({
+      path: r.path,
+      title: r.title,
+      type: r.type,
+      color: r.color,
+    }));
+    const edges = (s.graphEdges.all() as EdgeRow[]).map((r) => ({
+      source: r.source,
+      target: r.target,
+      targetTitle: r.target_title,
+      kind: r.kind,
+    }));
+    return Promise.resolve({ nodes, edges });
+  }
+```
+
+- [ ] **Step 3: Extend the adapter test**
+
+In `apps/desktop/electron/adapters/index-store.sqlite.test.ts`, find or add a `describe('graph — getFullGraph SQL', ...)` block. Add cases:
+
+```ts
+describe('graph nodes — type + color join', () => {
+  it('returns null type/color for untyped notes', () => {
+    setupNote('untyped.md');
+    const rows = db
+      .prepare(
+        `SELECT n.path AS path, n.title AS title, np.text_value AS type, ot.color AS color
+         FROM notes n
+         LEFT JOIN note_properties np
+           ON np.source_path = n.path AND np.prop_key = 'type'
+          AND np.prop_type = 'text' AND np.text_value IS NOT NULL AND np.text_value <> ''
+         LEFT JOIN object_types ot ON ot.id = np.text_value`,
+      )
+      .all() as Array<{ path: string; title: string; type: string | null; color: string | null }>;
+    expect(rows).toEqual([{ path: 'untyped.md', title: 'untyped', type: null, color: null }]);
+  });
+
+  it('returns the type slug + null color when no schema is cached for the type', () => {
+    setupNote('book.md');
+    db.prepare(
+      `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+       VALUES (?, 'type', 'text', 'book')`,
+    ).run('book.md');
+    const rows = db
+      .prepare(/* same SQL as above */)
+      .all() as Array<{ path: string; type: string | null; color: string | null }>;
+    expect(rows[0]?.type).toBe('book');
+    expect(rows[0]?.color).toBeNull();
+  });
+
+  it('returns type + color when a schema with a color is cached', () => {
+    setupNote('book.md');
+    db.prepare(
+      `INSERT INTO note_properties (source_path, prop_key, prop_type, text_value)
+       VALUES (?, 'type', 'text', 'book')`,
+    ).run('book.md');
+    db.prepare(
+      `INSERT INTO object_types (id, label, icon, color, schema_json, mtime)
+       VALUES ('book', 'Libro', '📖', '#6366f1', '{}', 0)`,
+    ).run();
+    const rows = db
+      .prepare(/* same SQL as above */)
+      .all() as Array<{ path: string; type: string | null; color: string | null }>;
+    expect(rows[0]?.type).toBe('book');
+    expect(rows[0]?.color).toBe('#6366f1');
+  });
+});
+
+describe('graph edges — kind passthrough', () => {
+  it('returns the kind column on every edge ("" for generic body wikilinks)', () => {
+    setupNote('a.md');
+    setupNote('b.md');
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, '', 'B', 'b.md'), (?, 'author', 'B', 'b.md')`,
+    ).run('a.md', 'a.md');
+    const rows = db
+      .prepare(
+        `SELECT r.source_path AS source, r.target_path AS target,
+                n.title AS target_title, r.kind AS kind
+         FROM relations r
+         JOIN notes n ON n.path = r.target_path
+         WHERE r.target_path IS NOT NULL
+         ORDER BY r.kind`,
+      )
+      .all() as Array<{ source: string; target: string; target_title: string; kind: string }>;
+    expect(rows.map((r) => r.kind)).toEqual(['', 'author']);
+  });
+});
+```
+
+Inline the actual SQL in the second/third tests if the editor's `same SQL as above` shortcut is hard to maintain — just paste the full SQL.
+
+- [ ] **Step 4: Run tests + sanity**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm --filter ziba-desktop test -- index-store.sqlite.test
+```
+
+Expect green. Also the existing `getFullGraph`-using tests should still pass — but since `GraphNode` now requires `type` and `color`, any test file constructing GraphNode literals will need to add `type: null, color: null` (and `kind: ''` on edge literals). Check with:
+
+```bash
+grep -rn "GraphNode\b\|GraphEdge\b" apps/desktop --include="*.ts" --include="*.tsx" | grep -v ".test."
+```
+
+Update test fixtures that hand-craft graphs to include the new required fields (or downgrade them to optional via `?: ...` if existing code can't easily set them — but per the design they're nullable strings, not optional).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/query/index.ts \
+        apps/desktop/electron/adapters/index-store.sqlite.ts \
+        apps/desktop/electron/adapters/index-store.sqlite.test.ts \
+        apps/desktop/shared/ipc.ts
+git commit -m "feat(v1.0 phase5): extend GraphNode/Edge with type+color+kind"
+```
+
+> `shared/ipc.ts` may not need any change (it re-exports from `@ziba/core`); only stage it if you actually edited it (e.g. to update the re-export list or a comment). If unchanged, drop from the staged list.
+
+---
+
+## Task 2: `kind-color.ts` — deterministic kind → HSL hash
+
+**Files:**
+- Create: `apps/desktop/src/lib/kind-color.ts`
+- Create: `apps/desktop/src/lib/kind-color.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { kindToHsl } from './kind-color';
+
+describe('kindToHsl', () => {
+  it('returns the same color for the same kind', () => {
+    expect(kindToHsl('author')).toBe(kindToHsl('author'));
+  });
+
+  it('returns different colors for different kinds (high probability)', () => {
+    expect(kindToHsl('author')).not.toBe(kindToHsl('cites'));
+    expect(kindToHsl('author')).not.toBe(kindToHsl('in_series'));
+  });
+
+  it('returns a valid hsl() string with consistent S/L', () => {
+    const re = /^hsl\(\d+(\.\d+)?, \d+%, \d+%\)$/;
+    expect(kindToHsl('author')).toMatch(re);
+    expect(kindToHsl('cites')).toMatch(re);
+  });
+
+  it('returns a fallback color for the empty-string sentinel', () => {
+    expect(kindToHsl('')).toBe('hsl(0, 0%, 60%)');
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+const SATURATION_PCT = 55;
+const LIGHTNESS_PCT = 55;
+
+/**
+ * Deterministic kind → HSL color. The empty-string sentinel (generic
+ * body wikilink) returns a neutral grey so the canvas can distinguish
+ * "no kind" from a real relation kind without an extra branch.
+ *
+ * djb2 hash modulo 360 for the hue. Fixed saturation + lightness keeps
+ * the palette visually coherent across kinds.
+ */
+export function kindToHsl(kind: string): string {
+  if (kind === '') return 'hsl(0, 0%, 60%)';
+  let hash = 5381;
+  for (let i = 0; i < kind.length; i++) {
+    hash = ((hash << 5) + hash + kind.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, ${SATURATION_PCT}%, ${LIGHTNESS_PCT}%)`;
+}
+```
+
+- [ ] **Step 3: Run tests, expect green; commit**
+
+```bash
+pnpm --filter ziba-desktop test -- kind-color
+git add apps/desktop/src/lib/kind-color.ts apps/desktop/src/lib/kind-color.test.ts
+git commit -m "feat(v1.0 phase5): kind-color deterministic HSL hash"
+```
+
+---
+
+## Task 3: `convexHull.ts` — Andrew's monotone-chain
+
+**Files:**
+- Create: `apps/desktop/src/components/GlobalGraph/convexHull.ts`
+- Create: `apps/desktop/src/components/GlobalGraph/convexHull.test.ts`
+
+- [ ] **Step 1: Tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { convexHull } from './convexHull';
+
+describe('convexHull', () => {
+  it('returns [] for 0 points', () => {
+    expect(convexHull([])).toEqual([]);
+  });
+
+  it('returns the single point for 1 input', () => {
+    expect(convexHull([{ x: 1, y: 1 }])).toEqual([{ x: 1, y: 1 }]);
+  });
+
+  it('returns both endpoints for 2 collinear inputs (no triangle yet)', () => {
+    const got = convexHull([{ x: 0, y: 0 }, { x: 2, y: 2 }]);
+    expect(got).toHaveLength(2);
+  });
+
+  it('returns the three vertices of a triangle (3 inputs)', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 2, y: 0 }, { x: 1, y: 2 }];
+    const got = convexHull(pts);
+    expect(got).toHaveLength(3);
+    expect(new Set(got.map((p) => `${p.x},${p.y}`))).toEqual(
+      new Set(['0,0', '2,0', '1,2']),
+    );
+  });
+
+  it('excludes interior points from the hull', () => {
+    const pts = [
+      { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 }, // square corners
+      { x: 2, y: 2 }, // interior
+    ];
+    const got = convexHull(pts);
+    expect(got).toHaveLength(4);
+    expect(got.some((p) => p.x === 2 && p.y === 2)).toBe(false);
+  });
+
+  it('handles duplicates without crashing', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 0, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 1 }];
+    const got = convexHull(pts);
+    expect(got.length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+export type HullPoint = { x: number; y: number };
+
+/**
+ * Andrew's monotone-chain convex hull. O(n log n) time, no
+ * dependencies. Returns the hull vertices in counter-clockwise order
+ * starting at the lowest-then-leftmost point. Returns at most one copy
+ * of each unique vertex — duplicate inputs are deduplicated implicitly.
+ *
+ * Edge cases:
+ *   - 0 points → []
+ *   - 1 point  → [the point]
+ *   - collinear inputs → both endpoints
+ *   - duplicates → deduplicated; never returns a degenerate hull
+ */
+export function convexHull(points: ReadonlyArray<HullPoint>): HullPoint[] {
+  if (points.length === 0) return [];
+  if (points.length === 1) return [{ x: points[0]!.x, y: points[0]!.y }];
+
+  const sorted = [...points].sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  // Deduplicate identical points so the cross-product check doesn't
+  // produce zero-area artifacts that confuse the chain.
+  const uniq: HullPoint[] = [];
+  for (const p of sorted) {
+    const last = uniq[uniq.length - 1];
+    if (last === undefined || last.x !== p.x || last.y !== p.y) uniq.push(p);
+  }
+  if (uniq.length < 2) return uniq;
+
+  const cross = (o: HullPoint, a: HullPoint, b: HullPoint): number =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+  const lower: HullPoint[] = [];
+  for (const p of uniq) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2]!, lower[lower.length - 1]!, p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: HullPoint[] = [];
+  for (let i = uniq.length - 1; i >= 0; i--) {
+    const p = uniq[i]!;
+    while (upper.length >= 2 && cross(upper[upper.length - 2]!, upper[upper.length - 1]!, p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  // The last point of each half is the start of the other half — drop it.
+  lower.pop();
+  upper.pop();
+  return lower.concat(upper);
+}
+```
+
+- [ ] **Step 3: Run tests, expect green; commit**
+
+```bash
+git add apps/desktop/src/components/GlobalGraph/convexHull.ts \
+        apps/desktop/src/components/GlobalGraph/convexHull.test.ts
+git commit -m "feat(v1.0 phase5): convex hull (Andrew's monotone-chain)"
+```
+
+---
+
+## Task 4: Layout — cluster bias force + LayoutNode.nodeType
+
+**Files:**
+- Modify: `apps/desktop/src/components/MiniGraph/layout.ts`
+- Modify: `apps/desktop/src/components/MiniGraph/layout.test.ts` (or create `apps/desktop/src/components/GlobalGraph/cluster-bias.test.ts` if no shared test file)
+- Modify: `apps/desktop/src/components/GlobalGraph/layout.ts`
+- Modify: `apps/desktop/src/lib/graph-tuning.ts`
+
+- [ ] **Step 1: Inspect existing layout file**
+
+Read `apps/desktop/src/components/MiniGraph/layout.ts` end-to-end to confirm the `LayoutNode` shape, the `simulateLayout` function signature, and the per-iteration force-sum structure.
+
+- [ ] **Step 2: Add `nodeType` to `LayoutNode` (optional)**
+
+```ts
+export type LayoutNode = {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  kind: LayoutNodeKind;
+  /**
+   * v1.0 Phase 5: optional type slug for cluster-bias forces. When
+   * set on a subset of nodes, those nodes mutually attract within
+   * `simulateLayout` with weight `kClusterStrength`. Mini-graph
+   * callers don't set this; the cluster term is skipped for them.
+   */
+  nodeType?: string | null;
+};
+```
+
+> Per `exactOptionalPropertyTypes`, callers that don't set this field omit it entirely. Don't assign `nodeType: null` in literals where it's unknown — leave it out.
+
+- [ ] **Step 3: Add `kClusterStrength` option + force loop**
+
+In `simulateLayout`, add an optional `kClusterStrength?: number` to `LayoutOptions`. Default to 0 (mini-graph behaviour unchanged).
+
+In the iteration body, after the repulsion loop but before the spring loop, add:
+
+```ts
+    const kCluster = opts.kClusterStrength ?? 0;
+    if (kCluster > 0) {
+      // Same-type bias: pairs of nodes with matching `nodeType` exert
+      // a mild attractive force on each other. O(n²); cheap enough at
+      // vault scale where the global graph is already O(n²) for
+      // repulsion. Skips nodes without a `nodeType` so untyped notes
+      // float freely between clusters.
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        if (a === undefined || a.nodeType === undefined || a.nodeType === null) continue;
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          if (b === undefined || b.nodeType !== a.nodeType) continue;
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const dist2 = dx * dx + dy * dy;
+          if (dist2 < 0.01) continue;
+          const dist = Math.sqrt(dist2);
+          // Linear attractor — easy to reason about, stable under
+          // damping. Force magnitude grows with distance so isolated
+          // same-type satellites get pulled back into the cluster.
+          const f = kCluster * dist;
+          const ux = dx / dist;
+          const uy = dy / dist;
+          a.vx += f * ux;
+          a.vy += f * uy;
+          b.vx -= f * ux;
+          b.vy -= f * uy;
+        }
+      }
+    }
+```
+
+Place this BEFORE the existing repulsion/spring/centering sums so the bias gets damped along with everything else.
+
+> Wait — better to add it AFTER repulsion so the cluster bias acts on top of an already-spaced configuration; OR before, integrated equally. Re-read the existing force loop and pick whichever placement is cleanest given the existing ordering. The MiniGraph file's existing flow is repulsion → spring → centering → integrate; add cluster between spring and centering, which makes the bias compete with springs (which is what we want — typed siblings without an explicit edge still cluster).
+
+- [ ] **Step 4: Add tuning constant**
+
+In `apps/desktop/src/lib/graph-tuning.ts`:
+
+```ts
+/**
+ * v1.0 Phase 5: same-type cluster bias coefficient. Larger = tighter
+ * type clusters, smaller = clusters loosen and node positions are
+ * dominated by edges + repulsion. 0.3 was tuned against a 200-node
+ * mixed-type synthetic graph: visible clustering without nodes
+ * piling on top of each other.
+ */
+export const GRAPH_CLUSTER_STRENGTH = 0.3;
+```
+
+- [ ] **Step 5: Thread through `GlobalGraph/layout.ts`**
+
+```ts
+// initializePositions: accept an optional per-id type map and stamp it
+// onto the LayoutNode.
+export function initializePositions(
+  ids: string[],
+  width: number,
+  height: number,
+  typeById?: ReadonlyMap<string, string | null>,
+): LayoutNode[] {
+  const radius = Math.min(width, height) / 2 - 24;
+  const seedRadius = Math.max(60, Math.min(radius, 30 + Math.sqrt(ids.length) * 8));
+  return miniInitializeOnCircle(
+    ids.map((id) => {
+      const t = typeById?.get(id) ?? null;
+      const base: { id: string; kind: 'outbound' } = { id, kind: 'outbound' };
+      // Only attach nodeType when it's a non-empty string — the
+      // simulator's cluster loop checks `=== undefined || === null`,
+      // and exactOptionalPropertyTypes is on, so we avoid passing
+      // `nodeType: null` in a literal.
+      return t !== null ? { ...base, nodeType: t } : base;
+    }),
+    width,
+    height,
+    seedRadius,
+  );
+}
+```
+
+`runGlobalLayout` — forward `GRAPH_CLUSTER_STRENGTH` to the simulator:
+
+```ts
+import { GRAPH_CLUSTER_STRENGTH } from '../../lib/graph-tuning';
+
+export function runGlobalLayout(
+  nodes: LayoutNode[],
+  edges: LayoutEdge[],
+  opts: GlobalLayoutOptions,
+): LayoutNode[] {
+  const iterations = opts.iterations ?? defaultIterations(nodes.length);
+  return miniSimulateLayout(nodes, edges, {
+    width: opts.width,
+    height: opts.height,
+    iterations,
+    kRepulsive: GLOBAL_DEFAULTS.kRepulsive,
+    kAttractive: GLOBAL_DEFAULTS.kAttractive,
+    restLen: GLOBAL_DEFAULTS.restLen,
+    damping: GLOBAL_DEFAULTS.damping,
+    kCenter: GLOBAL_DEFAULTS.kCenter,
+    kClusterStrength: GRAPH_CLUSTER_STRENGTH,
+  });
+}
+```
+
+- [ ] **Step 6: Tests**
+
+Write a synthetic-graph test that verifies the cluster bias actually clusters. Add `apps/desktop/src/components/GlobalGraph/cluster-bias.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { initializePositions, runGlobalLayout } from './layout';
+
+describe('cluster bias', () => {
+  it('with two types and no edges, same-type nodes settle closer to their type centroid than the global centroid', () => {
+    // 20 typed nodes split 10/10 between book and person, no edges.
+    const ids = Array.from({ length: 20 }, (_, i) => `n${i}`);
+    const typeById = new Map<string, string>(
+      ids.map((id, i) => [id, i < 10 ? 'book' : 'person']),
+    );
+    const nodes = initializePositions(ids, 1000, 1000, typeById);
+    runGlobalLayout(nodes, [], { width: 1000, height: 1000, iterations: 800 });
+
+    const booksX = nodes.filter((n) => n.nodeType === 'book');
+    const peopleX = nodes.filter((n) => n.nodeType === 'person');
+    const cBook = centroid(booksX);
+    const cPerson = centroid(peopleX);
+    const sBook = avgDist(booksX, cBook);
+    const sPerson = avgDist(peopleX, cPerson);
+    const separation = dist(cBook, cPerson);
+
+    // Sanity: clusters separated by more than each cluster's spread.
+    expect(separation).toBeGreaterThan(sBook);
+    expect(separation).toBeGreaterThan(sPerson);
+  });
+});
+
+function centroid(ns: { x: number; y: number }[]): { x: number; y: number } {
+  let sx = 0;
+  let sy = 0;
+  for (const n of ns) {
+    sx += n.x;
+    sy += n.y;
+  }
+  return { x: sx / ns.length, y: sy / ns.length };
+}
+
+function avgDist(ns: { x: number; y: number }[], c: { x: number; y: number }): number {
+  let s = 0;
+  for (const n of ns) s += dist(n, c);
+  return s / ns.length;
+}
+
+function dist(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+```
+
+> The simulation is deterministic given the same seed (initializeOnCircle is deterministic; the simulator has no RNG). The test is robust as long as the bias force actually pushes types apart.
+
+- [ ] **Step 7: Run tests, expect pass; commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+git add apps/desktop/src/components/MiniGraph/layout.ts \
+        apps/desktop/src/components/GlobalGraph/layout.ts \
+        apps/desktop/src/components/GlobalGraph/cluster-bias.test.ts \
+        apps/desktop/src/lib/graph-tuning.ts
+git commit -m "feat(v1.0 phase5): cluster-bias force + nodeType LayoutNode field"
+```
+
+---
+
+## Task 5: Canvas — render hulls + edge color + node fill from type
+
+**Files:**
+- Modify: `apps/desktop/src/components/GlobalGraph/Canvas.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/HullsLayer.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/HullsLayer.test.tsx`
+
+- [ ] **Step 1: Extend `CanvasNode` + `CanvasEdge`**
+
+In `Canvas.tsx`:
+
+```ts
+export type CanvasNode = {
+  id: NotePath;
+  x: number;
+  y: number;
+  r: number;
+  title: string;
+  degree: number;
+  /** v1.0 Phase 5: type slug from the note (null = untyped). */
+  type: string | null;
+  /** v1.0 Phase 5: hex color from the type's schema; canvas tints the fill. */
+  color: string | null;
+};
+
+export type CanvasEdge = {
+  source: NotePath;
+  target: NotePath;
+  /** v1.0 Phase 5: relation kind. `''` = generic body wikilink. */
+  kind: string;
+};
+```
+
+- [ ] **Step 2: Add a `clusterOverlay` + edge-coloring prop**
+
+```ts
+type Props = {
+  // ...existing
+  /** v1.0 Phase 5: when true, render convex-hull overlays per type. */
+  clusterOverlayOn: boolean;
+  /** v1.0 Phase 5: when non-null, fade out nodes/edges not matching this type. */
+  highlightType: string | null;
+  /** v1.0 Phase 5: when non-empty, fade out edges whose kind isn't in this set. */
+  highlightKinds: ReadonlySet<string>;
+};
+```
+
+- [ ] **Step 3: Edge rendering — color per kind, dim by filter**
+
+Use `kindToHsl(edge.kind)` for the stroke color. When `highlightKinds.size > 0` and `!highlightKinds.has(edge.kind)`, render the edge with `DIM_OPACITY`. The neighbor-of-selected logic still applies on top.
+
+- [ ] **Step 4: Node rendering — fill tint from type color**
+
+When `node.color !== null`, use it as the fill in the resolved-not-dimmed state. The CSS variable fallback `NODE_FILL` stays in place for untyped nodes. Dim/broken treatments unchanged.
+
+When `highlightType !== null && node.type !== highlightType`, treat as dimmed.
+
+- [ ] **Step 5: Hulls layer**
+
+Create `HullsLayer.tsx`:
+
+```tsx
+import { useMemo } from 'react';
+import type { JSX } from 'react';
+import type { NotePath } from '@ziba/core';
+import { convexHull } from './convexHull';
+import type { CanvasNode } from './Canvas';
+
+const MIN_NODES_FOR_HULL = 3;
+const HULL_FILL_OPACITY = 0.08;
+const HULL_STROKE_OPACITY = 0.25;
+const HULL_PADDING = 24;
+
+type Props = {
+  nodes: ReadonlyArray<CanvasNode>;
+  /** Hide hulls whose type is in this set (e.g. dimmed by the type chip filter). */
+  hiddenTypes: ReadonlySet<string>;
+};
+
+/**
+ * Renders one semi-transparent convex-hull polygon per type with
+ * ≥ 3 visible nodes. Hulls sit underneath the nodes/edges layer in
+ * the parent SVG. Color is read from the first node of the group's
+ * `color` field (consistent — all nodes of a given type share the
+ * same schema color).
+ */
+export function HullsLayer({ nodes, hiddenTypes }: Props): JSX.Element | null {
+  const hulls = useMemo(() => {
+    const byType = new Map<string, CanvasNode[]>();
+    for (const n of nodes) {
+      if (n.type === null || n.type === '') continue;
+      if (hiddenTypes.has(n.type)) continue;
+      const bucket = byType.get(n.type);
+      if (bucket === undefined) byType.set(n.type, [n]);
+      else bucket.push(n);
+    }
+    const out: Array<{ type: string; color: string; path: string }> = [];
+    for (const [type, group] of byType) {
+      if (group.length < MIN_NODES_FOR_HULL) continue;
+      const color = group.find((n) => n.color !== null)?.color ?? 'rgb(var(--accent))';
+      const pts = convexHull(group.map((n) => ({ x: n.x, y: n.y })));
+      if (pts.length < MIN_NODES_FOR_HULL) continue;
+      const padded = padOutward(pts, HULL_PADDING);
+      const d = polygonPath(padded);
+      out.push({ type, color, path: d });
+    }
+    return out;
+  }, [nodes, hiddenTypes]);
+
+  if (hulls.length === 0) return null;
+  return (
+    <g aria-hidden="true">
+      {hulls.map((h) => (
+        <path
+          key={h.type}
+          d={h.path}
+          fill={h.color}
+          fillOpacity={HULL_FILL_OPACITY}
+          stroke={h.color}
+          strokeOpacity={HULL_STROKE_OPACITY}
+          strokeLinejoin="round"
+        />
+      ))}
+    </g>
+  );
+}
+
+function polygonPath(pts: ReadonlyArray<{ x: number; y: number }>): string {
+  if (pts.length === 0) return '';
+  return (
+    pts.map((p, i) => (i === 0 ? `M ${p.x} ${p.y}` : `L ${p.x} ${p.y}`)).join(' ') + ' Z'
+  );
+}
+
+/**
+ * Inflate the polygon outward from its centroid by `pad` units so the
+ * hull encloses the nodes' radii (not just their centres).
+ */
+function padOutward(
+  pts: ReadonlyArray<{ x: number; y: number }>,
+  pad: number,
+): Array<{ x: number; y: number }> {
+  if (pts.length === 0) return [];
+  let cx = 0;
+  let cy = 0;
+  for (const p of pts) {
+    cx += p.x;
+    cy += p.y;
+  }
+  cx /= pts.length;
+  cy /= pts.length;
+  return pts.map((p) => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d < 0.0001) return { x: p.x, y: p.y };
+    return { x: p.x + (dx / d) * pad, y: p.y + (dy / d) * pad };
+  });
+}
+```
+
+- [ ] **Step 6: Mount `<HullsLayer>` inside Canvas**
+
+Wrap the existing `<g>` group: hulls FIRST (underneath), then edges, then nodes. Only render when `clusterOverlayOn` is true.
+
+```tsx
+        {clusterOverlayOn && (
+          <HullsLayer
+            nodes={nodes}
+            hiddenTypes={highlightType === null ? EMPTY_STRING_SET : new Set([...allTypes].filter((t) => t !== highlightType))}
+          />
+        )}
+```
+
+Where `allTypes` is a memo of unique non-null types in `nodes`. Hidden types include everything except the active highlight.
+
+- [ ] **Step 7: HullsLayer test**
+
+`HullsLayer.test.tsx`:
+
+```tsx
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { HullsLayer } from './HullsLayer';
+import type { CanvasNode } from './Canvas';
+
+function n(id: string, x: number, y: number, type: string | null): CanvasNode {
+  return { id, x, y, r: 4, degree: 0, title: id, type, color: '#6366f1' };
+}
+
+describe('<HullsLayer>', () => {
+  it('renders nothing when fewer than 3 typed nodes share the same type', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[n('a', 0, 0, 'book'), n('b', 1, 0, 'book')]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  it('renders one hull when ≥ 3 nodes share the same type', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[
+            n('a', 0, 0, 'book'),
+            n('b', 10, 0, 'book'),
+            n('c', 5, 10, 'book'),
+          ]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelectorAll('path').length).toBe(1);
+  });
+
+  it('omits hulls whose type is in hiddenTypes', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[
+            n('a', 0, 0, 'book'),
+            n('b', 10, 0, 'book'),
+            n('c', 5, 10, 'book'),
+          ]}
+          hiddenTypes={new Set(['book'])}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  it('skips nodes whose type is null or empty string', () => {
+    const { container } = render(
+      <svg>
+        <HullsLayer
+          nodes={[
+            n('a', 0, 0, null),
+            n('b', 10, 0, null),
+            n('c', 5, 10, null),
+            n('d', 0, 0, ''),
+            n('e', 10, 0, ''),
+            n('f', 5, 10, ''),
+          ]}
+          hiddenTypes={new Set()}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('path')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 8: Run all tests**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Existing Canvas tests (if any) might need updating to pass the new required props. If `Canvas.test.tsx` doesn't exist, that's fine — the integration smoke catches Canvas regressions visually.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/components/GlobalGraph/Canvas.tsx \
+        apps/desktop/src/components/GlobalGraph/HullsLayer.tsx \
+        apps/desktop/src/components/GlobalGraph/HullsLayer.test.tsx
+git commit -m "feat(v1.0 phase5): hulls overlay + edge color per kind + type fill"
+```
+
+---
+
+## Task 6: Header controls — TypeChips, KindFilterDropdown, Legend, cluster toggle
+
+**Files:**
+- Create: `apps/desktop/src/components/GlobalGraph/TypeChips.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/TypeChips.test.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/KindFilterDropdown.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/KindFilterDropdown.test.tsx`
+- Create: `apps/desktop/src/components/GlobalGraph/Legend.tsx`
+- Modify: `apps/desktop/src/components/GlobalGraph/index.tsx`
+
+**TypeChips** — single-select chip row; clicking a chip sets `selectedType`; clicking "Tutti" clears.
+
+**KindFilterDropdown** — multi-select checklist; reads the union of edge `kind` strings (excluding `''`) and toggles them in/out of `selectedKinds`.
+
+**Legend** — top-right floating panel listing active type label + color swatch + active kind label + color swatch (from `kindToHsl`).
+
+Each component is ~80 lines. Follow the `TypeFilterDropdown` (DatabaseView Phase 4) pattern verbatim for menu architecture and accessibility.
+
+Then in `GlobalGraph/index.tsx`:
+- Add state: `selectedType: string | null`, `selectedKinds: ReadonlySet<string>`, `clusterOverlayOn: boolean` (default false).
+- Compute `typeOptions` from `useTagsStore.types` (count > 0).
+- Compute `kindOptions` from `load.graph.edges` (`new Set(edges.map((e) => e.kind).filter((k) => k !== ''))`).
+- Build `typeById` map for `initializePositions`.
+- Build `canvasNodes` to include `type` + `color` per node (read from the graph response; the IPC now ships these).
+- Build `canvasEdges` to include `kind`.
+- Render the new controls in the header.
+- Pass `clusterOverlayOn`, `highlightType`, `highlightKinds` to `Canvas`.
+- Mount `<Legend>` as an absolute-positioned overlay in the canvas container.
+
+Write tests for `TypeChips` and `KindFilterDropdown` (no test for `Legend` — pure presentation; visual review covers it). Reuse the patterns from `TypeFilterDropdown.test.tsx`.
+
+Step list is long — split into sub-commits if needed:
+- TypeChips component + tests
+- KindFilterDropdown component + tests
+- Legend component (no tests; pure presentation)
+- GlobalGraph wiring + integration
+
+Commit at each clean point. Final commit message for the integration:
+
+```bash
+git commit -m "feat(v1.0 phase5): header controls + cluster toggle + legend"
+```
+
+---
+
+## Task 7: E2E smoke + open PR + merge
+
+- [ ] **Step 1: Manual smoke** (best-effort, document if you can't run the app)
+
+Open a seeded vault with multiple typed notes. Verify:
+- Type chips row appears with `Tutti` + each type.
+- Selecting a type fades non-matching nodes/edges.
+- Toggling "Mostra cluster" overlays semi-transparent hulls per type.
+- Kind filter dropdown lets the user pick which relation kinds are highlighted.
+- Legend top-right shows the active type + active kinds with color swatches.
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin feat/v1.0-phase5-constellation-graph
+gh pr create --base main --title "feat(v1.0 phase 5): constellation graph — cluster bias + hulls + kind filter" --body "..."
+```
+
+PR body:
+
+```
+## Summary
+- Core `GraphNode/Edge` gain `type`, `color`, `kind` fields; adapter SQL joins note_properties + object_types.
+- Force simulator gains a same-type cluster bias (`GRAPH_CLUSTER_STRENGTH = 0.3`).
+- Convex hull overlay per type with ≥ 3 nodes (toggleable, off by default).
+- Edge color per kind via deterministic HSL hash; legend lists active kinds with swatches.
+- Header: type chip row (single-select), kind filter multi-select dropdown, "Mostra cluster" toggle.
+
+## Test plan
+- [x] Convex hull: 6 cases
+- [x] Cluster bias: synthetic 2-type graph separates
+- [x] Kind color hash: deterministic + consistent format
+- [x] HullsLayer: render gating (< 3 nodes, hidden type, untyped)
+- [x] TypeChips / KindFilterDropdown: interaction tests
+- [ ] Manual smoke
+```
+
+- [ ] **Step 3: Merge after CI** — same flow as Phases 3 and 4.
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage**:
+   - §4.3 GraphNode `type`+`color`, GraphEdge `kind` — Task 1
+   - §6.1 cluster bias forces — Task 4
+   - §6.2 hulls overlay — Task 3 + Task 5
+   - §6.3 edge styling per kind — Task 2 + Task 5
+   - §6.4 type chips — Task 6
+   - §6.5 legend — Task 6
+   - §10 success criterion 3: "graph view with cluster overlay on makes types visually distinct for 200+ notes mixing 5+ types" — covered by Task 4 (cluster-bias.test) + Task 5 (hulls) + visual smoke.
+
+2. **No new IPC channels**: the wire shape extends in place via core types.
+
+3. **`exactOptionalPropertyTypes`**: `LayoutNode.nodeType?` and `LayoutOptions.kClusterStrength?` are properly optional; literals never assign `undefined`.
+
+4. **Backward-compat**: mini-graph callers don't pass `typeById` and don't pass `kClusterStrength`; the cluster loop is a no-op for them.
+
+5. **Type consistency**: `type`/`color` are `string | null` everywhere (core, adapter, layout, canvas). `kind` is `string` everywhere with `''` sentinel for untyped edges.

--- a/docs/vault-format.md
+++ b/docs/vault-format.md
@@ -1,0 +1,228 @@
+# Formato vault
+
+Questa guida descrive la struttura locale di un vault Ziba: directory, naming dei file, forma del frontmatter e file schema che guidano il modello a oggetti tipizzati introdotto in v1.0.
+
+## Struttura del vault
+
+Un vault Ziba è una directory di file markdown. Ziba aggiunge una sola sottodirectory `.ziba/` per i propri dati:
+
+```
+my-vault/
+├── tolkien.md
+├── the-hobbit.md
+├── projects/
+│   └── ziba.md
+├── people/
+│   └── tolkien.md
+└── .ziba/
+    ├── index.db          # cache SQLite (rigenerabile, mai autoritativa)
+    └── schema/
+        ├── note.yml
+        ├── person.yml
+        ├── book.yml
+        ├── project.yml
+        ├── idea.yml
+        ├── daily.yml
+        └── meeting.yml
+```
+
+- **File `.md`**: la fonte unica di verità. Editabili in qualsiasi editor. Ziba non aggiunge sintassi proprietaria al corpo della nota — solo frontmatter YAML standard.
+- **`.ziba/index.db`**: cache SQLite. Cancellabile senza perdere dati — Ziba la ricostruisce all'apertura del vault.
+- **`.ziba/schema/*.yml`**: definizioni dei tipi di oggetto. Opzionali ma consigliati. Al primo avvio di un vault vuoto, Ziba copia i sette schemi seed — editabili, cancellabili, sostituibili liberamente.
+
+## Frontmatter delle note
+
+Il frontmatter segue il formato YAML standard di Obsidian. Ziba riconosce i campi seguenti:
+
+```yaml
+---
+title: Titolo della nota        # opzionale — se assente, Ziba usa il primo H1 o il basename
+tags:
+  - filosofia
+  - lettura
+type: book                      # v1.0 — slug del tipo (referenzia .ziba/schema/book.yml)
+relations:
+  author: "[[Tolkien]]"         # v1.0 — relazione scalare
+  genres:                       # v1.0 — relazione multipla (lista)
+    - "[[Fantasy]]"
+    - "[[Adventure]]"
+# ...qualsiasi altra property...
+year: 1937
+status: letto
+---
+```
+
+### Campi standard
+
+| Campo | Tipo | Descrizione |
+|---|---|---|
+| `title` | text | Titolo della nota. Se assente, derivato dal primo H1 nel body o dal filename (senza estensione). |
+| `tags` | string[] | Tag associati alla nota. Equivalenti ai `#tag` nel body. |
+| `type` | text | Slug del tipo di oggetto (v1.0). Referenzia `.ziba/schema/<type>.yml`. |
+| `relations` | mapping | Relazioni tipizzate verso altri oggetti (v1.0). Le chiavi sono i `kind` definiti nello schema. |
+
+### Campi property (liberi)
+
+Qualsiasi altro campo nel frontmatter viene trattato come property della nota. Il tipo viene rilevato automaticamente:
+
+| Valore YAML | Tipo rilevato |
+|---|---|
+| `true` / `false` | `boolean` |
+| Numero intero o decimale | `number` |
+| Stringa ISO `YYYY-MM-DD` | `date` |
+| Stringa che inizia con `http://` o `https://` | `url` |
+| Lista di stringhe | `string-array` |
+| Qualsiasi altra stringa | `text` |
+
+Il rilevamento è lo stesso usato dal PropertyEditor nel renderer — nessuna differenza tra ciò che vedi nella UI e ciò che Ziba indicizza.
+
+## Relazioni tipizzate (v1.0)
+
+Le relazioni tipizzate collegano una nota (l'origine) ad altre note (i target) con un `kind` semantico definito nello schema. Si dichiarano nel frontmatter sotto `relations:`.
+
+### Relazione scalare (un solo target)
+
+```yaml
+relations:
+  author: "[[Tolkien]]"
+```
+
+### Relazione multipla (lista di target)
+
+```yaml
+relations:
+  genres:
+    - "[[Fantasy]]"
+    - "[[Adventure]]"
+```
+
+### Alias di visualizzazione
+
+```yaml
+relations:
+  author: "[[J. R. R. Tolkien|Tolkien]]"
+```
+
+L'alias (`|Display`) è separato dal target (`[[Target]]`) nel parser — il target usato per la join nel grafo è `J. R. R. Tolkien`, il testo visualizzato è `Tolkien`.
+
+### Wikilink generici nel body
+
+I wikilink `[[...]]` nel corpo della nota vengono indicizzati come relazioni con `kind = ''` (untyped). Sono backward-compatible con i vault v0.x e restano visibili nel grafo globale. Non richiedono `type:` né `relations:` nel frontmatter.
+
+## Schemi dei tipi (`.ziba/schema/*.yml`)
+
+Gli schemi descrivono l'intenzione per un tipo di oggetto: quali property aspettarsi, quali relation kind hanno senso, quali relazioni inverse mostrare nel pannello. Sono **soft** — Ziba non rifiuta mai un salvataggio che diverge dallo schema.
+
+### Forma completa di uno schema
+
+```yaml
+id: book            # slug, ^[a-z][a-z0-9-]*$, obbligatorio
+label: Libro        # nome visualizzato (sidebar, dropdown), obbligatorio
+icon: 📖            # emoji o stringa ≤ 2 char, opzionale
+color: "#6366f1"    # hex CSS #RRGGBB, opzionale
+
+properties:
+  title:
+    type: text        # text|number|boolean|date|url|string-array
+    required: true    # opzionale — avvisa ma non blocca il salvataggio
+    label: Titolo     # opzionale — label nel PropertyPanel
+  year:
+    type: number
+  isbn:
+    type: text
+
+relations:
+  author:
+    target: person    # id del tipo atteso (soft — non validato)
+    multiple: false   # default false
+    label: Autore
+  in_series:
+    target: book
+    label: Serie
+
+inverse:
+  cited_by:
+    reverse_of: cites   # kind usato per la join inversa
+    label: Citato da
+```
+
+### Campi dello schema
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `id` | slug | sì | Identificatore univoco del tipo. Deve corrispondere al basename del file (es. `book.yml` → `id: book`). Pattern: `^[a-z][a-z0-9-]*$`. |
+| `label` | text | sì | Nome visualizzato nei dropdown, nella sidebar TypesSection, e nel ObjectPanel. |
+| `icon` | string | no | Emoji o glifo breve (≤ 2 char) mostrato accanto al nome del tipo. |
+| `color` | string | no | Colore CSS hex `#RRGGBB` usato per gli hull nel grafo e per i chip di tipo in sidebar. |
+| `properties` | mapping | no | Specifica delle property attese. Le chiavi sono i nomi delle property nel frontmatter. |
+| `relations` | mapping | no | Specifica delle relazioni in uscita. Le chiavi diventano i `kind` validi in `relations:` nel frontmatter. |
+| `inverse` | mapping | no | Specifica delle relazioni in entrata da mostrare nell'ObjectPanel. Non sono nel frontmatter — vengono derivate via join sul campo `reverse_of`. |
+
+### Tipi di property
+
+| Valore `type` | Corrisponde a |
+|---|---|
+| `text` | Stringa libera |
+| `number` | Intero o decimale |
+| `boolean` | `true` / `false` |
+| `date` | Stringa ISO `YYYY-MM-DD` |
+| `url` | URL (stringa con schema `http://` o `https://`) |
+| `string-array` | Lista di stringhe |
+
+### Relazioni in uscita (`relations`)
+
+Ogni chiave in `relations:` dello schema definisce un `kind` ammesso. Lo schema permette di specificare:
+
+- `target`: il tipo atteso del nodo di destinazione (soft).
+- `multiple`: se `true`, il frontmatter accetta una lista di wikilink; se `false` (default), uno scalare.
+- `label`: etichetta visualizzata nel RelationPickerPopup e nell'ObjectPanel.
+
+### Relazioni in entrata (`inverse`)
+
+Le relazioni inverse non vengono scritte nel frontmatter della nota corrente. Sono derivate cercando nel grafo tutte le note che hanno `relations.<reverse_of>: [[QuestaNota]]`.
+
+Esempio: se `book.yml` dichiara `inverse: { cited_by: { reverse_of: cites } }`, l'ObjectPanel di ogni libro mostra automaticamente le note che hanno `relations.cites: [[Questo Libro]]`.
+
+## Schemi seed
+
+Al primo avvio di un vault senza `.ziba/schema/`, Ziba copia sette schemi predefiniti. Sono un punto di partenza — editali, cancellali, o aggiungine di nuovi.
+
+| ID | Label | Icon | Relazioni chiave |
+|---|---|---|---|
+| `note` | Nota | 📝 | — (inverse: `cited_by`) |
+| `person` | Persona | 👤 | `works_at` → project, `knows` → person |
+| `book` | Libro | 📖 | `author` → person, `in_series` → book |
+| `project` | Progetto | 🚀 | `owner` → person, `blocks` → project |
+| `idea` | Idea | 💡 | `inspired_by` → idea, `related_to` → idea |
+| `daily` | Daily | 🗓️ | `worked_on` → project, `met_with` → person, `read` → book |
+| `meeting` | Meeting | 🤝 | `attended_by` → person, `for_project` → project |
+
+## Convenzioni di authoring
+
+### Slug dei tipi
+
+Gli `id` negli schemi devono essere kebab-case minuscolo: `book`, `daily-log`, `reading-note`. Non `Book`, non `daily_log`, non `DailyLog`.
+
+### Icone
+
+Usa emoji standard (monoglifo preferito) oppure stringhe di max 2 caratteri. Evita sequence emoji lunghe — la resa nei pill e nei nodi del grafo dipende dal font di sistema.
+
+### Colori
+
+Usa hex `#RRGGBB` a 6 cifre. I colori degli schemi seed sono:
+
+| Tipo | Colore |
+|---|---|
+| note | `#71717a` |
+| person | `#f97316` |
+| book | `#6366f1` |
+| project | `#10b981` |
+| idea | `#eab308` |
+| daily | `#06b6d4` |
+| meeting | `#a855f7` |
+
+### Backward compatibility
+
+Un vault v0.x (nessun `type:`, nessun `relations:`, nessuna directory `.ziba/schema/`) continua a funzionare senza modifiche. I wikilink nel body vengono indicizzati come relazioni `kind = ''` e sono visibili nel grafo globale esattamente come prima.
+
+Aggiungere `type:` a note esistenti non richiede nessuna migrazione — Ziba riconosce il campo al prossimo salvataggio o reindex.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ziba",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "description": "Open-source second brain: Notion DB + Obsidian local-first markdown + graph + AI-native",
   "homepage": "https://github.com/metaforismo/Ziba",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ziba/core",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Pre-release audit of v1.0 across 4 angles (cross-phase integration, performance, accessibility, docs) by 4 parallel Opus reviewers; consolidated findings and applied surgical fixes via 3 parallel sonnet sprints. v1.0 is now release-ready.

## Fixes by category

### Data correctness
- **Synthetic vault event on save**: `markSelfWrite` was silently suppressing chokidar events for renderer-initiated writes, leaving `typedPaths` stale → wikilink icons + sidebar counts + graph never updated. Now `saveNote`/`createNote` push an explicit `change` event after reindex.
- **`selectedType` reset on vault switch**: the close path reset it, the switch path didn't. Added reset on vault-root change (mirrors `useTagsStore`).
- **`setRelationInFrontmatter` preserves alias + heading**: was always writing `[[target]]` and silently dropping `|Display` / `#heading`. Now accepts an optional `{ alias, heading }` parameter; idempotency check stays based on bare target.

### Performance
- **Canvas `nodeById` Map**: `nodeIndex` was an O(E·N) linear scan. Replaced with one O(N) Map build → O(1) per edge lookup. Saves ~80-150 ms per Canvas reconcile at 1000 nodes / 5000 edges.
- **Discrete actions bypass keystroke debounce**: `setSort`/`setGroupBy`/`setType` now run the query immediately instead of through the 200 ms debouncer. Saves 200 ms latency per dropdown / chip click in DatabaseView.

### Accessibility
- **RelationsSection delete button**: was keyboard-focusable but invisible (opacity-0 hover-only). Added `focus:opacity-100 focus-visible:outline-accent`.
- **RelationPickerPopup focus trap**: added `aria-modal="true"` + Tab/Shift+Tab cycle among focusable descendants.
- **Suggested-kind chips**: added `focus-visible:outline-accent` + `aria-label`.
- **Wikilink type icon**: was concatenated into the wikilink text node (screen-reader noise). Now rendered as `<span aria-hidden="true">` child.
- **Kind color WCAG AA**: lowered HSL lightness from 55%→42%, raised saturation 55%→60%. Many hues failed contrast on white background.
- **Hulls opacity**: bumped fill 0.08→0.15, stroke 0.25→0.5 so they're actually visible.

### Release readiness
- **Package versions** bumped to 1.0.0 across root + workspaces.
- **CHANGELOG**: restructured — moved v0.6 rebrand and v1.0.1 followups into their own sections; added full v1.0.0 entry with the 5-phase summary, usage notes, and known limitations.
- **README**: refreshed for v1.0 (status badge, feature ticks, vault format example, clean roadmap with "done / next").
- **architecture.md**: refreshed at v1.0 (schema lifecycle, `relations` table, renderer caches, IPC additions, new UI surfaces).
- **CONTRIBUTING**: corrected test counts; documented the raw-SQL adapter test pattern, Italian-UI/English-code rule, TDD-for-pure-functions expectation, phase pattern.
- **New `docs/vault-format.md`**: user-facing guide to vault layout + schemas.
- **Phase 3/4/5 plans** committed for historical reference.

## Test plan

- [x] `pnpm typecheck` — 3/3 green
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 327 desktop + 167 core = 494 total, all green (+10 from baseline 484)
- [ ] Manual smoke: dark theme visual check on new color palette
- [ ] Tag `v1.0.0` after merge

## Deferred to v1.1 (documented in CHANGELOG)

- Unified `selectedType` slice across Sidebar / DatabaseView / GlobalGraph (currently 3 independent stores).
- Aliased relations exposed in popup inputs (helper API now supports them).
- Web Worker for layout simulation (1.5-2.5 s blocking at 1000 nodes).
- Batched wikilink resolution IPC (50-100 ms first paint win on link-heavy notes).
- Schema icon hot-reload repaint of existing wikilink atom nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)