### PR TITLE
fix: contain sidebar scroll and dark theme contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
   pannello laterale, DatabaseView e toolbar del grafo.
 - Controllo "Righe" nella DatabaseView, collegato a `DatabaseQuery.limit`.
 
+### Fixed
+
+- La sidebar non trascina piu' la finestra verso il basso: file tree,
+  strumenti e sezioni Organizza scrollano in regioni interne.
+- I temi scuri applicano anche la classe Tailwind `.dark`, quindi le utility
+  `dark:` tornano coerenti con i token `data-theme` ed evitano stati
+  bianco-su-bianco o nero-su-nero.
+
 ## [1.0.1] - 2026-05-10
 
 ### Phase 2 followups

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ Current state:
 
 - Local vaults backed by `.md` files and YAML frontmatter.
 - Electron desktop app with React, Tiptap, Tailwind, Zustand, and SQLite.
-- Full-text search, tags, backlinks, file tree, database views, and graph views.
+- Full-text search, tags, backlinks, mentions, file tree, database views, and graph views.
 - Typed objects and semantic relations via `.ziba/schema/*.yml`.
+- Saved database views in `.ziba/database-views.json`, including table, board,
+  calendar, and gallery layouts.
+- Inline database blocks that render saved views inside notes.
 - Extensive unit and component coverage across the core and desktop app.
 - MIT licensed and open to contributors.
 
@@ -118,8 +121,9 @@ Current state:
 - Frontmatter property editor.
 - Typed property indexing for fast queries.
 - Tags from both frontmatter and inline `#tag` syntax.
-- Database table view with typed filters, sorting, grouping, and column picking.
-- Board and calendar views for property-driven workflows.
+- Saved database views with typed filters, sorting, grouping, limits, and column picking.
+- Table, board, calendar, and gallery layouts for property-driven workflows.
+- Inline database blocks via `/database`, backed by saved views in the vault.
 
 ### Typed objects and semantic relations
 
@@ -168,9 +172,12 @@ editing your files however you want.
 
 - Local mini-graph around the current note.
 - Global graph with pan, zoom, search, and node selection.
-- Obsidian-style visual polish with dark canvas, subtle links, and hover focus.
+- SiYuan/Obsidian-style global and local graph modes with compact controls,
+  search, refresh, fit, fullscreen, and focusable local neighborhoods.
 - Constellation mode with type clusters, color groups, relation-kind filters,
   and graph settings.
+- Right-side References panel with backlinks, plain-text mentions, counts,
+  filters, sorting, and inline context previews.
 
 ### Desktop workflows
 
@@ -251,6 +258,7 @@ my-vault/
 |   `-- the-hobbit.md
 `-- .ziba/
     |-- index.db
