### PR TITLE
feat: add inline database blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 - Attribute Views salvate in `<vault>/.ziba/database-views.json`, con tab
   vista, layout `table | board | calendar | gallery`, colonne e query
   persistite.
+- Blocco database inline per l'editor (`<div data-ziba-db="view-id"></div>`)
+  con picker `/database`, creazione rapida di viste e celle frontmatter
+  modificabili nella tabella.
 - Controllo "Righe" nella DatabaseView, collegato a `DatabaseQuery.limit`.
 
 ## [1.0.1] - 2026-05-10

--- a/apps/desktop/src/components/DatabaseView/Table.tsx
+++ b/apps/desktop/src/components/DatabaseView/Table.tsx
@@ -10,6 +10,13 @@ import type {
 
 type SortSpec = NonNullable<DatabaseQuery['sort']>;
 
+export type DatabaseCellCommit = {
+  path: string;
+  key: string;
+  type: PropertyType | null;
+  value: string | boolean;
+};
+
 type Props = {
   rows: readonly DatabaseRow[];
   groups: readonly DatabaseGroup[];
@@ -22,6 +29,7 @@ type Props = {
   groupBy: string | undefined;
   onSortChange(sort: SortSpec): void;
   onRowClick(path: string): void;
+  onCellCommit?(args: DatabaseCellCommit): void;
 };
 
 /**
@@ -165,6 +173,91 @@ function PropertyCell({ prop }: { prop: DetectedProperty | undefined }): JSX.Ele
   }
 }
 
+function editableValue(prop: DetectedProperty | undefined): string {
+  if (prop === undefined) return '';
+  if (prop.type === 'string-array') return prop.value.join(', ');
+  if (prop.type === 'boolean') return prop.value ? 'true' : 'false';
+  return String(prop.value);
+}
+
+function EditablePropertyCell({
+  row,
+  keyName,
+  type,
+  prop,
+  onCommit,
+}: {
+  row: DatabaseRow;
+  keyName: string;
+  type: PropertyType | null;
+  prop: DetectedProperty | undefined;
+  onCommit(args: DatabaseCellCommit): void;
+}): JSX.Element {
+  const label = `${keyName} per ${row.title}`;
+  const value = editableValue(prop);
+
+  if (type === 'boolean' || prop?.type === 'boolean') {
+    const checked = prop?.type === 'boolean' ? prop.value : false;
+    return (
+      <input
+        type="checkbox"
+        aria-label={label}
+        defaultChecked={checked}
+        onClick={(event): void => event.stopPropagation()}
+        onChange={(event): void => {
+          onCommit({
+            path: row.path,
+            key: keyName,
+            type: 'boolean',
+            value: event.currentTarget.checked,
+          });
+        }}
+        className="size-4 rounded border-border accent-accent"
+      />
+    );
+  }
+
+  const normalizedType = type ?? prop?.type ?? 'text';
+  const inputType =
+    normalizedType === 'number'
+      ? 'number'
+      : normalizedType === 'date'
+        ? 'date'
+        : normalizedType === 'url'
+          ? 'url'
+          : 'text';
+
+  return (
+    <input
+      type={inputType}
+      aria-label={label}
+      defaultValue={value}
+      onClick={(event): void => event.stopPropagation()}
+      onKeyDown={(event): void => {
+        event.stopPropagation();
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          event.currentTarget.blur();
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          event.currentTarget.value = value;
+          event.currentTarget.blur();
+        }
+      }}
+      onBlur={(event): void => {
+        if (event.currentTarget.value === value) return;
+        onCommit({
+          path: row.path,
+          key: keyName,
+          type: normalizedType,
+          value: event.currentTarget.value,
+        });
+      }}
+      className="w-full min-w-24 rounded border border-transparent bg-transparent px-1 py-0.5 text-fg-subtle outline-none hover:border-border hover:bg-bg focus:border-accent focus:bg-bg focus:text-fg"
+    />
+  );
+}
+
 /**
  * Sortable column header. Clicking toggles asc/desc for that key; clicking
  * a different key resets to asc.
@@ -236,6 +329,7 @@ export function Table({
   groupBy,
   onSortChange,
   onRowClick,
+  onCellCommit,
 }: Props): JSX.Element {
   const activeSort = sort?.[0] ?? null;
   const activeKey = activeSort?.key ?? null;
@@ -342,6 +436,7 @@ export function Table({
                     columns={columns}
                     columnTypes={columnTypes}
                     onRowClick={onRowClick}
+                    {...(onCellCommit !== undefined && { onCellCommit })}
                   />
                 );
               })}
@@ -353,6 +448,7 @@ export function Table({
                   columns={columns}
                   columnTypes={columnTypes}
                   onRowClick={onRowClick}
+                  {...(onCellCommit !== undefined && { onCellCommit })}
                 />
               ))}
           </tbody>
@@ -387,6 +483,7 @@ function GroupSection({
   columns,
   columnTypes,
   onRowClick,
+  onCellCommit,
 }: {
   label: string;
   count: number;
@@ -395,6 +492,7 @@ function GroupSection({
   columns: string[];
   columnTypes: Map<string, PropertyType | null>;
   onRowClick(path: string): void;
+  onCellCommit?(args: DatabaseCellCommit): void;
 }): JSX.Element {
   return (
     <>
@@ -413,6 +511,7 @@ function GroupSection({
           columns={columns}
           columnTypes={columnTypes}
           onRowClick={onRowClick}
+          {...(onCellCommit !== undefined && { onCellCommit })}
         />
       ))}
     </>
@@ -424,11 +523,13 @@ function RowItem({
   columns,
   columnTypes,
   onRowClick,
+  onCellCommit,
 }: {
   row: DatabaseRow;
   columns: string[];
   columnTypes: Map<string, PropertyType | null>;
   onRowClick(path: string): void;
+  onCellCommit?(args: DatabaseCellCommit): void;
 }): JSX.Element {
   return (
     <tr
@@ -455,7 +556,17 @@ function RowItem({
               t === 'number' && 'text-right',
             )}
           >
-            <PropertyCell prop={row.properties[key]} />
+            {onCellCommit === undefined ? (
+              <PropertyCell prop={row.properties[key]} />
+            ) : (
+              <EditablePropertyCell
+                row={row}
+                keyName={key}
+                type={t}
+                prop={row.properties[key]}
+                onCommit={onCellCommit}
+              />
+            )}
           </td>
         );
       })}

--- a/apps/desktop/src/components/DatabaseView/index.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   IpcChannels,
   type DatabaseResult,
@@ -68,6 +68,15 @@ beforeEach(() => {
   };
   mock.setHandler(IpcChannels.listDatabaseViews, async () => viewsFile);
   mock.setHandler(IpcChannels.runDatabaseQuery, async () => makeRows());
+  mock.setHandler(IpcChannels.loadNote, async ({ path }) => ({
+    path,
+    title: 'Ziba',
+    content: '# Ziba',
+    frontmatter: { status: 'active' },
+    wikilinks: [],
+    mtimeMs: 0,
+  }));
+  mock.setHandler(IpcChannels.saveNote, async () => ({ mtimeMs: 1 }));
   mock.setHandler(IpcChannels.upsertDatabaseView, async ({ view }) => view);
   useVaultStore.setState({
     current: { root: '/vault-a', name: 'vault-a', openedAt: 0 },
@@ -118,6 +127,49 @@ describe('<DatabaseView>', () => {
           layout: 'gallery',
           columns: ['status'],
         }),
+      });
+    });
+  });
+
+  it('uses the embedded initial view and reports view changes to the host node', async () => {
+    const onActiveViewChange = vi.fn();
+
+    render(
+      <DatabaseView embedded initialViewId="projects" onActiveViewChange={onActiveViewChange} />,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
+    await waitFor(() => {
+      const calls = mock.getCallsFor(IpcChannels.runDatabaseQuery);
+      expect(calls.at(-1)?.[0]).toEqual({
+        query: expect.objectContaining({
+          filters: [
+            { kind: 'eq', key: 'type', value: 'project' },
+            { kind: 'eq', key: 'status', value: 'active' },
+          ],
+          groupBy: 'status',
+          limit: 25,
+        }),
+      });
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tutte' }));
+
+    expect(onActiveViewChange).toHaveBeenCalledWith('default');
+  });
+
+  it('commits table cell edits back to note frontmatter', async () => {
+    render(<DatabaseView />);
+
+    const status = await screen.findByLabelText('status per Ziba');
+    fireEvent.change(status, { target: { value: 'done' } });
+    fireEvent.blur(status);
+
+    await waitFor(() => {
+      expect(mock.getSpy(IpcChannels.saveNote)).toHaveBeenCalledWith({
+        path: 'Projects/Ziba.md',
+        body: '# Ziba',
+        frontmatter: { status: 'done' },
       });
     });
   });

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -1,26 +1,29 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX } from 'react';
-import type { NotePath } from '@ziba/core';
+import type { Frontmatter, NotePath } from '@ziba/core';
 import type {
   DatabaseGroup,
   DatabaseQuery,
   DatabaseRow,
   DatabaseViewDefinition,
   DatabaseViewsFile,
+  PropertyType,
 } from '../../../shared/ipc';
 import { useDatabaseStore } from '../../stores/database';
 import { navigateToNote } from '../../lib/navigate';
 import { ipc } from '../../lib/ipc';
+import { ipcErrorMessage } from '../../lib/ipc-error';
 import { useUiStore, type DatabaseViewMode } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { useTagsStore } from '../../stores/tags';
+import { toast } from '../../stores/toast';
 import { TypeFilterDropdown } from './TypeFilterDropdown';
 import { BoardView } from './BoardView';
 import { CalendarView } from './CalendarView';
 import { ColumnPicker } from './ColumnPicker';
 import { FilterBar } from './FilterBar';
 import { GalleryView } from './GalleryView';
-import { Table } from './Table';
+import { Table, type DatabaseCellCommit } from './Table';
 
 /**
  * Default count of property columns rendered when the user hasn't picked
@@ -43,8 +46,42 @@ const TIME_FORMATTER = new Intl.DateTimeFormat('it', {
   second: '2-digit',
 });
 
+export type DatabaseViewProps = {
+  /** Saved view to apply first, used by inline database blocks. */
+  initialViewId?: string;
+  /** Compact framed surface for rendering inside the editor body. */
+  embedded?: boolean;
+  /** Notifies the embedding node when the user switches to another saved view. */
+  onActiveViewChange?: (viewId: string) => void;
+};
+
 function createViewId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `view-${Date.now().toString(36)}`;
+}
+
+function coerceCellValue(type: PropertyType | null, value: string | boolean): unknown {
+  if (typeof value === 'boolean') return value;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+
+  switch (type) {
+    case 'number': {
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    case 'boolean':
+      return trimmed.toLowerCase() === 'true' || trimmed === '1' || trimmed.toLowerCase() === 'si';
+    case 'string-array':
+      return trimmed
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+    case 'date':
+    case 'url':
+    case 'text':
+    default:
+      return trimmed;
+  }
 }
 
 /**
@@ -60,7 +97,8 @@ function createViewId(): string {
  *    `openNote` is async, but we switch the view synchronously so the
  *    editor pane is already mounted by the time the note resolves.
  */
-export function DatabaseView(): JSX.Element {
+export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
+  const { initialViewId, embedded = false, onActiveViewChange } = props;
   const query = useDatabaseStore((s) => s.query);
   const result = useDatabaseStore((s) => s.result);
   const loading = useDatabaseStore((s) => s.loading);
@@ -102,6 +140,7 @@ export function DatabaseView(): JSX.Element {
   const applyDatabaseView = useCallback(
     (view: DatabaseViewDefinition): void => {
       setActiveViewId(view.id);
+      onActiveViewChange?.(view.id);
       setDatabaseViewMode(view.layout);
       if (view.columns.length > 0) {
         seededRef.current = true;
@@ -112,7 +151,7 @@ export function DatabaseView(): JSX.Element {
       }
       void applyViewState({ query: view.query, selectedType: view.selectedType });
     },
-    [applyViewState, setDatabaseViewMode],
+    [applyViewState, onActiveViewChange, setDatabaseViewMode],
   );
 
   useEffect(() => {
@@ -123,7 +162,7 @@ export function DatabaseView(): JSX.Element {
         const file = await ipc.listDatabaseViews();
         if (cancelled) return;
         setViewsFile(file);
-        const nextActiveId = file.activeViewId ?? file.views[0]?.id ?? null;
+        const nextActiveId = initialViewId ?? file.activeViewId ?? file.views[0]?.id ?? null;
         setActiveViewId(nextActiveId);
         const nextActive = file.views.find((view) => view.id === nextActiveId) ?? file.views[0];
         if (nextActive !== undefined) applyDatabaseView(nextActive);
@@ -135,15 +174,17 @@ export function DatabaseView(): JSX.Element {
     void loadViews();
     const off = ipc.onDatabaseViewsChanged((file) => {
       setViewsFile(file);
-      const nextActiveId = file.activeViewId ?? file.views[0]?.id ?? null;
+      const nextActiveId = initialViewId ?? file.activeViewId ?? file.views[0]?.id ?? null;
       setActiveViewId(nextActiveId);
+      const nextActive = file.views.find((view) => view.id === nextActiveId) ?? file.views[0];
+      if (nextActive !== undefined) applyDatabaseView(nextActive);
     });
 
     return () => {
       cancelled = true;
       off();
     };
-  }, [applyDatabaseView]);
+  }, [applyDatabaseView, initialViewId]);
 
   useEffect(() => {
     if (seededRef.current) return;
@@ -157,6 +198,7 @@ export function DatabaseView(): JSX.Element {
   // user would lose their curation on every save.
   useEffect(() => {
     if (!seededRef.current) return;
+    if (availableProperties.length === 0) return;
     const known = new Set(availableProperties);
     const filtered = visibleColumns.filter((k) => known.has(k));
     if (filtered.length !== visibleColumns.length) {
@@ -375,6 +417,32 @@ export function DatabaseView(): JSX.Element {
     void navigateToNote(path);
   };
 
+  const handleCellCommit = useCallback(
+    async ({ path, key, type, value }: DatabaseCellCommit): Promise<void> => {
+      try {
+        const note = await ipc.loadNote({ path: path as NotePath });
+        const nextFrontmatter: Frontmatter = { ...note.frontmatter };
+        const nextValue = coerceCellValue(type, value);
+        if (nextValue === undefined) delete nextFrontmatter[key];
+        else nextFrontmatter[key] = nextValue;
+
+        await ipc.saveNote({
+          path: path as NotePath,
+          body: note.content,
+          frontmatter: nextFrontmatter,
+        });
+        await runQuery();
+        await useVaultStore
+          .getState()
+          .refreshNotes()
+          .catch(() => undefined);
+      } catch (err: unknown) {
+        toast.error(ipcErrorMessage(err), 'Impossibile aggiornare la cella');
+      }
+    },
+    [runQuery],
+  );
+
   // The body switches between three states (in priority order):
   //   1. error banner — show even if `result` is non-null, so the user
   //      sees the latest error overlaying the last good table.
@@ -391,18 +459,42 @@ export function DatabaseView(): JSX.Element {
   // (App.tsx renders <EmptyState />), but we guard defensively.
   if (currentVault === null) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-bg p-8 text-fg-muted">
+      <div
+        className={
+          embedded
+            ? 'flex min-h-64 w-full items-center justify-center rounded-md border border-border bg-bg p-8 text-fg-muted'
+            : 'flex h-full w-full items-center justify-center bg-bg p-8 text-fg-muted'
+        }
+      >
         <span className="text-sm">Apri un vault per usare la vista database.</span>
       </div>
     );
   }
 
   return (
-    <section className="flex h-full w-full flex-col bg-bg">
-      <header className="shrink-0 border-b border-border bg-bg-subtle px-4 py-2">
+    <section
+      className={
+        embedded
+          ? 'flex h-[420px] w-full flex-col overflow-hidden rounded-md border border-border bg-bg text-sm'
+          : 'flex h-full w-full flex-col bg-bg'
+      }
+    >
+      <header
+        className={
+          embedded
+            ? 'shrink-0 border-b border-border bg-bg-subtle px-3 py-2'
+            : 'shrink-0 border-b border-border bg-bg-subtle px-4 py-2'
+        }
+      >
         <div className="flex items-baseline justify-between gap-2">
           <div className="flex items-baseline gap-3">
-            <h1 className="text-base font-semibold text-fg">Database</h1>
+            <h1
+              className={
+                embedded ? 'text-sm font-semibold text-fg' : 'text-base font-semibold text-fg'
+              }
+            >
+              {embedded && activeView !== null ? activeView.name : 'Database'}
+            </h1>
             <span className="text-xs text-fg-muted">{noteCountLabel}</span>
             {visibleWindowLabel !== null && (
               <span className="text-xs text-fg-muted">{visibleWindowLabel}</span>
@@ -581,6 +673,9 @@ export function DatabaseView(): JSX.Element {
             groupBy={query.groupBy}
             onSortChange={setSort}
             onRowClick={onRowClick}
+            onCellCommit={(args): void => {
+              void handleCellCommit(args);
+            }}
           />
         )}
 

--- a/apps/desktop/src/components/Editor/DatabaseBlockPickerPopup.test.tsx
+++ b/apps/desktop/src/components/Editor/DatabaseBlockPickerPopup.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { DatabaseViewDefinition } from '../../../shared/ipc';
+import { DatabaseBlockPickerPopup } from './DatabaseBlockPickerPopup';
+
+function view(id: string, name: string): DatabaseViewDefinition {
+  return {
+    id,
+    name,
+    layout: 'table',
+    query: { filters: [], limit: 1000 },
+    selectedType: null,
+    columns: [],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe('<DatabaseBlockPickerPopup>', () => {
+  it('selects a saved database view from the picker', () => {
+    const onSelect = vi.fn();
+
+    render(
+      <DatabaseBlockPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        views={[view('projects', 'Projects')]}
+        loading={false}
+        error={null}
+        onSelect={onSelect}
+        onCreateQuick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole('option', { name: /Projects/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('projects');
+  });
+
+  it('offers quick creation when no saved view is suitable', () => {
+    const onCreateQuick = vi.fn();
+
+    render(
+      <DatabaseBlockPickerPopup
+        position={{ top: 0, left: 0, bottom: 0 }}
+        views={[]}
+        loading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onCreateQuick={onCreateQuick}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: /Nuova vista database/i }));
+
+    expect(onCreateQuick).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/components/Editor/DatabaseBlockPickerPopup.tsx
+++ b/apps/desktop/src/components/Editor/DatabaseBlockPickerPopup.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import type { DatabaseViewDefinition } from '../../../shared/ipc';
+
+export type DatabaseBlockPickerPopupProps = {
+  position: { top: number; left: number; bottom: number };
+  views: readonly DatabaseViewDefinition[];
+  loading: boolean;
+  error: string | null;
+  onSelect(viewId: string): void;
+  onCreateQuick(): void;
+  onCancel(): void;
+};
+
+const POPUP_HEIGHT_ESTIMATE = 300;
+
+export function DatabaseBlockPickerPopup(props: DatabaseBlockPickerPopupProps): JSX.Element | null {
+  const { position, views, loading, error, onSelect, onCreateQuick, onCancel } = props;
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  const placement = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { top: position.bottom + 4, left: position.left };
+    }
+    const wouldOverflow = position.bottom + POPUP_HEIGHT_ESTIMATE > window.innerHeight;
+    if (wouldOverflow && position.top - POPUP_HEIGHT_ESTIMATE > 0) {
+      return { top: position.top - POPUP_HEIGHT_ESTIMATE - 4, left: position.left };
+    }
+    return { top: position.bottom + 4, left: position.left };
+  }, [position.bottom, position.left, position.top]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-label="Inserisci vista database"
+      className="fixed z-50 w-72 rounded-md border border-border bg-bg-subtle shadow-lg"
+      style={{ top: placement.top, left: placement.left }}
+    >
+      <div className="border-b border-border px-3 py-2">
+        <div className="text-xs font-semibold uppercase tracking-wide text-fg-muted">Database</div>
+        <div className="mt-0.5 text-sm font-medium text-fg">Inserisci una vista salvata</div>
+      </div>
+
+      {error !== null && (
+        <div role="alert" className="border-b border-border px-3 py-2 text-xs text-red-600">
+          {error}
+        </div>
+      )}
+
+      <div role="listbox" aria-label="Viste database salvate" className="max-h-56 overflow-y-auto">
+        {loading && <div className="px-3 py-2 text-xs text-fg-muted">Carico viste...</div>}
+        {!loading && views.length === 0 && (
+          <div className="px-3 py-2 text-xs text-fg-muted">Nessuna vista salvata.</div>
+        )}
+        {!loading &&
+          views.map((view) => (
+            <button
+              key={view.id}
+              type="button"
+              role="option"
+              aria-selected={false}
+              onMouseDown={(event): void => {
+                event.preventDefault();
+                onSelect(view.id);
+              }}
+              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-fg hover:bg-bg"
+            >
+              <span className="min-w-0">
+                <span className="block truncate font-medium">{view.name}</span>
+                <span className="block truncate text-xs text-fg-muted">{view.layout}</span>
+              </span>
+              <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[11px] text-fg-muted">
+                DB
+              </span>
+            </button>
+          ))}
+      </div>
+
+      <div className="border-t border-border p-1">
+        <button
+          type="button"
+          onMouseDown={(event): void => {
+            event.preventDefault();
+            onCreateQuick();
+          }}
+          className="block w-full rounded px-2 py-1.5 text-left text-xs font-medium text-accent hover:bg-bg"
+        >
+          Nuova vista database
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/components/Editor/EditorExtensions.ts
+++ b/apps/desktop/src/components/Editor/EditorExtensions.ts
@@ -2,6 +2,7 @@ import type { Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from 'tiptap-markdown';
 import { CalloutExtension } from './extensions/Callout';
+import { DatabaseBlockExtension } from './extensions/DatabaseBlock';
 import { EmbedExtension } from './extensions/Embed';
 import { MathBlockExtension } from './extensions/MathBlock';
 import { MathInlineExtension } from './extensions/MathInline';
@@ -33,6 +34,7 @@ export type BuildExtensionsOptions = {
   createSlashRenderer?: () => SlashCommandRenderer;
   /** Forwarded to `SlashCommandExtension.configure(...)`. */
   onSlashRelationRequested?: SlashCommandOptions['onRelationRequested'];
+  onSlashDatabaseRequested?: SlashCommandOptions['onDatabaseRequested'];
   slashLatestRect?: SlashCommandOptions['latestRect'];
 };
 
@@ -72,6 +74,7 @@ export function buildEditorExtensions(options: BuildExtensionsOptions): Extensio
     // is a `div[data-callout]` selector, which doesn't overlap with
     // blockquote's tag matcher.
     CalloutExtension,
+    DatabaseBlockExtension,
     // Block-level embed (transclusion) node. Order matters relative to
     // Markdown (must come before, like every other custom node) so
     // tiptap-markdown picks up its `addStorage().markdown` hooks. Order
@@ -101,6 +104,9 @@ export function buildEditorExtensions(options: BuildExtensionsOptions): Extensio
         })),
       ...(options.onSlashRelationRequested !== undefined && {
         onRelationRequested: options.onSlashRelationRequested,
+      }),
+      ...(options.onSlashDatabaseRequested !== undefined && {
+        onDatabaseRequested: options.onSlashDatabaseRequested,
       }),
       ...(options.slashLatestRect !== undefined && { latestRect: options.slashLatestRect }),
     }),

--- a/apps/desktop/src/components/Editor/extensions/DatabaseBlock.test.ts
+++ b/apps/desktop/src/components/Editor/extensions/DatabaseBlock.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
+import { DatabaseBlockExtension } from './DatabaseBlock';
+
+function makeEditor(content = ''): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      DatabaseBlockExtension,
+      Markdown.configure({
+        html: false,
+        tightLists: true,
+        linkify: false,
+        breaks: true,
+      }),
+    ],
+    content,
+  });
+}
+
+describe('DatabaseBlockExtension', () => {
+  it('parses a saved database view block from markdown html syntax', () => {
+    const editor = makeEditor('<div data-ziba-db="projects"></div>');
+
+    const node = editor.state.doc.firstChild;
+    expect(node?.type.name).toBe('databaseBlock');
+    expect(node?.attrs.viewId).toBe('projects');
+
+    editor.destroy();
+  });
+
+  it('serializes inserted database blocks back to the compact html marker', () => {
+    const editor = makeEditor();
+
+    editor.commands.insertDatabaseBlock({ viewId: 'projects' });
+
+    const markdown =
+      (editor.storage.markdown as { getMarkdown?: () => string } | undefined)?.getMarkdown?.() ??
+      '';
+    expect(markdown.trim()).toBe('<div data-ziba-db="projects"></div>');
+
+    editor.destroy();
+  });
+});

--- a/apps/desktop/src/components/Editor/extensions/DatabaseBlock.ts
+++ b/apps/desktop/src/components/Editor/extensions/DatabaseBlock.ts
@@ -1,0 +1,147 @@
+import { mergeAttributes, Node } from '@tiptap/core';
+import type { MarkdownSerializerState } from '@tiptap/pm/markdown';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { DatabaseBlockNodeView } from './DatabaseBlockNodeView';
+
+const DATABASE_BLOCK_RE = /^<div\s+data-ziba-db=(?:"([^"]+)"|'([^']+)')\s*><\/div>$/i;
+
+type DatabaseBlockAttributes = {
+  viewId: string;
+};
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    databaseBlock: {
+      /** Insert a saved database view as an inline block inside the note body. */
+      insertDatabaseBlock: (attrs: { viewId: string }) => ReturnType;
+    };
+  }
+}
+
+function markerViewId(content: string): string | null {
+  const match = DATABASE_BLOCK_RE.exec(content.trim());
+  if (match === null) return null;
+  const viewId = (match[1] ?? match[2] ?? '').trim();
+  return viewId.length === 0 ? null : viewId;
+}
+
+export const DatabaseBlockExtension = Node.create({
+  name: 'databaseBlock',
+  group: 'block',
+  atom: true,
+  selectable: true,
+  defining: true,
+  content: '',
+  draggable: false,
+
+  addAttributes() {
+    return {
+      viewId: {
+        default: '',
+        parseHTML: (el): string => el.getAttribute('data-ziba-db') ?? '',
+        renderHTML: (attrs): Record<string, string> => ({
+          'data-ziba-db': String((attrs as DatabaseBlockAttributes).viewId ?? ''),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-ziba-db]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const viewId = String((node.attrs as DatabaseBlockAttributes).viewId ?? '');
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-ziba-db': viewId,
+        class: 'ziba-database-block',
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(DatabaseBlockNodeView);
+  },
+
+  addCommands() {
+    return {
+      insertDatabaseBlock:
+        ({ viewId }) =>
+        ({ chain }): boolean => {
+          const normalized = viewId.trim();
+          if (normalized.length === 0) return false;
+          return chain()
+            .focus()
+            .insertContent({ type: this.name, attrs: { viewId: normalized } })
+            .run();
+        },
+    };
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: ProseMirrorNode): void {
+          const viewId = String((node.attrs as DatabaseBlockAttributes).viewId ?? '');
+          state.write(`<div data-ziba-db="${escapeAttr(viewId)}"></div>\n`);
+          state.closeBlock(node);
+        },
+        parse: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          setup(md: any): void {
+            if (md.zibaDatabaseBlockRegistered === true) return;
+            md.zibaDatabaseBlockRegistered = true;
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            md.core.ruler.after('block', 'ziba_database_block', (state: any): boolean => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const tokens: any[] = state.tokens;
+
+              for (let i = tokens.length - 1; i >= 0; i--) {
+                const token = tokens[i];
+                if (token?.type === 'html_block') {
+                  const viewId = markerViewId(String(token.content ?? ''));
+                  if (viewId === null) continue;
+                  token.content = `<div data-ziba-db="${escapeAttr(viewId)}"></div>\n`;
+                  token.block = true;
+                  continue;
+                }
+
+                if (i > tokens.length - 3) continue;
+                const open = tokens[i];
+                const inline = tokens[i + 1];
+                const close = tokens[i + 2];
+
+                if (open?.type !== 'paragraph_open') continue;
+                if (inline?.type !== 'inline') continue;
+                if (close?.type !== 'paragraph_close') continue;
+
+                const viewId = markerViewId(String(inline.content ?? ''));
+                if (viewId === null) continue;
+
+                const Token = open.constructor;
+                const htmlToken = new Token('html_block', '', 0);
+                htmlToken.content = `<div data-ziba-db="${escapeAttr(viewId)}"></div>\n`;
+                htmlToken.block = true;
+                tokens.splice(i, 3, htmlToken);
+              }
+
+              return false;
+            });
+          },
+        },
+      },
+    };
+  },
+});
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/apps/desktop/src/components/Editor/extensions/DatabaseBlockNodeView.tsx
+++ b/apps/desktop/src/components/Editor/extensions/DatabaseBlockNodeView.tsx
@@ -1,0 +1,23 @@
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { DatabaseView } from '../../DatabaseView';
+
+export function DatabaseBlockNodeView(props: NodeViewProps): JSX.Element {
+  const viewId = String(props.node.attrs.viewId ?? '');
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      data-ziba-db={viewId}
+      contentEditable={false}
+      className="ziba-database-block my-5"
+    >
+      <DatabaseView
+        embedded
+        initialViewId={viewId}
+        onActiveViewChange={(nextViewId): void => {
+          if (nextViewId !== viewId) props.updateAttributes({ viewId: nextViewId });
+        }}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/apps/desktop/src/components/Editor/extensions/SlashCommand.test.ts
+++ b/apps/desktop/src/components/Editor/extensions/SlashCommand.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { runSlashCommand, slashMenuItems } from './SlashCommand';
+
+describe('SlashCommand database item', () => {
+  it('exposes a database slash entry searchable by saved view terms', () => {
+    expect(slashMenuItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'database',
+          title: 'Database',
+          keywords: expect.arrayContaining(['database', 'vista', 'view']),
+        }),
+      ]),
+    );
+  });
+
+  it('delegates the database slash entry to the database picker callback', () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    });
+    const onDatabaseRequested = vi.fn();
+    const range = { from: 1, to: 1 };
+    const position = { top: 12, left: 24, bottom: 36 };
+
+    runSlashCommand(editor, 'database', {
+      range,
+      position,
+      onDatabaseRequested,
+    });
+
+    expect(onDatabaseRequested).toHaveBeenCalledWith({ editor, range, position });
+    editor.destroy();
+  });
+});

