### PR TITLE
feat: polish shared panel controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 - Blocco database inline per l'editor (`<div data-ziba-db="view-id"></div>`)
   con picker `/database`, creazione rapida di viste e celle frontmatter
   modificabili nella tabella.
+- Controlli UI condivisi per tab segmentati e icon button, applicati a
+  pannello laterale, DatabaseView e toolbar del grafo.
 - Controllo "Righe" nella DatabaseView, collegato a `DatabaseQuery.limit`.
 
 ## [1.0.1] - 2026-05-10

--- a/apps/desktop/src/components/BacklinksPanel/ReferencesPanel.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/ReferencesPanel.tsx
@@ -12,6 +12,7 @@ import { ipc } from '../../lib/ipc';
 import { navigateToNote } from '../../lib/navigate';
 import { BACKLINKS_REFETCH_MS } from '../../lib/timings';
 import { SnippetText } from '../SearchPalette/SnippetText';
+import { IconButton } from '../ui/IconButton';
 
 type Props = {
   currentPath: NotePath | null;
@@ -214,17 +215,13 @@ export function ReferencesPanel({ currentPath, onLoadingChange }: Props): JSX.El
             <option value="title-asc">{SORT_LABELS['title-asc']}</option>
             <option value="title-desc">{SORT_LABELS['title-desc']}</option>
           </select>
-          <button
-            type="button"
+          <IconButton
             onClick={(): void => {
               void fetchReferences();
             }}
-            className="flex h-7 w-7 items-center justify-center rounded border border-border text-fg-muted hover:bg-bg-muted hover:text-fg"
-            title="Aggiorna riferimenti"
-            aria-label="Aggiorna riferimenti"
-          >
-            <ArrowCounterClockwise aria-hidden className="h-3.5 w-3.5" />
-          </button>
+            label="Aggiorna riferimenti"
+            icon={<ArrowCounterClockwise aria-hidden className="h-3.5 w-3.5" />}
+          />
         </div>
         <div className="mt-1 flex items-center justify-between px-0.5 text-[10px] uppercase tracking-wide text-fg-muted">
           <span>Riferimenti</span>

--- a/apps/desktop/src/components/BacklinksPanel/index.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/index.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from '../../stores/editor';
 import { useUiStore, type RightPaneTab } from '../../stores/ui';
 import { MiniGraph } from '../MiniGraph';
 import { ObjectPanel } from '../ObjectPanel';
+import { SegmentedControl } from '../ui/SegmentedControl';
 import { ReferencesPanel } from './ReferencesPanel';
 
 type TabSpec = {
@@ -58,31 +59,12 @@ export function BacklinksPanel(): JSX.Element {
   return (
     <aside className="flex h-full flex-col overflow-hidden bg-bg-subtle">
       <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
-        <div role="tablist" aria-label="Pannello laterale" className="flex items-center gap-2">
-          {tabs.map((tab) => {
-            const active = tab.id === activeTab;
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                aria-controls={`right-pane-panel-${tab.id}`}
-                id={`right-pane-tab-${tab.id}`}
-                onClick={(): void => {
-                  setRightPaneTab(tab.id);
-                }}
-                className={
-                  active
-                    ? 'rounded px-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-fg'
-                    : 'rounded px-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-fg-muted hover:text-fg-subtle'
-                }
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
+        <SegmentedControl
+          ariaLabel="Pannello laterale"
+          value={activeTab}
+          items={tabs}
+          onChange={setRightPaneTab}
+        />
         {activeLoading && (
           <span className="text-[10px] uppercase tracking-wide text-fg-muted">…</span>
         )}

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -17,6 +17,7 @@ import { useUiStore, type DatabaseViewMode } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { useTagsStore } from '../../stores/tags';
 import { toast } from '../../stores/toast';
+import { SegmentedControl } from '../ui/SegmentedControl';
 import { TypeFilterDropdown } from './TypeFilterDropdown';
 import { BoardView } from './BoardView';
 import { CalendarView } from './CalendarView';
@@ -858,28 +859,12 @@ function ViewModeTabs({
     { id: 'gallery', label: 'Galleria' },
   ];
   return (
-    <div role="tablist" aria-label="Vista database" className="ml-auto flex items-center gap-0.5">
-      {TABS.map((t) => {
-        const active = t.id === current;
-        return (
-          <button
-            key={t.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={(): void => {
-              onChange(t.id);
-            }}
-            className={
-              active
-                ? 'rounded bg-bg-muted px-2 py-0.5 text-xs font-medium text-fg'
-                : 'rounded px-2 py-0.5 text-xs font-medium text-fg-subtle hover:bg-bg-muted hover:text-fg'
-            }
-          >
-            {t.label}
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedControl
+      ariaLabel="Vista database"
+      value={current}
+      items={TABS}
+      onChange={onChange}
+      className="ml-auto"
+    />
   );
 }

--- a/apps/desktop/src/components/GlobalGraph/index.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.test.tsx
@@ -64,15 +64,15 @@ describe('<GlobalGraph>', () => {
       expect(screen.getByText(/4 nodi/)).toBeInTheDocument();
     });
 
-    expect(screen.getByRole('button', { name: 'Globale' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('tab', { name: 'Globale' })).toHaveAttribute('aria-pressed', 'true');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Locale' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Locale' }));
 
     await waitFor(() => {
       expect(screen.getByText('Grafo locale')).toBeInTheDocument();
       expect(screen.getByText(/Root: Beta/)).toBeInTheDocument();
       expect(screen.getByText(/3 nodi/)).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: 'Locale' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('tab', { name: 'Locale' })).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/apps/desktop/src/components/GlobalGraph/index.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.tsx
@@ -34,6 +34,8 @@ import { useTagsStore } from '../../stores/tags';
 import { useVaultStore } from '../../stores/vault';
 import { useGraphSettingsStore } from '../../stores/graph';
 import { useEditorStore } from '../../stores/editor';
+import { IconButton } from '../ui/IconButton';
+import { SegmentedControl } from '../ui/SegmentedControl';
 import { GraphSettingsPanel, type GraphPreset } from './GraphSettingsPanel';
 import type { GraphGroupRule } from '../../lib/graph-settings';
 import { graphGroupQueryMatchesNode } from '../../lib/graph-groups';
@@ -60,6 +62,11 @@ const NODE_R_MAX = 18;
 const ZOOM_STEP = 1.25;
 
 type GraphScope = 'global' | 'local';
+
+const GRAPH_SCOPE_ITEMS: ReadonlyArray<{ id: GraphScope; label: string }> = [
+  { id: 'global', label: 'Globale' },
+  { id: 'local', label: 'Locale' },
+];
 
 type LoadState =
   | { kind: 'idle' }
@@ -750,24 +757,13 @@ export function GlobalGraph(): JSX.Element {
           </div>
 
           <div className="pointer-events-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
-            <div className="flex h-9 items-center overflow-hidden rounded-lg border border-[#3a3a3f] bg-[#242426]/86 shadow-lg shadow-black/20 backdrop-blur">
-              <button
-                type="button"
-                onClick={(): void => handleScopeChange('global')}
-                className={graphScopeButtonClass(graphScope === 'global')}
-                aria-pressed={graphScope === 'global'}
-              >
-                Globale
-              </button>
-              <button
-                type="button"
-                onClick={(): void => handleScopeChange('local')}
-                className={graphScopeButtonClass(graphScope === 'local')}
-                aria-pressed={graphScope === 'local'}
-              >
-                Locale
-              </button>
-            </div>
+            <SegmentedControl
+              ariaLabel="Ambito grafo"
+              value={graphScope}
+              items={GRAPH_SCOPE_ITEMS}
+              onChange={handleScopeChange}
+              variant="graph"
+            />
             {searchOpen && (
               <label className="flex h-9 w-64 max-w-[38vw] items-center gap-2 rounded-lg border border-[#3a3a3f] bg-[#242426]/86 px-2.5 text-[#b7b7bd] shadow-lg shadow-black/20 backdrop-blur transition focus-within:border-[#5a5a62] focus-within:ring-2 focus-within:ring-white/10">
                 <MagnifyingGlass size={16} aria-hidden="true" />
@@ -784,72 +780,57 @@ export function GlobalGraph(): JSX.Element {
                 />
               </label>
             )}
-            <div className="flex h-9 items-center overflow-hidden rounded-lg border border-[#3a3a3f] bg-[#242426]/86 shadow-lg shadow-black/20 backdrop-blur">
-              <button
-                type="button"
+            <div className="flex h-9 items-center divide-x divide-[#3a3a3f] overflow-hidden rounded-lg border border-[#3a3a3f] bg-[#242426]/86 shadow-lg shadow-black/20 backdrop-blur">
+              <IconButton
                 onClick={(): void => setSearchOpen((open) => !open)}
-                className={graphToolbarButtonClass}
+                label={searchOpen ? 'Nascondi ricerca grafo' : 'Mostra ricerca grafo'}
                 title="Cerca"
-                aria-label={searchOpen ? 'Nascondi ricerca grafo' : 'Mostra ricerca grafo'}
-              >
-                <MagnifyingGlass size={15} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                pressed={searchOpen}
+                variant="graph"
+                icon={<MagnifyingGlass size={15} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={(): void => {
                   void fetchGraph();
                 }}
-                className={`${graphToolbarButtonClass} border-l border-[#3a3a3f]`}
-                title="Aggiorna grafo"
-                aria-label="Aggiorna grafo"
-              >
-                <ArrowCounterClockwise size={15} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                label="Aggiorna grafo"
+                variant="graph"
+                icon={<ArrowCounterClockwise size={15} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={(): void => handleZoom(1 / ZOOM_STEP)}
-                className={`${graphToolbarButtonClass} border-l border-[#3a3a3f]`}
+                label="Diminuisci zoom"
                 title="Zoom out"
-                aria-label="Diminuisci zoom"
-              >
-                <Minus size={15} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                variant="graph"
+                icon={<Minus size={15} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={(): void => handleZoom(ZOOM_STEP)}
-                className={graphToolbarButtonClass}
+                label="Aumenta zoom"
                 title="Zoom in"
-                aria-label="Aumenta zoom"
-              >
-                <Plus size={15} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                variant="graph"
+                icon={<Plus size={15} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={fitToScreen}
-                className={`${graphToolbarButtonClass} border-l border-[#3a3a3f]`}
-                title="Adatta alla finestra"
-                aria-label="Adatta alla finestra"
-              >
-                <CornersOut size={16} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                label="Adatta alla finestra"
+                variant="graph"
+                icon={<CornersOut size={16} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={(): void => setSurfaceFullscreen((open) => !open)}
-                className={`${graphToolbarButtonClass} border-l border-[#3a3a3f]`}
-                title={surfaceFullscreen ? 'Riduci grafo' : 'Espandi grafo'}
-                aria-label={surfaceFullscreen ? 'Riduci grafo' : 'Espandi grafo'}
-              >
-                <ArrowSquareOut size={16} aria-hidden="true" />
-              </button>
-              <button
-                type="button"
+                label={surfaceFullscreen ? 'Riduci grafo' : 'Espandi grafo'}
+                pressed={surfaceFullscreen}
+                variant="graph"
+                icon={<ArrowSquareOut size={16} aria-hidden="true" />}
+              />
+              <IconButton
                 onClick={(): void => setSettingsOpen(true)}
-                className={`${graphToolbarButtonClass} border-l border-[#3a3a3f]`}
+                label="Apri controlli grafo"
                 title="Controlli grafo"
-                aria-label="Apri controlli grafo"
-              >
-                <Gear size={16} aria-hidden="true" />
-              </button>
+                variant="graph"
+                icon={<Gear size={16} aria-hidden="true" />}
+              />
             </div>
           </div>
         </div>
@@ -1001,18 +982,6 @@ function groupColorForNode(
     if (graphGroupQueryMatchesNode(node, group.query)) return group.color;
   }
   return null;
-}
-
-const graphToolbarButtonClass =
-  'grid h-full min-w-9 place-items-center px-2 text-[#b7b7bd] transition hover:bg-[#303034] hover:text-[#f4f4f5] focus-visible:outline focus-visible:outline-2 focus-visible:outline-white/25 active:bg-[#343438]';
-
-function graphScopeButtonClass(active: boolean): string {
-  return [
-    'h-full px-3 text-[12px] font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-white/25',
-    active
-      ? 'bg-[#d7d7da] text-[#1d1d1f]'
-      : 'text-[#b7b7bd] hover:bg-[#303034] hover:text-[#f4f4f5]',
-  ].join(' ');
 }
 
 function GraphStatus({

--- a/apps/desktop/src/components/ui/Controls.test.tsx
+++ b/apps/desktop/src/components/ui/Controls.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Gear } from '@phosphor-icons/react';
+import { IconButton } from './IconButton';
+import { SegmentedControl } from './SegmentedControl';
+
+describe('shared panel controls', () => {
+  it('renders a segmented tab control and reports value changes', () => {
+    const onChange = vi.fn();
+
+    render(
+      <SegmentedControl
+        ariaLabel="Pannello laterale"
+        value="references"
+        items={[
+          { id: 'references', label: 'Riferimenti' },
+          { id: 'graph', label: 'Grafo' },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Grafo' }));
+
+    expect(onChange).toHaveBeenCalledWith('graph');
+  });
+
+  it('renders an icon-only button with accessible label and pressed state', () => {
+    const onClick = vi.fn();
+
+    render(
+      <IconButton
+        label="Apri controlli"
+        pressed
+        onClick={onClick}
+        icon={<Gear size={16} aria-hidden="true" />}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Apri controlli' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/components/ui/IconButton.tsx
+++ b/apps/desktop/src/components/ui/IconButton.tsx
@@ -1,0 +1,48 @@
+import clsx from 'clsx';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+type IconButtonVariant = 'panel' | 'graph';
+
+export type IconButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> & {
+  label: string;
+  icon: ReactNode;
+  variant?: IconButtonVariant;
+  pressed?: boolean;
+};
+
+const BASE =
+  'inline-flex shrink-0 items-center justify-center transition disabled:cursor-not-allowed disabled:opacity-50';
+
+const VARIANT_CLASS: Record<IconButtonVariant, string> = {
+  panel:
+    'h-7 w-7 rounded border border-border bg-bg-subtle text-fg-muted hover:bg-bg-muted hover:text-fg',
+  graph: 'h-9 w-9 text-[#c9c9cf] hover:bg-white/8 hover:text-[#f4f4f5]',
+};
+
+export function IconButton({
+  label,
+  icon,
+  variant = 'panel',
+  pressed,
+  className,
+  title,
+  ...buttonProps
+}: IconButtonProps): JSX.Element {
+  return (
+    <button
+      {...buttonProps}
+      type={buttonProps.type ?? 'button'}
+      aria-label={label}
+      title={title ?? label}
+      {...(pressed !== undefined && { 'aria-pressed': pressed })}
+      className={clsx(BASE, VARIANT_CLASS[variant], pressed && pressedClass(variant), className)}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function pressedClass(variant: IconButtonVariant): string {
+  if (variant === 'graph') return 'bg-white/10 text-[#f4f4f5]';
+  return 'bg-bg-muted text-fg';
+}

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,69 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+type SegmentedVariant = 'panel' | 'graph';
+
+export type SegmentedControlItem<T extends string> = {
+  id: T;
+  label: string;
+  icon?: ReactNode;
+};
+
+export type SegmentedControlProps<T extends string> = {
+  ariaLabel: string;
+  value: T;
+  items: readonly SegmentedControlItem<T>[];
+  onChange(value: T): void;
+  variant?: SegmentedVariant;
+  className?: string;
+};
+
+export function SegmentedControl<T extends string>({
+  ariaLabel,
+  value,
+  items,
+  onChange,
+  variant = 'panel',
+  className,
+}: SegmentedControlProps<T>): JSX.Element {
+  return (
+    <div role="tablist" aria-label={ariaLabel} className={clsx(containerClass(variant), className)}>
+      {items.map((item) => {
+        const active = item.id === value;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-pressed={active}
+            onClick={(): void => onChange(item.id)}
+            className={clsx(itemClass(variant), active && activeItemClass(variant))}
+          >
+            {item.icon !== undefined && <span aria-hidden="true">{item.icon}</span>}
+            <span className="truncate">{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function containerClass(variant: SegmentedVariant): string {
+  if (variant === 'graph') {
+    return 'inline-flex h-9 items-center overflow-hidden rounded-lg border border-[#3a3a3f] bg-[#242426]/86 shadow-lg shadow-black/20 backdrop-blur';
+  }
+  return 'inline-flex min-w-0 items-center gap-0.5 rounded-md border border-border bg-bg px-0.5 py-0.5';
+}
+
+function itemClass(variant: SegmentedVariant): string {
+  if (variant === 'graph') {
+    return 'inline-flex h-full items-center gap-1 px-3 text-[12px] font-medium text-[#a9a9af] transition hover:bg-white/8 hover:text-[#f4f4f5]';
+  }
+  return 'inline-flex min-w-0 items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold text-fg-muted transition hover:bg-bg-muted hover:text-fg';
+}
+
+function activeItemClass(variant: SegmentedVariant): string {
+  if (variant === 'graph') return 'bg-white/10 text-[#f4f4f5]';
+  return 'bg-bg-muted text-fg';
+}


### PR DESCRIPTION
## Summary
- Adds shared `IconButton` and `SegmentedControl` UI controls for compact panel/tool surfaces.
- Applies the shared segmented control to the right pane and DatabaseView layout switch.
- Applies the shared graph icon-button/segmented-control variants to the graph toolbar while preserving behavior.

## Stack
- Stacked on #15 / `codex/siyuan-database-block`.
- This is PR 4 of the SiYuan-like roadmap: shell/panel polish.

## Test plan
- `pnpm --filter ziba-desktop test -- src/components/ui/Controls.test.tsx src/components/BacklinksPanel/index.test.tsx src/components/DatabaseView/index.test.tsx src/components/GlobalGraph/index.test.tsx src/components/GlobalGraph/keyboard.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 608 tests passed
- `pnpm build`