+    |-- database-views.json
     `-- schema/
         |-- note.yml
         |-- person.yml
@@ -263,6 +271,7 @@ my-vault/
 
 - `.md` files are the durable user data.
 - `.ziba/index.db` is a rebuildable SQLite cache.
+- `.ziba/database-views.json` stores saved database view definitions.
 - `.ziba/schema/*.yml` describes optional object types and relation kinds.
 
 See [docs/vault-format.md](docs/vault-format.md) for the full vault format,
@@ -310,10 +319,12 @@ Read [docs/architecture.md](docs/architecture.md) for the deeper walkthrough.
 Recently shipped:
 
 - Local vault, markdown editor, wikilinks, backlinks, tags, full-text search.
-- Database table, board, and calendar views.
-- Global graph and local mini-graph.
+- References panel with backlinks, mentions, filters, sorting, and previews.
+- Saved database table, board, calendar, and gallery views.
+- Inline database blocks inside notes.
+- Global/local graph modes and local mini-graph.
 - Typed objects, schemas, relation table, object panel, and type sidebar.
-- Obsidian-style graph polish, graph settings, and improved file actions.
+- SiYuan/Obsidian-style graph polish, graph settings, and compact panel controls.
 
 Next directions:
 

--- a/apps/desktop/src/components/Layout.tsx
+++ b/apps/desktop/src/components/Layout.tsx
@@ -20,16 +20,16 @@ export function Layout(): JSX.Element {
   const pickAndOpenVault = useVaultStore((s) => s.pickAndOpenVault);
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
       <TopBar
         onChangeVault={(): void => {
           void pickAndOpenVault();
         }}
       />
 
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         <Ribbon />
-        <div style={{ width: `${sidebarWidth}px` }} className="shrink-0">
+        <div style={{ width: `${sidebarWidth}px` }} className="min-h-0 shrink-0 overflow-hidden">
           <Sidebar />
         </div>
         <Resizer
@@ -41,7 +41,7 @@ export function Layout(): JSX.Element {
 
         {mainView === 'editor' && (
           <>
-            <div className="flex min-w-0 flex-1">
+            <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
               <Editor />
             </div>
 
@@ -55,7 +55,7 @@ export function Layout(): JSX.Element {
                 />
                 <div
                   style={{ width: `${backlinksWidth}px` }}
-                  className="shrink-0 border-l border-border"
+                  className="min-h-0 shrink-0 overflow-hidden border-l border-border"
                 >
                   <BacklinksPanel />
                 </div>
@@ -65,13 +65,13 @@ export function Layout(): JSX.Element {
         )}
 
         {mainView === 'database' && (
-          <div className="flex min-w-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
             <DatabaseView />
           </div>
         )}
 
         {mainView === 'graph' && (
-          <div className="flex min-w-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
             <GlobalGraph />
           </div>
         )}

--- a/apps/desktop/src/components/Ribbon.tsx
+++ b/apps/desktop/src/components/Ribbon.tsx
@@ -26,7 +26,7 @@ export function Ribbon(): JSX.Element {
   return (
     <nav
       aria-label="Navigazione principale"
-      className="flex h-full w-12 shrink-0 flex-col items-center border-r border-border bg-bg-subtle/95 py-2"
+      className="flex h-full min-h-0 w-12 shrink-0 flex-col items-center overflow-hidden border-r border-border bg-bg-subtle/95 py-2"
     >
       <RibbonButton
         label="File"

--- a/apps/desktop/src/components/Sidebar/index.test.tsx
+++ b/apps/desktop/src/components/Sidebar/index.test.tsx
@@ -108,4 +108,17 @@ describe('Sidebar navigation', () => {
     expect(screen.getByRole('button', { name: 'Cerca note' })).toBeInTheDocument();
     expect(screen.queryByText('Cerca note...')).toBeNull();
   });
+
+  it('contains sidebar scrolling to internal regions', () => {
+    render(<Sidebar />);
+
+    const sidebar = screen.getByLabelText('Esplora vault');
+    expect(sidebar).toHaveClass('min-h-0', 'overflow-hidden');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Organizza' }));
+    const tools = screen.getByText('Strumenti').closest('div')?.parentElement?.parentElement;
+
+    expect(tools).toHaveClass('max-h-[48%]', 'overflow-hidden');
+    expect(screen.getByLabelText('Tipi').parentElement).toHaveClass('overflow-y-auto');
+  });
 });

--- a/apps/desktop/src/components/Sidebar/index.tsx
+++ b/apps/desktop/src/components/Sidebar/index.tsx
@@ -484,7 +484,7 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
 
   return (
     <aside
-      className="flex h-full flex-col overflow-hidden border-r border-border bg-bg-subtle"
+      className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-bg-subtle"
       tabIndex={0}
       onKeyDown={handleKeyDown}
       aria-label="Esplora vault"
@@ -541,7 +541,7 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
         </div>
       )}
 
-      <div className="relative flex-1 overflow-y-auto border-t border-border/70 pt-2">
+      <div className="relative min-h-[7rem] flex-1 overflow-y-auto border-t border-border/70 pt-2">
         <FileTree
           rows={flatRows}
           currentPath={currentPath}
@@ -566,44 +566,46 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
         )}
       </div>
 
-      <div className="shrink-0 border-t border-border bg-bg-subtle">
-        <div className="px-3 pt-2 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
-          Strumenti
-        </div>
-        <div className="space-y-0.5 px-2 py-2">
-          <ToolButton
-            label="Grafo"
-            active={mainView === 'graph'}
-            icon={<Graph size={16} aria-hidden="true" />}
-            onClick={(): void => setMainView('graph')}
-          />
-          <ToolButton
-            label="Database"
-            active={mainView === 'database'}
-            icon={<Database size={16} aria-hidden="true" />}
-            onClick={(): void => setMainView('database')}
-          />
-          <ToolButton
-            label="Organizza"
-            active={organizeOpen}
-            icon={<SlidersHorizontal size={16} aria-hidden="true" />}
-            trailing={
-              organizeOpen ? (
-                <CaretDown size={13} aria-hidden="true" />
-              ) : (
-                <CaretRight size={13} aria-hidden="true" />
-              )
-            }
-            onClick={(): void => setOrganizeOpen((open) => !open)}
-          />
+      <div className="flex max-h-[48%] shrink-0 flex-col overflow-hidden border-t border-border bg-bg-subtle">
+        <div className="shrink-0">
+          <div className="px-3 pt-2 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
+            Strumenti
+          </div>
+          <div className="space-y-0.5 px-2 py-2">
+            <ToolButton
+              label="Grafo"
+              active={mainView === 'graph'}
+              icon={<Graph size={16} aria-hidden="true" />}
+              onClick={(): void => setMainView('graph')}
+            />
+            <ToolButton
+              label="Database"
+              active={mainView === 'database'}
+              icon={<Database size={16} aria-hidden="true" />}
+              onClick={(): void => setMainView('database')}
+            />
+            <ToolButton
+              label="Organizza"
+              active={organizeOpen}
+              icon={<SlidersHorizontal size={16} aria-hidden="true" />}
+              trailing={
+                organizeOpen ? (
+                  <CaretDown size={13} aria-hidden="true" />
+                ) : (
+                  <CaretRight size={13} aria-hidden="true" />
+                )
+              }
+              onClick={(): void => setOrganizeOpen((open) => !open)}
+            />
+          </div>
         </div>
         {organizeOpen && (
-          <div className="max-h-[38vh] overflow-y-auto border-t border-border bg-bg">
+          <div className="min-h-0 flex-1 overflow-y-auto border-t border-border bg-bg">
             <TypesSection />
             <TagsSection />
           </div>
         )}
-        <div className="border-t border-border px-2 py-2">
+        <div className="shrink-0 border-t border-border px-2 py-2">
           <ToolButton
             label="Impostazioni"
             active={false}

--- a/apps/desktop/src/lib/theme.test.ts
+++ b/apps/desktop/src/lib/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyTheme, DEFAULT_THEME_ID, isThemeId, THEME_IDS } from './theme';
+import { applyTheme, DEFAULT_THEME_ID, isDarkTheme, isThemeId, THEME_IDS } from './theme';
 
 describe('theme registry', () => {
   it('exposes the supported theme ids with ziba-light as the default', () => {
@@ -20,10 +20,23 @@ describe('theme registry', () => {
     expect(isThemeId(null)).toBe(false);
   });
 
-  it('applies themes through documentElement.dataset.theme', () => {
+  it('classifies themes that need Tailwind dark variants', () => {
+    expect(isDarkTheme('ziba-light')).toBe(false);
+    expect(isDarkTheme('warm-paper')).toBe(false);
+    expect(isDarkTheme('obsidian-dark')).toBe(true);
+    expect(isDarkTheme('graphite')).toBe(true);
+    expect(isDarkTheme('high-contrast')).toBe(true);
+  });
+
+  it('applies themes through documentElement.dataset.theme and .dark', () => {
     applyTheme('graphite');
 
     expect(document.documentElement.dataset.theme).toBe('graphite');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    applyTheme('ziba-light');
+
+    expect(document.documentElement.dataset.theme).toBe('ziba-light');
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -10,6 +10,8 @@ export type ThemeId = (typeof THEME_IDS)[number];
 
 export const DEFAULT_THEME_ID: ThemeId = 'ziba-light';
 
+export const DARK_THEME_IDS = ['obsidian-dark', 'graphite', 'high-contrast'] as const;
+
 export type ThemeDefinition = {
   id: ThemeId;
   label: string;
@@ -27,8 +29,12 @@ export function isThemeId(value: unknown): value is ThemeId {
   return typeof value === 'string' && (THEME_IDS as readonly string[]).includes(value);
 }
 
+export function isDarkTheme(themeId: ThemeId): boolean {
+  return (DARK_THEME_IDS as readonly ThemeId[]).includes(themeId);
+}
+
 export function applyTheme(themeId: ThemeId): void {
   if (typeof document === 'undefined') return;
   document.documentElement.dataset.theme = themeId;
-  document.documentElement.classList.remove('dark');
+  document.documentElement.classList.toggle('dark', isDarkTheme(themeId));
 }

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -100,6 +100,8 @@ html,
 body,
 #root {
   height: 100%;
+  width: 100%;
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary\n- Contain app/sidebar scrolling so the file tree, dock, and Organizza sections stay within the window instead of pushing the sidebar downward.\n- Apply Tailwind's .dark class for dark themes so dark: utilities match the active data-theme.\n- Update README and changelog with the current graph/references/database-view state now merged into main.\n\n## SiYuan Reference Notes\n- Used SiYuan as a product/UX reference for stable dock/panel behavior and contextual side surfaces. No AGPL code was copied.\n\n## Test Plan\n- pnpm --filter ziba-desktop test src/lib/theme.test.ts src/components/Sidebar/index.test.tsx\n- pnpm typecheck\n- pnpm lint\n- pnpm format:check\n- pnpm test\n- pnpm build\n\nNote: GitHub Actions may not start because the account currently reports a billing lock; local verification passed.