--- a/apps/desktop/src/components/Editor/extensions/SlashCommand.ts
+++ b/apps/desktop/src/components/Editor/extensions/SlashCommand.ts
@@ -52,6 +52,16 @@ export type SlashCommandOptions = {
     position: { top: number; left: number; bottom: number };
   }) => void;
   /**
+   * Callback invoked when the user picks `/database`. The React editor
+   * opens a saved-view picker and inserts `databaseBlock` after the user
+   * selects or creates a view.
+   */
+  onDatabaseRequested?: (args: {
+    editor: Editor;
+    range: Range;
+    position: { top: number; left: number; bottom: number };
+  }) => void;
+  /**
    * The latest trigger-anchor rect, mutated by the renderer on every
    * suggestion `onStart` / `onUpdate`. We use it inside `command` to
    * anchor the relation popover at the slash position. A ref-like
@@ -195,6 +205,13 @@ const SLASH_MENU_ITEMS: ReadonlyArray<SlashMenuItem> = [
     icon: '↗',
   },
   {
+    id: 'database',
+    title: 'Database',
+    description: 'Inserisci una vista database salvata',
+    keywords: ['database', 'db', 'vista', 'view', 'tabella', 'board'],
+    icon: 'DB',
+  },
+  {
     id: 'math-block',
     title: 'Formula matematica',
     description: 'Blocco LaTeX `$$..$$` con rendering KaTeX',
@@ -270,13 +287,14 @@ function filterItems(query: string): SlashMenuItem[] {
  * is closed-set, so an unknown id is a programming error rather than a
  * user-facing failure.
  */
