### PR TITLE
feat: add right pane outline navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 - Controlli UI condivisi per tab segmentati e icon button, applicati a
   pannello laterale, DatabaseView e toolbar del grafo.
 - Controllo "Righe" nella DatabaseView, collegato a `DatabaseQuery.limit`.
+- Pannello `Indice` nel right pane, con filtro titoli e jump ai heading della
+  nota corrente.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Current state:
 - Saved database views in `.ziba/database-views.json`, including table, board,
   calendar, and gallery layouts.
 - Inline database blocks that render saved views inside notes.
+- Right-side document outline for quick heading navigation.
 - Extensive unit and component coverage across the core and desktop app.
 - MIT licensed and open to contributors.
 
@@ -178,6 +179,7 @@ editing your files however you want.
   and graph settings.
 - Right-side References panel with backlinks, plain-text mentions, counts,
   filters, sorting, and inline context previews.
+- Right-side Outline panel for jumping between headings in the current note.
 
 ### Desktop workflows
 
@@ -320,6 +322,7 @@ Recently shipped:
 
 - Local vault, markdown editor, wikilinks, backlinks, tags, full-text search.
 - References panel with backlinks, mentions, filters, sorting, and previews.
+- Outline panel for current-note heading navigation.
 - Saved database table, board, calendar, and gallery views.
 - Inline database blocks inside notes.
 - Global/local graph modes and local mini-graph.

