### PR TITLE
feat: add persisted database views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
   globale/locale, refresh, ricerca compatta e fullscreen della surface.
 - Pannello `Riferimenti` con sezioni Backlinks/Mentions, filtro, sort,
   conteggi e preview inline.
+- Attribute Views salvate in `<vault>/.ziba/database-views.json`, con tab
+  vista, layout `table | board | calendar | gallery`, colonne e query
+  persistite.
 - Controllo "Righe" nella DatabaseView, collegato a `DatabaseQuery.limit`.
 
 ## [1.0.1] - 2026-05-10

--- a/apps/desktop/electron/ipc/database-views.test.ts
+++ b/apps/desktop/electron/ipc/database-views.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IpcChannels, type DatabaseViewDefinition } from '../../shared/ipc';
+import { setCurrentVault } from '../state';
+
+let root: string;
+
+function makeView(patch: Partial<DatabaseViewDefinition> = {}): DatabaseViewDefinition {
+  return {
+    id: 'view-1',
+    name: 'Projects',
+    layout: 'board',
+    query: {
+      filters: [{ kind: 'eq', key: 'status', value: 'active' }],
+      sort: [{ key: 'title', direction: 'asc' }],
+      groupBy: 'status',
+      limit: 25,
+    },
+    selectedType: 'project',
+    columns: ['status', 'owner'],
+    createdAt: 10,
+    updatedAt: 10,
+    ...patch,
+  };
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'ziba-database-views-'));
+  setCurrentVault({ root, name: 'test', openedAt: 0 });
+});
+
+afterEach(async () => {
+  setCurrentVault(null);
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('database views IPC', () => {
+  it('returns a default view when the vault has no persisted views file', async () => {
+    const { listDatabaseViews } = await import('./database-views');
+
+    const file = await listDatabaseViews();
+
+    expect(file.version).toBe(1);
+    expect(file.views).toEqual([
+      expect.objectContaining({
+        id: 'default',
+        name: 'Tutte',
+        layout: 'table',
+        columns: [],
+      }),
+    ]);
+    expect(file.activeViewId).toBe('default');
+  });
+
+  it('persists upserted views under <vault>/.ziba/database-views.json', async () => {
+    const { upsertDatabaseView } = await import('./database-views');
+    const win = { webContents: { send: vi.fn() } };
+
+    const saved = await upsertDatabaseView(win as never, { view: makeView() });
+    const raw = await readFile(join(root, '.ziba/database-views.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+
+    expect(saved).toEqual(expect.objectContaining({ id: 'view-1', name: 'Projects' }));
+    expect(parsed.views).toEqual([expect.objectContaining({ id: 'view-1', layout: 'board' })]);
+    expect(parsed.activeViewId).toBe('view-1');
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      IpcChannels.databaseViewsChanged,
+      expect.objectContaining({ activeViewId: 'view-1' }),
+    );
+  });
+
+  it('duplicates and deletes views while keeping a valid activeViewId', async () => {
+    const { deleteDatabaseView, duplicateDatabaseView, upsertDatabaseView } =
+      await import('./database-views');
+    const win = { webContents: { send: vi.fn() } };
+
+    await mkdir(join(root, '.ziba'), { recursive: true });
+    await upsertDatabaseView(win as never, { view: makeView() });
+
+    const copy = await duplicateDatabaseView(win as never, { id: 'view-1' });
+    expect(copy.id).not.toBe('view-1');
+    expect(copy.name).toBe('Projects copia');
+
+    const afterDelete = await deleteDatabaseView(win as never, { id: 'view-1' });
+    expect(afterDelete.views.map((view) => view.id)).toEqual([copy.id]);
+    expect(afterDelete.activeViewId).toBe(copy.id);
+  });
+});

--- a/apps/desktop/electron/ipc/database-views.ts
+++ b/apps/desktop/electron/ipc/database-views.ts
@@ -1,0 +1,267 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { BrowserWindow } from 'electron';
+import type {
+  DatabaseViewDefinition,
+  DatabaseViewLayout,
+  DatabaseViewsFile,
+  ScalarFilter,
+} from '../../shared/ipc.js';
+import { IpcChannels } from '../../shared/ipc.js';
+import { requireVault } from '../state.js';
+
+const DATABASE_VIEWS_VERSION = 1;
+const DATABASE_VIEWS_PATH = ['.ziba', 'database-views.json'] as const;
+const DEFAULT_VIEW_ID = 'default';
+
+function now(): number {
+  return Date.now();
+}
+
+function defaultView(timestamp = now()): DatabaseViewDefinition {
+  return {
+    id: DEFAULT_VIEW_ID,
+    name: 'Tutte',
+    layout: 'table',
+    query: { filters: [], limit: 1000 },
+    selectedType: null,
+    columns: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function defaultFile(): DatabaseViewsFile {
+  return {
+    version: DATABASE_VIEWS_VERSION,
+    activeViewId: DEFAULT_VIEW_ID,
+    views: [defaultView()],
+  };
+}
+
+function viewsPath(): string {
+  return path.join(requireVault().root, ...DATABASE_VIEWS_PATH);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isLayout(value: unknown): value is DatabaseViewLayout {
+  return value === 'table' || value === 'board' || value === 'calendar' || value === 'gallery';
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) && value.every((item): item is string => typeof item === 'string')
+    ? [...value]
+    : [];
+}
+
+function isScalarFilter(value: unknown): value is ScalarFilter {
+  if (!isRecord(value) || typeof value.kind !== 'string' || typeof value.key !== 'string') {
+    return false;
+  }
+  switch (value.kind) {
+    case 'has':
+    case 'lacks':
+      return true;
+    case 'contains':
+      return typeof value.value === 'string';
+    case 'eq':
+      return (
+        typeof value.value === 'string' ||
+        typeof value.value === 'number' ||
+        typeof value.value === 'boolean'
+      );
+    case 'in':
+      return (
+        Array.isArray(value.values) &&
+        value.values.every(
+          (item) =>
+            typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean',
+        )
+      );
+    case 'lt':
+    case 'gt':
+    case 'lte':
+    case 'gte':
+      return typeof value.value === 'string' || typeof value.value === 'number';
+    default:
+      return false;
+  }
+}
+
+function sanitizeQuery(raw: unknown): DatabaseViewDefinition['query'] {
+  if (!isRecord(raw)) return { filters: [], limit: 1000 };
+  const query: DatabaseViewDefinition['query'] = {};
+
+  if (typeof raw.folder === 'string' && raw.folder.trim() !== '') query.folder = raw.folder;
+  if (Array.isArray(raw.filters)) {
+    query.filters = raw.filters.filter(isScalarFilter);
+  } else {
+    query.filters = [];
+  }
+  if (Array.isArray(raw.sort)) {
+    const sort = raw.sort.flatMap((item) => {
+      if (!isRecord(item)) return [];
+      if (typeof item.key !== 'string') return [];
+      if (item.direction !== 'asc' && item.direction !== 'desc') return [];
+      const direction: 'asc' | 'desc' = item.direction;
+      return [{ key: item.key, direction }];
+    });
+    if (sort.length > 0) query.sort = sort;
+  }
+  if (typeof raw.groupBy === 'string' && raw.groupBy.trim() !== '') query.groupBy = raw.groupBy;
+  if (typeof raw.limit === 'number' && Number.isFinite(raw.limit) && raw.limit > 0) {
+    query.limit = Math.floor(raw.limit);
+  } else {
+    query.limit = 1000;
+  }
+
+  return query;
+}
+
+function normalizeView(raw: unknown, fallbackId?: string): DatabaseViewDefinition | null {
+  if (!isRecord(raw)) return null;
+  const id = typeof raw.id === 'string' && raw.id.trim() !== '' ? raw.id : fallbackId;
+  const name = typeof raw.name === 'string' && raw.name.trim() !== '' ? raw.name.trim() : null;
+  if (id === undefined || name === null || !isLayout(raw.layout)) return null;
+
+  const timestamp = now();
+  return {
+    id,
+    name,
+    layout: raw.layout,
+    query: sanitizeQuery(raw.query),
+    selectedType: typeof raw.selectedType === 'string' ? raw.selectedType : null,
+    columns: stringArray(raw.columns),
+    createdAt:
+      typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt)
+        ? raw.createdAt
+        : timestamp,
+    updatedAt:
+      typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt)
+        ? raw.updatedAt
+        : timestamp,
+  };
+}
+
+function normalizeFile(raw: unknown): DatabaseViewsFile {
+  if (!isRecord(raw)) return defaultFile();
+  const views = Array.isArray(raw.views)
+    ? raw.views.flatMap((item): DatabaseViewDefinition[] => {
+        const view = normalizeView(item);
+        return view === null ? [] : [view];
+      })
+    : [];
+
+  if (views.length === 0) return defaultFile();
+  const activeViewId =
+    typeof raw.activeViewId === 'string' && views.some((view) => view.id === raw.activeViewId)
+      ? raw.activeViewId
+      : views[0]!.id;
+
+  return {
+    version: DATABASE_VIEWS_VERSION,
+    activeViewId,
+    views,
+  };
+}
+
+async function readDatabaseViewsFile(): Promise<DatabaseViewsFile> {
+  try {
+    return normalizeFile(JSON.parse(await readFile(viewsPath(), 'utf8')));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return defaultFile();
+    if (err instanceof SyntaxError) return defaultFile();
+    throw err;
+  }
+}
+
+async function writeDatabaseViewsFile(file: DatabaseViewsFile): Promise<DatabaseViewsFile> {
+  const normalized = normalizeFile(file);
+  const filePath = viewsPath();
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(normalized, null, 2), 'utf8');
+  return normalized;
+}
+
+function emitChanged(win: BrowserWindow, file: DatabaseViewsFile): void {
+  win.webContents.send(IpcChannels.databaseViewsChanged, file);
+}
+
+export async function listDatabaseViews(): Promise<DatabaseViewsFile> {
+  return readDatabaseViewsFile();
+}
+
+export async function upsertDatabaseView(
+  win: BrowserWindow,
+  args: { view: DatabaseViewDefinition },
+): Promise<DatabaseViewDefinition> {
+  const current = await readDatabaseViewsFile();
+  const index = current.views.findIndex((view) => view.id === args.view.id);
+  const timestamp = now();
+  const normalized = normalizeView(args.view, args.view.id);
+  if (normalized === null) return defaultView(timestamp);
+
+  const view: DatabaseViewDefinition = {
+    ...normalized,
+    createdAt: index >= 0 ? current.views[index]!.createdAt : normalized.createdAt,
+    updatedAt: timestamp,
+  };
+  const views =
+    index >= 0
+      ? current.views.map((item, itemIndex) => (itemIndex === index ? view : item))
+      : [...current.views.filter((item) => item.id !== DEFAULT_VIEW_ID), view];
+  const file = await writeDatabaseViewsFile({
+    version: DATABASE_VIEWS_VERSION,
+    activeViewId: view.id,
+    views,
+  });
+  emitChanged(win, file);
+  return view;
+}
+
+export async function deleteDatabaseView(
+  win: BrowserWindow,
+  args: { id: string },
+): Promise<DatabaseViewsFile> {
+  const current = await readDatabaseViewsFile();
+  const remaining = current.views.filter((view) => view.id !== args.id);
+  const views = remaining.length > 0 ? remaining : [defaultView()];
+  const activeViewId =
+    current.activeViewId === args.id || !views.some((view) => view.id === current.activeViewId)
+      ? views[0]!.id
+      : current.activeViewId;
+  const file = await writeDatabaseViewsFile({
+    version: DATABASE_VIEWS_VERSION,
+    activeViewId,
+    views,
+  });
+  emitChanged(win, file);
+  return file;
+}
+
+export async function duplicateDatabaseView(
+  win: BrowserWindow,
+  args: { id: string },
+): Promise<DatabaseViewDefinition> {
+  const current = await readDatabaseViewsFile();
+  const source = current.views.find((view) => view.id === args.id) ?? current.views[0];
+  const timestamp = now();
+  const copy: DatabaseViewDefinition = {
+    ...source!,
+    id: randomUUID(),
+    name: `${source!.name} copia`,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  const file = await writeDatabaseViewsFile({
+    version: DATABASE_VIEWS_VERSION,
+    activeViewId: copy.id,
+    views: [...current.views, copy],
+  });
+  emitChanged(win, file);
+  return copy;
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -35,6 +35,12 @@ import { getBacklinks, getReferences, resolveTitle } from './links.js';
 import { searchFullText } from './search.js';
 import { listTags, getNotesByTag } from './tags.js';
 import { runDatabaseQuery } from './database.js';
+import {
+  deleteDatabaseView,
+  duplicateDatabaseView,
+  listDatabaseViews,
+  upsertDatabaseView,
+} from './database-views.js';
 import { getFullGraph } from './graph.js';
 import {
   listObjectTypes,
@@ -116,6 +122,10 @@ export function registerIpcHandlers(win: BrowserWindow): void {
 
   // Database queries / global graph (v0.3 Wave 1)
   handle(IpcChannels.runDatabaseQuery, (args) => runDatabaseQuery(args));
+  handle(IpcChannels.listDatabaseViews, () => listDatabaseViews());
+  handle(IpcChannels.upsertDatabaseView, (args) => upsertDatabaseView(win, args));
+  handle(IpcChannels.deleteDatabaseView, (args) => deleteDatabaseView(win, args));
+  handle(IpcChannels.duplicateDatabaseView, (args) => duplicateDatabaseView(win, args));
   handle(IpcChannels.getFullGraph, () => getFullGraph());
 
   // v1.0: typed object types + typed relations

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -10,6 +10,7 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import {
   IpcChannels,
+  type DatabaseViewsChangedPayload,
   type IndexProgressPayload,
   type IpcRequests,
   type IpcResponses,
@@ -45,6 +46,16 @@ const api: ZibaApi = {
     ipcRenderer.on(IpcChannels.indexProgress, wrapped);
     return () => {
       ipcRenderer.off(IpcChannels.indexProgress, wrapped);
+    };
+  },
+
+  onDatabaseViewsChanged(listener: (payload: DatabaseViewsChangedPayload) => void): () => void {
+    const wrapped = (_e: IpcRendererEvent, payload: DatabaseViewsChangedPayload): void => {
+      listener(payload);
+    };
+    ipcRenderer.on(IpcChannels.databaseViewsChanged, wrapped);
+    return () => {
+      ipcRenderer.off(IpcChannels.databaseViewsChanged, wrapped);
     };
   },
 };

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -7,6 +7,9 @@ import type {
   DatabaseQuery,
   DatabaseResult,
   DatabaseRow,
+  DatabaseViewDefinition,
+  DatabaseViewLayout,
+  DatabaseViewsFile,
   DetectedProperty,
   Frontmatter,
   FullGraph,
@@ -30,6 +33,9 @@ export type {
   DatabaseQuery,
   DatabaseResult,
   DatabaseRow,
+  DatabaseViewDefinition,
+  DatabaseViewLayout,
+  DatabaseViewsFile,
   DetectedProperty,
   FullGraph,
   GraphEdge,
@@ -81,6 +87,10 @@ export const IpcChannels = {
 
   // Database queries (v0.3 Wave 1)
   runDatabaseQuery: 'db:query',
+  listDatabaseViews: 'db:views:list',
+  upsertDatabaseView: 'db:views:upsert',
+  deleteDatabaseView: 'db:views:delete',
+  duplicateDatabaseView: 'db:views:duplicate',
   // Full graph (v0.3 Wave 1, used by Wave 2's global graph view)
   getFullGraph: 'graph:full',
 
@@ -98,6 +108,7 @@ export const IpcChannels = {
   // Watcher push events (main → renderer)
   vaultEvent: 'watcher:event',
   indexProgress: 'index:progress',
+  databaseViewsChanged: 'database:viewsChanged',
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
@@ -176,6 +187,10 @@ export type IpcRequests = {
   [IpcChannels.getNotesByTag]: { tag: string };
 
   [IpcChannels.runDatabaseQuery]: { query: DatabaseQuery };
+  [IpcChannels.listDatabaseViews]: void;
+  [IpcChannels.upsertDatabaseView]: { view: DatabaseViewDefinition };
+  [IpcChannels.deleteDatabaseView]: { id: string };
+  [IpcChannels.duplicateDatabaseView]: { id: string };
   [IpcChannels.getFullGraph]: void;
 
   // v1.0
@@ -208,6 +223,8 @@ export type LinkReferencesResult = {
   backlinks: LinkReference[];
   mentions: LinkReference[];
 };
+
+export type DatabaseViewsChangedPayload = DatabaseViewsFile;
 
 /** A single full-text-search hit returned to the renderer. */
 export type SearchHit = {
@@ -262,6 +279,10 @@ export type IpcResponses = {
   [IpcChannels.getNotesByTag]: NoteSummary[];
 
   [IpcChannels.runDatabaseQuery]: DatabaseResult;
+  [IpcChannels.listDatabaseViews]: DatabaseViewsFile;
+  [IpcChannels.upsertDatabaseView]: DatabaseViewDefinition;
+  [IpcChannels.deleteDatabaseView]: DatabaseViewsFile;
+  [IpcChannels.duplicateDatabaseView]: DatabaseViewDefinition;
   [IpcChannels.getFullGraph]: FullGraph;
 
   // v1.0
@@ -299,6 +320,7 @@ export interface ZibaApi {
 
   onVaultEvent(listener: (payload: VaultEventPayload) => void): () => void;
   onIndexProgress(listener: (payload: IndexProgressPayload) => void): () => void;
+  onDatabaseViewsChanged(listener: (payload: DatabaseViewsChangedPayload) => void): () => void;
 }
 
 declare global {

--- a/apps/desktop/src/components/DatabaseView/GalleryView.tsx
+++ b/apps/desktop/src/components/DatabaseView/GalleryView.tsx
@@ -1,0 +1,50 @@
+import type { NotePath } from '@ziba/core';
+import type { DatabaseRow } from '../../../shared/ipc';
+
+type Props = {
+  rows: readonly DatabaseRow[];
+  columns: readonly string[];
+  onRowClick(path: NotePath): void;
+};
+
+function propertyValue(row: DatabaseRow, key: string): string | null {
+  const property = row.properties[key];
+  if (property === undefined) return null;
+  if (Array.isArray(property.value)) return property.value.join(', ');
+  return String(property.value);
+}
+
+export function GalleryView({ rows, columns, onRowClick }: Props): JSX.Element {
+  return (
+    <div className="h-full overflow-auto p-3">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-2">
+        {rows.map((row) => (
+          <button
+            key={row.path}
+            type="button"
+            onClick={(): void => onRowClick(row.path)}
+            className="min-h-28 rounded border border-border bg-bg-subtle p-3 text-left transition hover:border-accent/50 hover:bg-bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            title={row.path}
+          >
+            <span className="block truncate text-sm font-medium text-fg">{row.title}</span>
+            <span className="mt-1 block truncate font-mono text-[10px] text-fg-muted">
+              {row.path}
+            </span>
+            <span className="mt-3 block space-y-1">
+              {columns.slice(0, 4).map((column) => {
+                const value = propertyValue(row, column);
+                if (value === null) return null;
+                return (
+                  <span key={column} className="flex min-w-0 items-baseline gap-1 text-xs">
+                    <span className="shrink-0 text-fg-muted">{column}</span>
+                    <span className="truncate text-fg-subtle">{value}</span>
+                  </span>
+                );
+              })}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/DatabaseView/index.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  IpcChannels,
+  type DatabaseResult,
+  type DatabaseViewDefinition,
+  type DatabaseViewsFile,
+} from '../../../shared/ipc';
+import { installMockIpc, type MockController } from '../../test/mock-ipc';
+import { useDatabaseStore } from '../../stores/database';
+import { useTagsStore } from '../../stores/tags';
+import { useUiStore } from '../../stores/ui';
+import { useVaultStore } from '../../stores/vault';
+import { DatabaseView } from './index';
+
+let mock: MockController;
+
+function makeView(patch: Partial<DatabaseViewDefinition>): DatabaseViewDefinition {
+  return {
+    id: 'default',
+    name: 'Tutte',
+    layout: 'table',
+    query: { filters: [], limit: 1000 },
+    selectedType: null,
+    columns: ['status'],
+    createdAt: 0,
+    updatedAt: 0,
+    ...patch,
+  };
+}
+
+function makeRows(): DatabaseResult {
+  return {
+    rows: [
+      {
+        path: 'Projects/Ziba.md',
+        title: 'Ziba',
+        mtimeMs: 0,
+        properties: {
+          status: { key: 'status', type: 'text', value: 'active' },
+        },
+      },
+    ],
+    groups: [],
+    totalCount: 1,
+  };
+}
+
+beforeEach(() => {
+  mock = installMockIpc();
+  const viewsFile: DatabaseViewsFile = {
+    version: 1,
+    activeViewId: 'default',
+    views: [
+      makeView({ id: 'default', name: 'Tutte' }),
+      makeView({
+        id: 'projects',
+        name: 'Projects',
+        layout: 'board',
+        query: {
+          filters: [{ kind: 'eq', key: 'status', value: 'active' }],
+          groupBy: 'status',
+          limit: 25,
+        },
+        selectedType: 'project',
+      }),
+    ],
+  };
+  mock.setHandler(IpcChannels.listDatabaseViews, async () => viewsFile);
+  mock.setHandler(IpcChannels.runDatabaseQuery, async () => makeRows());
+  mock.setHandler(IpcChannels.upsertDatabaseView, async ({ view }) => view);
+  useVaultStore.setState({
+    current: { root: '/vault-a', name: 'vault-a', openedAt: 0 },
+    notes: [],
+  });
+  useTagsStore.setState({ types: [], objectTypeSchemas: [] });
+  useUiStore.setState({ databaseViewMode: 'table' });
+  useDatabaseStore.setState({
+    query: { filters: [], limit: 1000 },
+    result: null,
+    loading: false,
+    error: null,
+    availableProperties: [],
+    lastUpdatedAt: null,
+    selectedType: null,
+  });
+});
+
+describe('<DatabaseView>', () => {
+  it('loads saved views, applies the selected view, and persists layout changes', async () => {
+    render(<DatabaseView />);
+
+    expect(await screen.findByRole('tab', { name: 'Tutte' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Projects' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Projects' }));
+
+    await waitFor(() => {
+      const calls = mock.getCallsFor(IpcChannels.runDatabaseQuery);
+      expect(calls.at(-1)?.[0]).toEqual({
+        query: expect.objectContaining({
+          filters: [
+            { kind: 'eq', key: 'type', value: 'project' },
+            { kind: 'eq', key: 'status', value: 'active' },
+          ],
+          groupBy: 'status',
+          limit: 25,
+        }),
+      });
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Galleria' }));
+
+    await waitFor(() => {
+      expect(mock.getSpy(IpcChannels.upsertDatabaseView)).toHaveBeenCalledWith({
+        view: expect.objectContaining({
+          id: 'projects',
+          layout: 'gallery',
+          columns: ['status'],
+        }),
+      });
+    });
+  });
+});

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX } from 'react';
 import type { NotePath } from '@ziba/core';
-import type { DatabaseGroup, DatabaseQuery, DatabaseRow } from '../../../shared/ipc';
+import type {
+  DatabaseGroup,
+  DatabaseQuery,
+  DatabaseRow,
+  DatabaseViewDefinition,
+  DatabaseViewsFile,
+} from '../../../shared/ipc';
 import { useDatabaseStore } from '../../stores/database';
 import { navigateToNote } from '../../lib/navigate';
+import { ipc } from '../../lib/ipc';
 import { useUiStore, type DatabaseViewMode } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { useTagsStore } from '../../stores/tags';
@@ -12,6 +19,7 @@ import { BoardView } from './BoardView';
 import { CalendarView } from './CalendarView';
 import { ColumnPicker } from './ColumnPicker';
 import { FilterBar } from './FilterBar';
+import { GalleryView } from './GalleryView';
 import { Table } from './Table';
 
 /**
@@ -35,6 +43,10 @@ const TIME_FORMATTER = new Intl.DateTimeFormat('it', {
   second: '2-digit',
 });
 
+function createViewId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `view-${Date.now().toString(36)}`;
+}
+
 /**
  * Top-level database view. Replaces the placeholder shipped in Wave 1.
  *
@@ -56,14 +68,12 @@ export function DatabaseView(): JSX.Element {
   const availableProperties = useDatabaseStore((s) => s.availableProperties);
   const lastUpdatedAt = useDatabaseStore((s) => s.lastUpdatedAt);
   const setFilters = useDatabaseStore((s) => s.setFilters);
-  const addFilter = useDatabaseStore((s) => s.addFilter);
-  const removeFilter = useDatabaseStore((s) => s.removeFilter);
-  const updateFilter = useDatabaseStore((s) => s.updateFilter);
   const setSort = useDatabaseStore((s) => s.setSort);
   const setGroupBy = useDatabaseStore((s) => s.setGroupBy);
   const setFolder = useDatabaseStore((s) => s.setFolder);
   const setLimit = useDatabaseStore((s) => s.setLimit);
   const runQuery = useDatabaseStore((s) => s.runQuery);
+  const applyViewState = useDatabaseStore((s) => s.applyViewState);
   const subscribeToVaultEvents = useDatabaseStore((s) => s.subscribeToVaultEvents);
 
   const selectedType = useDatabaseStore((s) => s.selectedType);
@@ -79,7 +89,61 @@ export function DatabaseView(): JSX.Element {
   // first non-empty available-properties list; subsequent vault events that
   // re-derive `availableProperties` don't reset the user's choice.
   const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
+  const [viewsFile, setViewsFile] = useState<DatabaseViewsFile | null>(null);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
   const seededRef = useRef(false);
+
+  const activeView = useMemo<DatabaseViewDefinition | null>(() => {
+    if (viewsFile === null || activeViewId === null) return null;
+    return viewsFile.views.find((view) => view.id === activeViewId) ?? null;
+  }, [activeViewId, viewsFile]);
+
+  const applyDatabaseView = useCallback(
+    (view: DatabaseViewDefinition): void => {
+      setActiveViewId(view.id);
+      setDatabaseViewMode(view.layout);
+      if (view.columns.length > 0) {
+        seededRef.current = true;
+        setVisibleColumns(view.columns);
+      } else {
+        seededRef.current = false;
+        setVisibleColumns([]);
+      }
+      void applyViewState({ query: view.query, selectedType: view.selectedType });
+    },
+    [applyViewState, setDatabaseViewMode],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadViews = async (): Promise<void> => {
+      try {
+        const file = await ipc.listDatabaseViews();
+        if (cancelled) return;
+        setViewsFile(file);
+        const nextActiveId = file.activeViewId ?? file.views[0]?.id ?? null;
+        setActiveViewId(nextActiveId);
+        const nextActive = file.views.find((view) => view.id === nextActiveId) ?? file.views[0];
+        if (nextActive !== undefined) applyDatabaseView(nextActive);
+      } catch {
+        if (!cancelled) setViewsFile(null);
+      }
+    };
+
+    void loadViews();
+    const off = ipc.onDatabaseViewsChanged((file) => {
+      setViewsFile(file);
+      const nextActiveId = file.activeViewId ?? file.views[0]?.id ?? null;
+      setActiveViewId(nextActiveId);
+    });
+
+    return () => {
+      cancelled = true;
+      off();
+    };
+  }, [applyDatabaseView]);
 
   useEffect(() => {
     if (seededRef.current) return;
@@ -123,6 +187,147 @@ export function DatabaseView(): JSX.Element {
 
   const filters = useMemo(() => query.filters ?? [], [query.filters]);
 
+  const persistActiveView = useCallback(
+    (patch: Partial<DatabaseViewDefinition>): void => {
+      if (activeView === null) return;
+      const nextView: DatabaseViewDefinition = {
+        ...activeView,
+        query,
+        selectedType,
+        layout: databaseViewMode,
+        columns: visibleColumns,
+        ...patch,
+        updatedAt: Date.now(),
+      };
+      setViewsFile((current) =>
+        current === null
+          ? current
+          : {
+              ...current,
+              activeViewId: nextView.id,
+              views: current.views.map((view) => (view.id === nextView.id ? nextView : view)),
+            },
+      );
+      void ipc.upsertDatabaseView({ view: nextView });
+    },
+    [activeView, databaseViewMode, query, selectedType, visibleColumns],
+  );
+
+  const handleSelectView = (view: DatabaseViewDefinition): void => {
+    applyDatabaseView(view);
+  };
+
+  const handleCreateView = (): void => {
+    const timestamp = Date.now();
+    const view: DatabaseViewDefinition = {
+      id: createViewId(),
+      name: `Vista ${(viewsFile?.views.length ?? 0) + 1}`,
+      layout: databaseViewMode,
+      query,
+      selectedType,
+      columns: visibleColumns,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    setViewMenuOpen(false);
+    setViewsFile((current) =>
+      current === null
+        ? { version: 1, activeViewId: view.id, views: [view] }
+        : { ...current, activeViewId: view.id, views: [...current.views, view] },
+    );
+    applyDatabaseView(view);
+    void ipc.upsertDatabaseView({ view });
+  };
+
+  const handleDuplicateView = (): void => {
+    if (activeView === null) return;
+    setViewMenuOpen(false);
+    void ipc.duplicateDatabaseView({ id: activeView.id }).then((copy) => {
+      setViewsFile((current) =>
+        current === null
+          ? { version: 1, activeViewId: copy.id, views: [copy] }
+          : { ...current, activeViewId: copy.id, views: [...current.views, copy] },
+      );
+      applyDatabaseView(copy);
+    });
+  };
+
+  const handleDeleteView = (): void => {
+    if (activeView === null) return;
+    setViewMenuOpen(false);
+    void ipc.deleteDatabaseView({ id: activeView.id }).then((file) => {
+      setViewsFile(file);
+      const next = file.views.find((view) => view.id === file.activeViewId) ?? file.views[0];
+      if (next !== undefined) applyDatabaseView(next);
+    });
+  };
+
+  const handleVisibleColumnsChange = (columns: string[]): void => {
+    setVisibleColumns(columns);
+    persistActiveView({ columns });
+  };
+
+  const handleFiltersChange = (nextFilters: DatabaseQuery['filters']): void => {
+    const nextQuery = { ...query, filters: nextFilters ?? [] };
+    setFilters(nextQuery.filters ?? []);
+    persistActiveView({ query: nextQuery });
+  };
+
+  const handleAddFilter = (filter: (typeof filters)[number]): void => {
+    handleFiltersChange([...filters, filter]);
+  };
+
+  const handleUpdateFilter = (index: number, filter: (typeof filters)[number]): void => {
+    const next = filters.slice();
+    next[index] = filter;
+    handleFiltersChange(next);
+  };
+
+  const handleRemoveFilter = (index: number): void => {
+    handleFiltersChange(filters.slice(0, index).concat(filters.slice(index + 1)));
+  };
+
+  const handleSortChange = (sortValue: DatabaseQuery['sort']): void => {
+    setSort(sortValue);
+    const nextQuery = { ...query };
+    if (sortValue === undefined || sortValue.length === 0) delete nextQuery.sort;
+    else nextQuery.sort = sortValue;
+    persistActiveView({ query: nextQuery });
+  };
+
+  const handleGroupByChange = (groupBy: string | null): void => {
+    setGroupBy(groupBy);
+    const nextQuery = { ...query };
+    if (groupBy === null) delete nextQuery.groupBy;
+    else nextQuery.groupBy = groupBy;
+    persistActiveView({ query: nextQuery });
+  };
+
+  const handleFolderCommit = (value: string): void => {
+    const trimmed = value.trim();
+    const folder = trimmed === '' ? undefined : trimmed;
+    setFolder(folder);
+    const nextQuery = { ...query };
+    if (folder === undefined) delete nextQuery.folder;
+    else nextQuery.folder = folder;
+    persistActiveView({ query: nextQuery });
+  };
+
+  const handleLimitChange = (limit: number): void => {
+    setLimit(limit);
+    persistActiveView({ query: { ...query, limit } });
+  };
+
+  const handleTypeChange = (type: string | null): void => {
+    setType(type);
+    persistActiveView({ selectedType: type });
+  };
+
+  const handleDatabaseViewModeChange = (mode: DatabaseViewMode): void => {
+    setDatabaseViewMode(mode);
+    persistActiveView({ layout: mode });
+  };
+
   const suggestedColumnKeys = useMemo<string[]>(() => {
     if (selectedType === null) return [];
     const schema = tagSchemas.find((s) => s.id === selectedType);
@@ -158,6 +363,9 @@ export function DatabaseView(): JSX.Element {
     setFilters([]);
     setFolder(undefined);
     setType(null);
+    const nextQuery = { ...query, filters: [] };
+    delete nextQuery.folder;
+    persistActiveView({ query: nextQuery, selectedType: null });
   };
 
   const onRowClick = (path: NotePath): void => {
@@ -211,13 +419,87 @@ export function DatabaseView(): JSX.Element {
             )}
           </div>
           <div className="flex items-center gap-2">
-            <TypeFilterDropdown types={tagTypes} selectedType={selectedType} onChange={setType} />
+            <TypeFilterDropdown
+              types={tagTypes}
+              selectedType={selectedType}
+              onChange={handleTypeChange}
+            />
             <ColumnPicker
               availableProperties={availableProperties}
               suggestedKeys={suggestedColumnKeys}
               visibleColumns={visibleColumns}
-              onChange={setVisibleColumns}
+              onChange={handleVisibleColumnsChange}
             />
+          </div>
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+          <div
+            role="tablist"
+            aria-label="Viste database salvate"
+            className="flex min-w-0 flex-wrap items-center gap-1"
+          >
+            {(viewsFile?.views ?? []).map((view) => {
+              const active = view.id === activeViewId;
+              return (
+                <button
+                  key={view.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={(): void => handleSelectView(view)}
+                  className={
+                    active
+                      ? 'rounded bg-bg-muted px-2 py-1 text-xs font-medium text-fg'
+                      : 'rounded px-2 py-1 text-xs font-medium text-fg-subtle hover:bg-bg-muted hover:text-fg'
+                  }
+                >
+                  {view.name}
+                </button>
+              );
+            })}
+          </div>
+          <div className="relative">
+            <button
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded={viewMenuOpen}
+              onClick={(): void => setViewMenuOpen((open) => !open)}
+              className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+            >
+              Vista
+            </button>
+            {viewMenuOpen && (
+              <div
+                role="menu"
+                className="absolute right-0 z-20 mt-1 w-40 rounded border border-border bg-bg p-1 text-xs shadow-lg"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleCreateView}
+                  className="block w-full rounded px-2 py-1 text-left text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                >
+                  Nuova vista
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleDuplicateView}
+                  className="block w-full rounded px-2 py-1 text-left text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                >
+                  Duplica
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleDeleteView}
+                  className="block w-full rounded px-2 py-1 text-left text-red-600 hover:bg-red-500/10"
+                >
+                  Elimina
+                </button>
+              </div>
+            )}
           </div>
         </div>
 
@@ -226,9 +508,9 @@ export function DatabaseView(): JSX.Element {
             filters={filters}
             availableProperties={availableProperties}
             rows={rows}
-            onAdd={addFilter}
-            onUpdate={updateFilter}
-            onRemove={removeFilter}
+            onAdd={handleAddFilter}
+            onUpdate={handleUpdateFilter}
+            onRemove={handleRemoveFilter}
           />
         </div>
 
@@ -237,27 +519,24 @@ export function DatabaseView(): JSX.Element {
             sortKey={sortKey}
             sortDirection={sortDirection}
             availableProperties={availableProperties}
-            onChange={setSort}
+            onChange={handleSortChange}
           />
 
           <GroupByControl
             groupBy={query.groupBy ?? null}
             availableProperties={availableProperties}
-            onChange={setGroupBy}
+            onChange={handleGroupByChange}
           />
 
           <FolderScopeInput
             value={folderDraft}
             onChange={setFolderDraft}
-            onCommit={(v): void => {
-              const trimmed = v.trim();
-              setFolder(trimmed === '' ? undefined : trimmed);
-            }}
+            onCommit={handleFolderCommit}
           />
 
-          <LimitControl value={queryLimit} onChange={setLimit} />
+          <LimitControl value={queryLimit} onChange={handleLimitChange} />
 
-          <ViewModeTabs current={databaseViewMode} onChange={setDatabaseViewMode} />
+          <ViewModeTabs current={databaseViewMode} onChange={handleDatabaseViewModeChange} />
         </div>
       </header>
 
@@ -308,6 +587,10 @@ export function DatabaseView(): JSX.Element {
         {!isEmpty && result !== null && databaseViewMode === 'board' && <BoardView />}
 
         {!isEmpty && result !== null && databaseViewMode === 'calendar' && <CalendarView />}
+
+        {!isEmpty && result !== null && databaseViewMode === 'gallery' && (
+          <GalleryView rows={rows} columns={visibleColumns} onRowClick={onRowClick} />
+        )}
 
         {result === null && error === null && (
           <div className="flex h-full items-center justify-center p-8 text-fg-muted">
@@ -477,6 +760,7 @@ function ViewModeTabs({
     { id: 'table', label: 'Tabella' },
     { id: 'board', label: 'Board' },
     { id: 'calendar', label: 'Calendario' },
+    { id: 'gallery', label: 'Galleria' },
   ];
   return (
     <div role="tablist" aria-label="Vista database" className="ml-auto flex items-center gap-0.5">

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -7,6 +7,9 @@ import type {
   Backlink,
   DatabaseQuery,
   DatabaseResult,
+  DatabaseViewDefinition,
+  DatabaseViewsChangedPayload,
+  DatabaseViewsFile,
   FullGraph,
   IndexProgressPayload,
   LinkReferencesResult,
@@ -125,6 +128,18 @@ export const ipc = {
   runDatabaseQuery(args: { query: DatabaseQuery }): Promise<DatabaseResult> {
     return api().invoke(IpcChannels.runDatabaseQuery, args);
   },
+  listDatabaseViews(): Promise<DatabaseViewsFile> {
+    return api().invoke(IpcChannels.listDatabaseViews);
+  },
+  upsertDatabaseView(args: { view: DatabaseViewDefinition }): Promise<DatabaseViewDefinition> {
+    return api().invoke(IpcChannels.upsertDatabaseView, args);
+  },
+  deleteDatabaseView(args: { id: string }): Promise<DatabaseViewsFile> {
+    return api().invoke(IpcChannels.deleteDatabaseView, args);
+  },
+  duplicateDatabaseView(args: { id: string }): Promise<DatabaseViewDefinition> {
+    return api().invoke(IpcChannels.duplicateDatabaseView, args);
+  },
   getFullGraph(): Promise<FullGraph> {
     return api().invoke(IpcChannels.getFullGraph);
   },
@@ -160,6 +175,9 @@ export const ipc = {
   },
   onIndexProgress(listener: (payload: IndexProgressPayload) => void): () => void {
     return api().onIndexProgress(listener);
+  },
+  onDatabaseViewsChanged(listener: (payload: DatabaseViewsChangedPayload) => void): () => void {
+    return api().onDatabaseViewsChanged(listener);
   },
 };
 

--- a/apps/desktop/src/stores/database.test.ts
+++ b/apps/desktop/src/stores/database.test.ts
@@ -379,4 +379,30 @@ describe('useDatabaseStore — selectedType slice', () => {
 
     expect(observed!.filters?.some((f) => f.key === 'type')).toBe(false);
   });
+
+  it('applyViewState replaces query and selectedType in one immediate run', async () => {
+    const { useDatabaseStore, useVaultStore } = await loadStores();
+    useVaultStore.setState({ current: FAKE_VAULT });
+    let observed: DatabaseQuery | null = null;
+    mock.setHandler(IpcChannels.runDatabaseQuery, async ({ query }) => {
+      observed = query;
+      return { rows: [], groups: [], totalCount: 0 };
+    });
+
+    await useDatabaseStore.getState().applyViewState({
+      query: {
+        filters: [{ kind: 'eq', key: 'status', value: 'active' }],
+        groupBy: 'status',
+        limit: 25,
+      },
+      selectedType: 'project',
+    });
+
+    expect(useDatabaseStore.getState().query.limit).toBe(25);
+    expect(useDatabaseStore.getState().selectedType).toBe('project');
+    expect(observed!.filters).toEqual([
+      { kind: 'eq', key: 'type', value: 'project' },
+      { kind: 'eq', key: 'status', value: 'active' },
+    ]);
+  });
 });

--- a/apps/desktop/src/stores/database.ts
+++ b/apps/desktop/src/stores/database.ts
@@ -46,6 +46,8 @@ type DatabaseState = {
   setLimit(limit: number): void;
   /** v1.0 Phase 4: set or clear the page-level type filter. */
   setType(type: string | null): void;
+  /** Apply a saved database view without firing multiple intermediate queries. */
+  applyViewState(state: { query: DatabaseQuery; selectedType: string | null }): Promise<void>;
 
   // ---- Execution ---------------------------------------------------------
   /** Run the query immediately. Cancels any pending debounced run. */
@@ -180,6 +182,22 @@ export const useDatabaseStore = create<DatabaseState>((set, get) => {
       // than waiting out the keystroke debounce window.
       debouncedRun.cancel();
       void get().runQuery();
+    },
+
+    async applyViewState(state) {
+      const nextQuery: DatabaseQuery = {
+        ...state.query,
+        ...(state.query.filters !== undefined ? { filters: [...state.query.filters] } : {}),
+        ...(state.query.sort !== undefined
+          ? { sort: state.query.sort.map((item) => ({ ...item })) }
+          : {}),
+      };
+      set({
+        query: nextQuery,
+        selectedType: state.selectedType,
+      });
+      debouncedRun.cancel();
+      await get().runQuery();
     },
 
     async runQuery() {

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -21,10 +21,11 @@ export type MainView = 'editor' | 'database' | 'graph';
 /**
  * Sub-mode within the Database view. The same query (filters / sort /
  * groupBy) can be visualized as a sortable table (v0.3), a kanban-style
- * board grouped by a single property (v0.4), or a monthly calendar
- * grouped by a date property (v0.4). One DatabaseQuery, multiple shapes.
+ * board grouped by a single property (v0.4), a monthly calendar grouped
+ * by a date property (v0.4), or a card gallery. One DatabaseQuery,
+ * multiple shapes.
  */
-export type DatabaseViewMode = 'table' | 'board' | 'calendar';
+export type DatabaseViewMode = 'table' | 'board' | 'calendar' | 'gallery';
 
 export const FOLDER_ICON_IDS = [
   'folder',
@@ -119,7 +120,7 @@ function isMainView(v: unknown): v is MainView {
 }
 
 function isDatabaseViewMode(v: unknown): v is DatabaseViewMode {
-  return v === 'table' || v === 'board' || v === 'calendar';
+  return v === 'table' || v === 'board' || v === 'calendar' || v === 'gallery';
 }
 
 function isFolderIconId(v: unknown): v is FolderIconId {

--- a/apps/desktop/src/test/mock-ipc.ts
+++ b/apps/desktop/src/test/mock-ipc.ts
@@ -1,5 +1,6 @@
 import { vi, type Mock } from 'vitest';
 import type {
+  DatabaseViewsChangedPayload,
   IndexProgressPayload,
   IpcChannel,
   IpcRequests,
@@ -52,14 +53,20 @@ export interface MockController {
   onVaultEventSpy: Mock;
   /** Spy for `onIndexProgress` listener registrations. */
   onIndexProgressSpy: Mock;
+  /** Spy for `onDatabaseViewsChanged` listener registrations. */
+  onDatabaseViewsChangedSpy: Mock;
   /** Push a vault event to every subscribed listener. */
   triggerVaultEvent(payload: VaultEventPayload): void;
   /** Push an index-progress event to every subscribed listener. */
   triggerIndexProgress(payload: IndexProgressPayload): void;
+  /** Push a database-views change event to every subscribed listener. */
+  triggerDatabaseViewsChanged(payload: DatabaseViewsChangedPayload): void;
   /** Number of vault-event listeners currently registered. */
   vaultEventListenerCount(): number;
   /** Number of index-progress listeners currently registered. */
   indexProgressListenerCount(): number;
+  /** Number of database-views listeners currently registered. */
+  databaseViewsChangedListenerCount(): number;
 }
 
 /** Default handler returns for channels tests don't explicitly set up.
@@ -135,6 +142,53 @@ function buildDefaultHandlers(): Required<MockHandlers> {
       groups: [],
       totalCount: 0,
     }),
+    [IpcChannels.listDatabaseViews]: async () => ({
+      version: 1,
+      activeViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Tutte',
+          layout: 'table',
+          query: { filters: [], limit: 1000 },
+          selectedType: null,
+          columns: [],
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+    }),
+    [IpcChannels.upsertDatabaseView]: async (
+      args: IpcRequests[typeof IpcChannels.upsertDatabaseView],
+    ) => args.view,
+    [IpcChannels.deleteDatabaseView]: async () => ({
+      version: 1,
+      activeViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Tutte',
+          layout: 'table',
+          query: { filters: [], limit: 1000 },
+          selectedType: null,
+          columns: [],
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+    }),
+    [IpcChannels.duplicateDatabaseView]: async (
+      args: IpcRequests[typeof IpcChannels.duplicateDatabaseView],
+    ) => ({
+      id: `${args.id}-copy`,
+      name: 'Tutte copia',
+      layout: 'table',
+      query: { filters: [], limit: 1000 },
+      selectedType: null,
+      columns: [],
+      createdAt: 0,
+      updatedAt: 0,
+    }),
     [IpcChannels.getFullGraph]: async () => ({ nodes: [], edges: [] }),
 
     // v1.0 — taxonomy + relations
@@ -172,6 +226,7 @@ export function installMockIpc(overrides: MockHandlers = {}): MockController {
 
   const vaultEventListeners = new Set<(p: VaultEventPayload) => void>();
   const indexProgressListeners = new Set<(p: IndexProgressPayload) => void>();
+  const databaseViewsChangedListeners = new Set<(p: DatabaseViewsChangedPayload) => void>();
 
   const onVaultEventSpy = vi.fn((listener: (p: VaultEventPayload) => void) => {
     vaultEventListeners.add(listener);
@@ -185,6 +240,12 @@ export function installMockIpc(overrides: MockHandlers = {}): MockController {
       indexProgressListeners.delete(listener);
     };
   });
+  const onDatabaseViewsChangedSpy = vi.fn((listener: (p: DatabaseViewsChangedPayload) => void) => {
+    databaseViewsChangedListeners.add(listener);
+    return () => {
+      databaseViewsChangedListeners.delete(listener);
+    };
+  });
 
   const api: ZibaApi = {
     invoke: ((channel: IpcChannel, args?: unknown) => {
@@ -196,6 +257,8 @@ export function installMockIpc(overrides: MockHandlers = {}): MockController {
     }) as ZibaApi['invoke'],
     onVaultEvent: onVaultEventSpy as unknown as ZibaApi['onVaultEvent'],
     onIndexProgress: onIndexProgressSpy as unknown as ZibaApi['onIndexProgress'],
+    onDatabaseViewsChanged:
+      onDatabaseViewsChangedSpy as unknown as ZibaApi['onDatabaseViewsChanged'],
   };
 
   window.ziba = api;
@@ -217,17 +280,24 @@ export function installMockIpc(overrides: MockHandlers = {}): MockController {
     },
     onVaultEventSpy,
     onIndexProgressSpy,
+    onDatabaseViewsChangedSpy,
     triggerVaultEvent(payload) {
       for (const l of vaultEventListeners) l(payload);
     },
     triggerIndexProgress(payload) {
       for (const l of indexProgressListeners) l(payload);
     },
+    triggerDatabaseViewsChanged(payload) {
+      for (const l of databaseViewsChangedListeners) l(payload);
+    },
     vaultEventListenerCount() {
       return vaultEventListeners.size;
     },
     indexProgressListenerCount() {
       return indexProgressListeners.size;
+    },
+    databaseViewsChangedListenerCount() {
+      return databaseViewsChangedListeners.size;
     },
   };
 }

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -29,6 +29,7 @@ function makeFailingApi(): ZibaApi {
     invoke: ((channel: string) => fail(`invoke('${channel}')`)) as ZibaApi['invoke'],
     onVaultEvent: () => fail('onVaultEvent'),
     onIndexProgress: () => fail('onIndexProgress'),
+    onDatabaseViewsChanged: () => fail('onDatabaseViewsChanged'),
   };
 }
 

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -132,6 +132,25 @@ export type DatabaseQuery = {
   limit?: number;
 };
 
+export type DatabaseViewLayout = 'table' | 'board' | 'calendar' | 'gallery';
+
+export type DatabaseViewDefinition = {
+  id: string;
+  name: string;
+  layout: DatabaseViewLayout;
+  query: DatabaseQuery;
+  selectedType: string | null;
+  columns: string[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type DatabaseViewsFile = {
+  version: 1;
+  activeViewId: string | null;
+  views: DatabaseViewDefinition[];
+};
+
 /**
  * Materialised row returned by the query API. `properties` is keyed by
  * property name and contains the typed `DetectedProperty` for that key —


### PR DESCRIPTION
## Summary
- Adds Ziba-native shared Attribute Views persisted in `<vault>/.ziba/database-views.json`.
- Adds public database view types plus IPC/list/upsert/delete/duplicate handlers and `databaseViewsChanged` push events.
- Updates the Database UI with saved view tabs, a compact view menu, persisted layout/query/type/columns, and a new gallery layout.

## Stack
- Stacked on #13 / `codex/siyuan-inspired-graph-db`.
- This is PR 2 of the SiYuan-like roadmap: shared Attribute Views.

## Test plan
- `pnpm --filter ziba-desktop test -- electron/ipc/database-views.test.ts src/stores/database.test.ts src/components/DatabaseView/index.test.tsx src/stores/ui.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 598 tests passed
- `pnpm build`