-function runSlashCommand(
+export function runSlashCommand(
   editor: Editor,
   id: string,
   context: {
     range: Range;
     position: { top: number; left: number; bottom: number };
     onRelationRequested?: SlashCommandOptions['onRelationRequested'];
+    onDatabaseRequested?: SlashCommandOptions['onDatabaseRequested'];
   },
 ): void {
   switch (id) {
@@ -336,6 +354,13 @@ function runSlashCommand(
       // Renderer handles the popover; the suggestion plugin already
       // deleted the slash + query above us, so we just delegate.
       context.onRelationRequested?.({
+        editor,
+        range: context.range,
+        position: context.position,
+      });
+      return;
+    case 'database':
+      context.onDatabaseRequested?.({
         editor,
         range: context.range,
         position: context.position,
@@ -435,6 +460,7 @@ export const SlashCommandExtension = Extension.create<SlashCommandOptions>({
             range,
             position: options.latestRect?.current ?? { top: 0, left: 0, bottom: 0 },
             onRelationRequested: options.onRelationRequested,
+            onDatabaseRequested: options.onDatabaseRequested,
           });
         },
 

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -4,6 +4,7 @@ import type { Editor as TiptapEditor } from '@tiptap/core';
 import type { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion';
 import type { Frontmatter } from '@ziba/core';
 import { Check, CheckCircle, NotePencil } from '@phosphor-icons/react';
+import type { DatabaseViewDefinition } from '../../../shared/ipc';
 import { useEditorStore } from '../../stores/editor';
 import { useUiStore } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
@@ -23,6 +24,7 @@ import {
   type WikilinkSuggestionRenderer,
 } from './extensions/WikilinkSuggestion';
 import { RelationPickerPopup } from './RelationPickerPopup';
+import { DatabaseBlockPickerPopup } from './DatabaseBlockPickerPopup';
 import { SlashMenuPopup } from './SlashMenuPopup';
 import { useResolvedWikilinks } from './useResolvedWikilinks';
 import { useWikilinkTypes } from './useWikilinkTypes';
@@ -80,6 +82,22 @@ const INITIAL_RELATION_PICKER_STATE: RelationPickerState = {
   suggestedKinds: [],
 };
 
+type DatabasePickerState = {
+  open: boolean;
+  position: { top: number; left: number; bottom: number };
+  views: DatabaseViewDefinition[];
+  loading: boolean;
+  error: string | null;
+};
+
+const INITIAL_DATABASE_PICKER_STATE: DatabasePickerState = {
+  open: false,
+  position: { top: 0, left: 0, bottom: 0 },
+  views: [],
+  loading: false,
+  error: null,
+};
+
 function basenameTitle(path: string): string {
   const last = path.split('/').pop() ?? path;
   return last.replace(/\.md$/i, '');
@@ -98,6 +116,10 @@ function renamedPath(path: string, title: string): string {
   const parts = path.split('/');
   parts[parts.length - 1] = titleToFilename(title);
   return parts.join('/');
+}
+
+function createInlineDatabaseViewId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `inline-db-${Date.now().toString(36)}`;
 }
 
 /**
@@ -165,6 +187,9 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
 
   const [relationPicker, setRelationPicker] = useState<RelationPickerState>(
     INITIAL_RELATION_PICKER_STATE,
+  );
+  const [databasePicker, setDatabasePicker] = useState<DatabasePickerState>(
+    INITIAL_DATABASE_PICKER_STATE,
   );
 
   // Mutable ref shared with the SlashCommand extension so the relation
@@ -353,9 +378,48 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
     [suggestedRelationKinds],
   );
 
+  const handleDatabaseRequested = useCallback<
+    NonNullable<BuildExtensionsOptions['onSlashDatabaseRequested']>
+  >(({ position }) => {
+    setDatabasePicker({
+      open: true,
+      position,
+      views: [],
+      loading: true,
+      error: null,
+    });
+    void ipc
+      .listDatabaseViews()
+      .then((file) => {
+        setDatabasePicker((prev) =>
+          prev.open
+            ? {
+                ...prev,
+                views: file.views,
+                loading: false,
+                error: null,
+              }
+            : prev,
+        );
+      })
+      .catch((err: unknown) => {
+        setDatabasePicker((prev) =>
+          prev.open
+            ? {
+                ...prev,
+                loading: false,
+                error: ipcErrorMessage(err),
+              }
+            : prev,
+        );
+      });
+  }, []);
+
   const handleRelationRequestedRef = useRef(handleRelationRequested);
+  const handleDatabaseRequestedRef = useRef(handleDatabaseRequested);
   useEffect(() => {
     handleRelationRequestedRef.current = handleRelationRequested;
+    handleDatabaseRequestedRef.current = handleDatabaseRequested;
   });
 
   // Build extensions once. The closure captures `createSuggestionRenderer`
@@ -367,6 +431,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
         createSuggestionRenderer,
         createSlashRenderer,
         onSlashRelationRequested: (args) => handleRelationRequestedRef.current(args),
+        onSlashDatabaseRequested: (args) => handleDatabaseRequestedRef.current(args),
         slashLatestRect,
       }),
     [createSuggestionRenderer, createSlashRenderer],
@@ -611,6 +676,42 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
     }
   };
 
+  const handleInsertDatabaseBlock = useCallback(
+    (viewId: string): void => {
+      if (editor === null) return;
+      editor.commands.insertDatabaseBlock({ viewId });
+      setDatabasePicker(INITIAL_DATABASE_PICKER_STATE);
+    },
+    [editor],
+  );
+
+  const handleCreateInlineDatabaseView = useCallback(async (): Promise<void> => {
+    setDatabasePicker((prev) => ({ ...prev, loading: true, error: null }));
+    const timestamp = Date.now();
+    const view: DatabaseViewDefinition = {
+      id: createInlineDatabaseViewId(),
+      name: `Vista inline ${Math.max(1, databasePicker.views.length + 1)}`,
+      layout: 'table',
+      query: { filters: [], limit: 1000 },
+      selectedType: null,
+      columns: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    try {
+      const saved = await ipc.upsertDatabaseView({ view });
+      if (editor !== null) editor.commands.insertDatabaseBlock({ viewId: saved.id });
+      setDatabasePicker(INITIAL_DATABASE_PICKER_STATE);
+    } catch (err: unknown) {
+      setDatabasePicker((prev) => ({
+        ...prev,
+        loading: false,
+        error: ipcErrorMessage(err),
+      }));
+    }
+  }, [databasePicker.views.length, editor]);
+
   if (currentNote === null) {
     const showStarterAction = notes.length === 0;
 
@@ -839,6 +940,20 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
           onHover={(idx): void => {
             setSlash((prev) => ({ ...prev, selectedIndex: idx }));
           }}
+        />
+      )}
+
+      {databasePicker.open && (
+        <DatabaseBlockPickerPopup
+          position={databasePicker.position}
+          views={databasePicker.views}
+          loading={databasePicker.loading}
+          error={databasePicker.error}
+          onSelect={handleInsertDatabaseBlock}
+          onCreateQuick={(): void => {
+            void handleCreateInlineDatabaseView();
+          }}
+          onCancel={(): void => setDatabasePicker(INITIAL_DATABASE_PICKER_STATE)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Adds the Tiptap `DatabaseBlockExtension` for `<div data-ziba-db="view-id"></div>` round-trips.
- Adds `/database` with a saved-view picker and quick view creation.
- Reuses the Database surface inline inside notes, including saved view tabs, filters, sort, columns, layout switching, board/calendar/gallery rendering, and table frontmatter cell edits.

## Stack
- Stacked on #14 / `codex/siyuan-attribute-views`.
- This is PR 3 of the SiYuan-like roadmap: database block inline.

## Test plan
- `pnpm --filter ziba-desktop test -- src/components/Editor/extensions/DatabaseBlock.test.ts src/components/Editor/extensions/SlashCommand.test.ts src/components/Editor/DatabaseBlockPickerPopup.test.tsx src/components/DatabaseView/index.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 606 tests passed
- `pnpm build`