--- a/apps/desktop/src/components/BacklinksPanel/index.test.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/index.test.tsx
@@ -55,6 +55,7 @@ describe('BacklinksPanel', () => {
 
     render(<BacklinksPanel />);
 
+    expect(screen.getByRole('tab', { name: 'Indice' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Riferimenti' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Grafo' })).toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Oggetto' })).toBeNull();
@@ -83,7 +84,28 @@ describe('BacklinksPanel', () => {
     render(<BacklinksPanel />);
 
     expect(screen.getByRole('tab', { name: 'Oggetto' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Indice' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Riferimenti' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Grafo' })).toBeInTheDocument();
+  });
+
+  it('renders the Outline tab for the current note', () => {
+    useUiStore.setState({ rightPaneTab: 'outline' });
+    useEditorStore.setState({
+      currentNote: {
+        path: 'People/Ada.md',
+        title: 'Ada Lovelace',
+        frontmatter: {},
+        content: '# Ada\n## Notes',
+        wikilinks: [],
+        mtimeMs: 0,
+      },
+    });
+
+    render(<BacklinksPanel />);
+
+    expect(screen.getByRole('tab', { name: 'Indice' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Ada' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Notes' })).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/components/BacklinksPanel/index.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/index.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from '../../stores/editor';
 import { useUiStore, type RightPaneTab } from '../../stores/ui';
 import { MiniGraph } from '../MiniGraph';
 import { ObjectPanel } from '../ObjectPanel';
+import { OutlinePanel } from '../OutlinePanel';
 import { SegmentedControl } from '../ui/SegmentedControl';
 import { ReferencesPanel } from './ReferencesPanel';
 
@@ -13,12 +14,14 @@ type TabSpec = {
 };
 
 const TABS_UNTYPED: readonly TabSpec[] = [
+  { id: 'outline', label: 'Indice' },
   { id: 'references', label: 'Riferimenti' },
   { id: 'graph', label: 'Grafo' },
 ] as const;
 
 const TABS_TYPED: readonly TabSpec[] = [
   { id: 'object', label: 'Oggetto' },
+  { id: 'outline', label: 'Indice' },
   { id: 'references', label: 'Riferimenti' },
   { id: 'graph', label: 'Grafo' },
 ] as const;
@@ -26,6 +29,7 @@ const TABS_TYPED: readonly TabSpec[] = [
 /**
  * Tabbed shell for the right-side panel. Hosts:
  *  - `<ObjectPanel />`: typed-note properties and object relations.
+ *  - `<OutlinePanel />`: current-note heading index.
  *  - `<ReferencesPanel />`: inbound links plus plain-text mentions.
  *  - `<MiniGraph />`: the v0.2 Wave 3 local-neighborhood graph.
  *
@@ -53,8 +57,7 @@ export function BacklinksPanel(): JSX.Element {
 
   const isTyped = currentNote !== null && extractType(currentNote.frontmatter) !== null;
   const tabs = isTyped ? TABS_TYPED : TABS_UNTYPED;
-  const activeTab: RightPaneTab =
-    persistedTab === 'object' && !isTyped ? 'references' : persistedTab;
+  const activeTab: RightPaneTab = persistedTab === 'object' && !isTyped ? 'outline' : persistedTab;
 
   return (
     <aside className="flex h-full flex-col overflow-hidden bg-bg-subtle">
@@ -78,6 +81,8 @@ export function BacklinksPanel(): JSX.Element {
       >
         {activeTab === 'object' ? (
           <ObjectPanel />
+        ) : activeTab === 'outline' ? (
+          <OutlinePanel currentPath={currentPath} markdown={currentNote?.content ?? ''} />
         ) : activeTab === 'references' ? (
           <ReferencesPanel currentPath={currentPath} onLoadingChange={handleLoadingChange} />
         ) : (

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -10,6 +10,7 @@ import { useUiStore } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
+import { SCROLL_TO_HEADING_EVENT, type ScrollToHeadingDetail } from '../../lib/outline';
 import { createStarterVault } from '../../lib/starter-vault';
 import { debounce } from '../../lib/debounce';
 import { AUTOSAVE_DEBOUNCE_MS, PROPERTY_AUTOSAVE_DEBOUNCE_MS } from '../../lib/timings';
@@ -611,6 +612,30 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
       dom.removeEventListener('click', handler);
     };
   }, [editor, handleWikilinkClick]);
+
+  useEffect(() => {
+    if (editor === null) return;
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<ScrollToHeadingDetail>).detail;
+      if (detail.path !== currentNote?.path) return;
+      const headings = Array.from(
+        editor.view.dom.querySelectorAll('h1, h2, h3, h4, h5, h6'),
+      ).filter((node): node is HTMLElement => node instanceof HTMLElement);
+      const target = headings[detail.index];
+      if (target === undefined) return;
+
+      target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      target.classList.add('ziba-heading-focus');
+      window.setTimeout(() => {
+        target.classList.remove('ziba-heading-focus');
+      }, 900);
+    };
+
+    window.addEventListener(SCROLL_TO_HEADING_EVENT, handler);
+    return (): void => {
+      window.removeEventListener(SCROLL_TO_HEADING_EVENT, handler);
+    };
+  }, [editor, currentNote?.path]);
 
   const isExternalConflict =
     lastSaveError !== null && lastSaveError.includes('modificato esternamente');

--- a/apps/desktop/src/components/OutlinePanel/index.test.tsx
+++ b/apps/desktop/src/components/OutlinePanel/index.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SCROLL_TO_HEADING_EVENT, type ScrollToHeadingDetail } from '../../lib/outline';
+import { OutlinePanel } from './index';
+
+describe('OutlinePanel', () => {
+  it('filters headings and dispatches scroll requests', () => {
+    const events: ScrollToHeadingDetail[] = [];
+    const listener: EventListener = (event) => {
+      events.push((event as CustomEvent<ScrollToHeadingDetail>).detail);
+    };
+    window.addEventListener(SCROLL_TO_HEADING_EVENT, listener);
+
+    render(
+      <OutlinePanel
+        currentPath="Projects/Ziba.md"
+        markdown={`# Ziba
+## Graph
+### Database blocks
+## References`}
+      />,
+    );
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Filtra indice'), { target: { value: 'data' } });
+
+    expect(screen.queryByRole('button', { name: 'Graph' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Database blocks' }));
+
+    expect(events).toEqual([
+      {
+        path: 'Projects/Ziba.md',
+        index: 2,
+      },
+    ]);
+
+    window.removeEventListener(SCROLL_TO_HEADING_EVENT, listener);
+  });
+});

--- a/apps/desktop/src/components/OutlinePanel/index.tsx
+++ b/apps/desktop/src/components/OutlinePanel/index.tsx
@@ -1,0 +1,71 @@
+import { MagnifyingGlass } from '@phosphor-icons/react';
+import type { JSX } from 'react';
+import { useMemo, useState } from 'react';
+import { dispatchScrollToHeading, extractOutlineHeadings } from '../../lib/outline';
+
+export type OutlinePanelProps = {
+  currentPath: string | null;
+  markdown: string;
+};
+
+export function OutlinePanel({ currentPath, markdown }: OutlinePanelProps): JSX.Element {
+  const [query, setQuery] = useState('');
+  const headings = useMemo(() => extractOutlineHeadings(markdown), [markdown]);
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleHeadings = useMemo(() => {
+    if (normalizedQuery.length === 0) return headings;
+    return headings.filter((heading) => heading.text.toLowerCase().includes(normalizedQuery));
+  }, [headings, normalizedQuery]);
+
+  return (
+    <section className="flex min-h-full flex-col bg-bg-subtle">
+      <div className="shrink-0 border-b border-border px-3 py-2">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-fg-muted">Indice</h2>
+          <span className="rounded bg-bg-muted px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-fg-muted">
+            {headings.length}
+          </span>
+        </div>
+        <label className="flex h-8 items-center gap-2 rounded-md border border-border bg-bg px-2 text-fg-muted focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/15">
+          <MagnifyingGlass size={14} aria-hidden="true" />
+          <input
+            type="search"
+            aria-label="Filtra indice"
+            placeholder="Filtra indice"
+            value={query}
+            onChange={(event): void => setQuery(event.target.value)}
+            className="min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-muted"
+          />
+        </label>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {currentPath === null ? (
+          <p className="px-2 py-3 text-sm text-fg-muted">Nessuna nota aperta.</p>
+        ) : headings.length === 0 ? (
+          <p className="px-2 py-3 text-sm text-fg-muted">Nessun titolo nella nota.</p>
+        ) : visibleHeadings.length === 0 ? (
+          <p className="px-2 py-3 text-sm text-fg-muted">Nessun risultato.</p>
+        ) : (
+          <ol role="list" className="space-y-px">
+            {visibleHeadings.map((heading) => (
+              <li key={`${heading.index}-${heading.line}`}>
+                <button
+                  type="button"
+                  onClick={(): void => {
+                    dispatchScrollToHeading({ path: currentPath, index: heading.index });
+                  }}
+                  title={`Riga ${heading.line}`}
+                  style={{ paddingLeft: `${0.5 + (heading.level - 1) * 0.75}rem` }}
+                  className="flex min-h-7 w-full min-w-0 items-center rounded px-2 py-1 text-left text-xs text-fg-subtle transition hover:bg-bg-muted hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent/50"
+                >
+                  <span className="truncate">{heading.text}</span>
+                </button>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/lib/outline.test.ts
+++ b/apps/desktop/src/lib/outline.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dispatchScrollToHeading,
+  extractOutlineHeadings,
+  SCROLL_TO_HEADING_EVENT,
+  type ScrollToHeadingDetail,
+} from './outline';
+
+describe('outline extraction', () => {
+  it('extracts markdown headings while skipping frontmatter and code fences', () => {
+    const headings = extractOutlineHeadings(`---
+title: Draft
+---
+
+# Project [[Ziba]]
+
+\`\`\`md
+## Not a heading
+\`\`\`
+
+## Roadmap
+### [Graph](graph.md) **polish** ###
+`);
+
+    expect(headings).toEqual([
+      { index: 0, level: 1, line: 5, text: 'Project Ziba' },
+      { index: 1, level: 2, line: 11, text: 'Roadmap' },
+      { index: 2, level: 3, line: 12, text: 'Graph polish' },
+    ]);
+  });
+
+  it('dispatches a typed scroll event for editor integration', () => {
+    const events: ScrollToHeadingDetail[] = [];
+    const listener: EventListener = (event) => {
+      events.push((event as CustomEvent<ScrollToHeadingDetail>).detail);
+    };
+    window.addEventListener(SCROLL_TO_HEADING_EVENT, listener);
+
+    dispatchScrollToHeading({ path: 'Project.md', index: 2 });
+
+    expect(events).toEqual([{ path: 'Project.md', index: 2 }]);
+
+    window.removeEventListener(SCROLL_TO_HEADING_EVENT, listener);
+  });
+});

--- a/apps/desktop/src/lib/outline.ts
+++ b/apps/desktop/src/lib/outline.ts
@@ -1,0 +1,71 @@
+export const SCROLL_TO_HEADING_EVENT = 'ziba:scroll-to-heading';
+
+export type OutlineHeading = {
+  index: number;
+  level: number;
+  line: number;
+  text: string;
+};
+
+export type ScrollToHeadingDetail = {
+  path: string;
+  index: number;
+};
+
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
+    .replace(/\[\[([^\]]+)\]\]/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[`*_~]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isFenceStart(line: string): boolean {
+  return /^(```|~~~)/.test(line.trim());
+}
+
+export function extractOutlineHeadings(markdown: string): OutlineHeading[] {
+  const headings: OutlineHeading[] = [];
+  const lines = markdown.split(/\r?\n/);
+  let inFence = false;
+  let inFrontmatter = lines[0]?.trim() === '---';
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    const trimmed = line.trim();
+
+    if (i > 0 && inFrontmatter && trimmed === '---') {
+      inFrontmatter = false;
+      continue;
+    }
+    if (inFrontmatter) continue;
+
+    if (isFenceStart(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const match = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
+    if (match === null) continue;
+
+    const rawText = match[2]?.replace(/[ \t]+#+[ \t]*$/, '') ?? '';
+    const text = stripInlineMarkdown(rawText);
+    if (text.length === 0) continue;
+
+    headings.push({
+      index: headings.length,
+      level: match[1]?.length ?? 1,
+      line: i + 1,
+      text,
+    });
+  }
+
+  return headings;
+}
+
+export function dispatchScrollToHeading(detail: ScrollToHeadingDetail): void {
+  window.dispatchEvent(new CustomEvent<ScrollToHeadingDetail>(SCROLL_TO_HEADING_EVENT, { detail }));
+}

--- a/apps/desktop/src/stores/ui.test.ts
+++ b/apps/desktop/src/stores/ui.test.ts
@@ -213,6 +213,19 @@ describe('useUiStore — loadPersisted validator', () => {
     expect(useUiStore.getState().rightPaneTab).toBe('references');
   });
 
+  it('loads the persisted Outline right-pane tab', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        rightPaneTab: 'outline',
+      }),
+    );
+
+    const { useUiStore } = await loadUiStore();
+
+    expect(useUiStore.getState().rightPaneTab).toBe('outline');
+  });
+
   it('loads and applies a valid persisted theme id', async () => {
     window.localStorage.setItem(
       STORAGE_KEY,

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -5,10 +5,11 @@ const STORAGE_KEY = 'ziba.ui.v1';
 
 /**
  * Active tab in the right-side panel. `references` is the shared
- * Backlinks + Mentions surface, `object` is available for typed notes,
- * and `graph` hosts the local-neighborhood mini-graph.
+ * Backlinks + Mentions surface, `outline` is the current document index,
+ * `object` is available for typed notes, and `graph` hosts the
+ * local-neighborhood mini-graph.
  */
-export type RightPaneTab = 'object' | 'references' | 'graph';
+export type RightPaneTab = 'object' | 'outline' | 'references' | 'graph';
 
 /**
  * Top-level view that occupies the editor + right-pane area. The sidebar
@@ -105,7 +106,7 @@ const DEFAULTS: Persisted = {
 };
 
 function isRightPaneTab(v: unknown): v is RightPaneTab {
-  return v === 'object' || v === 'references' || v === 'graph';
+  return v === 'object' || v === 'outline' || v === 'references' || v === 'graph';
 }
 
 function normalizeRightPaneTab(v: unknown): RightPaneTab {

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -281,6 +281,12 @@ body {
   text-decoration: underline;
 }
 
+.ziba-heading-focus {
+  border-radius: 0.25rem;
+  outline: 2px solid rgb(var(--accent) / 0.45);
+  outline-offset: 0.25rem;
+}
+
 /*
  * ProseMirror selection styling. The default browser selection on top
  * of an atom node looks blocky; the `ProseMirror-selectednode` class


### PR DESCRIPTION
## Summary\n- Add a SiYuan-inspired Indice tab to the right pane for current-note heading navigation.\n- Parse markdown headings while skipping frontmatter and fenced code.\n- Dispatch heading jump events to the editor, which scrolls and briefly focuses the target heading.\n- Update README and changelog for the new workflow.\n\n## SiYuan Reference Notes\n- Product reference: SiYuan's dock Outline panel with filter and heading jump behavior. Implementation is original Ziba code.\n\n## Test Plan\n- pnpm --filter ziba-desktop test src/lib/outline.test.ts src/components/OutlinePanel/index.test.tsx src/components/BacklinksPanel/index.test.tsx src/stores/ui.test.ts\n- pnpm typecheck\n- pnpm lint\n- pnpm format:check\n- pnpm test\n- pnpm build\n\nNote: GitHub Actions may not start because the account currently reports a billing lock; local verification passed.