### PR TITLE
fix: expand editor workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 
 ### Added
 
-- Grafo ispirato a SiYuan con default piu' ariosi, frecce visibili, modalita'
+- Grafo con default piu' ariosi, frecce visibili, modalita'
   globale/locale, refresh, ricerca compatta e fullscreen della surface.
 - Pannello `Riferimenti` con sezioni Backlinks/Mentions, filtro, sort,
   conteggi e preview inline.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ editing your files however you want.
 
 - Local mini-graph around the current note.
 - Global graph with pan, zoom, search, and node selection.
-- SiYuan/Obsidian-style global and local graph modes with compact controls,
+- Obsidian-style global and local graph modes with compact controls,
   search, refresh, fit, fullscreen, and focusable local neighborhoods.
 - Constellation mode with type clusters, color groups, relation-kind filters,
   and graph settings.
@@ -327,7 +327,7 @@ Recently shipped:
 - Inline database blocks inside notes.
 - Global/local graph modes and local mini-graph.
 - Typed objects, schemas, relation table, object panel, and type sidebar.
-- SiYuan/Obsidian-style graph polish, graph settings, and compact panel controls.
+- Obsidian-style graph polish, graph settings, and compact panel controls.
 
 Next directions:
 

--- a/apps/desktop/src/components/BacklinksPanel/index.test.tsx
+++ b/apps/desktop/src/components/BacklinksPanel/index.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe('BacklinksPanel', () => {
-  it('renders a SiYuan-like References tab with Backlinks and Mentions sections', async () => {
+  it('renders a References tab with Backlinks and Mentions sections', async () => {
     mock.setHandler(IpcChannels.getReferences, async () => ({
       backlinks: [
         {

--- a/apps/desktop/src/components/Editor/index.test.tsx
+++ b/apps/desktop/src/components/Editor/index.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installMockIpc } from '../../test/mock-ipc';
+import { useEditorStore } from '../../stores/editor';
+import { useUiStore } from '../../stores/ui';
+import { useVaultStore } from '../../stores/vault';
+import { Editor } from './index';
+
+beforeEach(() => {
+  installMockIpc();
+  useVaultStore.setState({
+    current: { root: '/vault', name: 'vault', openedAt: 0 },
+    notes: [],
+    folders: [],
+    typedPaths: new Map(),
+  });
+  useEditorStore.setState({
+    currentPath: 'Projects/Ziba.md',
+    currentNote: {
+      path: 'Projects/Ziba.md',
+      title: 'Ziba',
+      frontmatter: {},
+      content: '# Ziba',
+      wikilinks: [],
+      mtimeMs: 0,
+    },
+    dirty: false,
+    lastSaveError: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('<Editor>', () => {
+  it('fills the available workspace when the right panel is closed', () => {
+    useUiStore.setState({ backlinksOpen: false });
+
+    const { container } = render(<Editor />);
+
+    expect(container.querySelector('.ziba-editor-root')).toHaveClass('w-full', 'flex-1');
+    expect(container.querySelector('.ziba-editor-scroll')).toHaveClass('min-w-0', 'flex-1');
+    expect(container.querySelector('.ziba-editor-content')).toHaveClass('max-w-none');
+    expect(container.querySelector('.ziba-editor-content')).not.toHaveClass('max-w-[760px]');
+  });
+
+  it('uses readable width when the right panel is open', () => {
+    useUiStore.setState({ backlinksOpen: true });
+
+    const { container } = render(<Editor />);
+
+    expect(container.querySelector('.ziba-editor-content')).toHaveClass('mx-auto', 'max-w-[760px]');
+  });
+});

--- a/apps/desktop/src/components/Editor/index.tsx
+++ b/apps/desktop/src/components/Editor/index.tsx
@@ -148,6 +148,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
   const openNote = useEditorStore((s) => s.openNote);
   const createUntitledNote = useEditorStore((s) => s.createUntitledNote);
   const setMainView = useUiStore((s) => s.setMainView);
+  const backlinksOpen = useUiStore((s) => s.backlinksOpen);
   const notes = useVaultStore((s) => s.notes);
   const [starterCreating, setStarterCreating] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
@@ -741,7 +742,7 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
     const showStarterAction = notes.length === 0;
 
     return (
-      <section className="flex h-full bg-bg">
+      <section className="flex h-full w-full min-w-0 bg-bg">
         <div className="mx-auto flex w-full max-w-[760px] flex-col px-8 py-10">
           <div className="mb-10 flex items-center justify-between gap-4 text-sm">
             <div className="truncate text-fg-muted">
@@ -838,9 +839,12 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
   const breadcrumb = pathParts.length > 0 ? pathParts.join(' / ') : 'Note';
   const saveStatus =
     lastSaveError !== null ? 'Errore salvataggio' : dirty ? 'Modifiche non salvate' : 'Salvato';
+  const editorContentClass =
+    'ziba-editor-content flex w-full flex-col py-10 ' +
+    (backlinksOpen ? 'mx-auto max-w-[760px] px-8' : 'max-w-none px-10 xl:px-14 2xl:px-16');
 
   return (
-    <section className="relative flex h-full flex-col bg-bg">
+    <section className="ziba-editor-root relative flex h-full w-full min-w-0 flex-1 flex-col bg-bg">
       {lastSaveError !== null && (
         <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-bg-subtle px-4 py-2 text-xs text-fg-subtle">
           <span className="truncate">{lastSaveError}</span>
@@ -868,12 +872,12 @@ export function Editor({ onSave }: EditorProps): JSX.Element {
       )}
 
       <div
-        className="ziba-editor-scroll flex-1 overflow-y-auto"
+        className="ziba-editor-scroll min-w-0 flex-1 overflow-y-auto"
         // The wikilink chip styles are inlined here (small surface area)
         // so we don't need a new CSS file. Tailwind utilities cover the
         // rest of the typography via `ziba-prose`.
       >
-        <div className="mx-auto flex w-full max-w-[760px] flex-col px-8 py-10">
+        <div className={editorContentClass}>
           <div className="mb-8 flex items-center justify-between gap-4 text-sm">
             <div className="min-w-0 truncate text-fg-muted">
               <span>{breadcrumb}</span>

--- a/apps/desktop/src/components/GlobalGraph/GraphSettingsPanel.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/GraphSettingsPanel.test.tsx
@@ -23,11 +23,11 @@ describe('<GraphSettingsPanel>', () => {
     expect(screen.queryByRole('heading', { name: 'Controlli grafo' })).toBeNull();
   });
 
-  it('renders the SiYuan-like drawer sections with local graph controls', () => {
+  it('renders the compact drawer sections with local graph controls', () => {
     render(<GraphSettingsPanel {...DEFAULT_PROPS} open />);
 
     expect(screen.getByRole('heading', { name: 'Controlli grafo' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Applica preset SiYuan' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Applica preset Collegato' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filtri' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Gruppi' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Aspetto' })).toBeInTheDocument();
@@ -78,11 +78,11 @@ describe('<GraphSettingsPanel>', () => {
     const onApplyPreset = vi.fn();
     render(<GraphSettingsPanel {...DEFAULT_PROPS} open onApplyPreset={onApplyPreset} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Applica preset SiYuan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Applica preset Collegato' }));
 
     expect(onApplyPreset).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: 'siyuan',
+        id: 'connected',
         query: expect.objectContaining({ minDegree: 1, includeOrphans: false }),
         display: expect.objectContaining({ showArrows: true }),
       }),

--- a/apps/desktop/src/components/GlobalGraph/GraphSettingsPanel.tsx
+++ b/apps/desktop/src/components/GlobalGraph/GraphSettingsPanel.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 export type GraphPreset = {
-  id: 'overview' | 'siyuan' | 'focus';
+  id: 'overview' | 'connected' | 'focus';
   label: string;
   description: string;
   query: Partial<GraphQueryFilters>;
@@ -57,8 +57,8 @@ const GRAPH_PRESETS: readonly GraphPreset[] = [
     },
   },
   {
-    id: 'siyuan',
-    label: 'SiYuan',
+    id: 'connected',
+    label: 'Collegato',
     description: 'Mappa orientata ai blocchi collegati, con frecce e soglia.',
     query: { includeOrphans: false, focusMode: false, minDegree: 1 },
     display: {

--- a/apps/desktop/src/lib/graph-settings.test.ts
+++ b/apps/desktop/src/lib/graph-settings.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 describe('graph settings defaults', () => {
-  it('matches the SiYuan-like graph defaults', async () => {
+  it('matches the connected graph defaults', async () => {
     const { DEFAULT_GRAPH_SETTINGS } = await loadGraphSettings();
 
     expect(DEFAULT_GRAPH_SETTINGS.query).toMatchObject({

--- a/apps/desktop/src/lib/graph-view.test.ts
+++ b/apps/desktop/src/lib/graph-view.test.ts
@@ -88,7 +88,7 @@ describe('deriveGraphView', () => {
     ]);
   });
 
-  it('applies a SiYuan-style minimum connection threshold', () => {
+  it('applies a minimum connection threshold', () => {
     const view = deriveGraphView(GRAPH, settings({ query: { minDegree: 2 } }));
 
     expect(view.graph.nodes.map((n) => n.path)).toEqual(['Projects/B.md']);

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -111,7 +111,7 @@ function isRightPaneTab(v: unknown): v is RightPaneTab {
 
 function normalizeRightPaneTab(v: unknown): RightPaneTab {
   // v0.x persisted the inbound-link panel as `backlinks`. Preserve that
-  // preference under the new SiYuan-like combined References surface.
+  // preference under the combined References surface.
   if (v === 'backlinks') return 'references';
   return isRightPaneTab(v) ? v : DEFAULTS.rightPaneTab;
 }


### PR DESCRIPTION
Summary:
- let the editor fill the available workspace when the right pane is closed
- keep the narrower readable column only when the right pane is open
- remove named external-reference labels from tracked source/docs and add editor layout regression tests

Verification:
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test
- pnpm build
- rg scan for removed external-reference terms in tracked/source files