### PR TITLE
fix: polish workspace chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 
 ### Fixed
 
+- Topbar e sidebar restano allineate quando la sidebar viene ridimensionata;
+  il toggle del pannello destro appare solo nell'editor e la sezione
+  Organizza usa un solo scroll interno.
 - La sidebar non trascina piu' la finestra verso il basso: file tree,
   strumenti e sezioni Organizza scrollano in regioni interne.
 - I temi scuri applicano anche la classe Tailwind `.dark`, quindi le utility

--- a/apps/desktop/src/components/GlobalGraph/Canvas.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.test.tsx
@@ -207,7 +207,7 @@ describe('<Canvas> — dim precedence', () => {
       />,
     );
 
-    const surface = container.querySelector('[data-graph-surface="obsidian-dark"]');
+    const surface = container.querySelector('[data-graph-surface="ziba-dark"]');
     expect(surface?.getAttribute('fill')).toBe('#1d1d1f');
     expect(container.querySelector('radialGradient')).toBeNull();
     expect(container.querySelector('[data-graph-grid="true"]')).toBeNull();

--- a/apps/desktop/src/components/GlobalGraph/Canvas.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.tsx
@@ -350,7 +350,7 @@ export const Canvas = memo(
           </marker>
         </defs>
 
-        <rect data-graph-surface="obsidian-dark" width={width} height={height} fill={CANVAS_BG} />
+        <rect data-graph-surface="ziba-dark" width={width} height={height} fill={CANVAS_BG} />
         {showGrid && (
           <rect
             data-graph-grid="true"
@@ -372,7 +372,7 @@ export const Canvas = memo(
                 if (a === null || b === null) return null;
                 const highlight =
                   activeId !== null && (e.source === activeId || e.target === activeId);
-                // Links stay neutral by default, like Obsidian. Relation-kind colour
+                // Links stay neutral by default. Relation-kind colour
                 // only appears when the user has explicitly filtered to kinds.
                 const stroke =
                   highlightKinds.size > 0 && highlightKinds.has(e.kind)

--- a/apps/desktop/src/components/Layout.tsx
+++ b/apps/desktop/src/components/Layout.tsx
@@ -22,6 +22,7 @@ export function Layout(): JSX.Element {
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
       <TopBar
+        sidebarWidth={sidebarWidth}
         onChangeVault={(): void => {
           void pickAndOpenVault();
         }}

--- a/apps/desktop/src/components/Sidebar/TagsSection.tsx
+++ b/apps/desktop/src/components/Sidebar/TagsSection.tsx
@@ -70,7 +70,7 @@ export function TagsSection(): JSX.Element {
               <code className="font-mono">tags: []</code> nel frontmatter di una nota.
             </p>
           ) : (
-            <ul role="list" className="max-h-[200px] space-y-px overflow-y-auto">
+            <ul role="list" className="space-y-px">
               {tags.map((t) => {
                 const active = selectedTag === t.tag;
                 return (
@@ -119,7 +119,7 @@ export function TagsSection(): JSX.Element {
               {notesForSelectedTag.length === 0 ? (
                 <p className="px-2 py-1 text-xs text-fg-muted">Nessuna nota con questo tag.</p>
               ) : (
-                <ul role="list" className="max-h-[180px] space-y-px overflow-y-auto">
+                <ul role="list" className="space-y-px">
                   {notesForSelectedTag.map((n) => {
                     const active = currentPath === n.path;
                     return (

--- a/apps/desktop/src/components/Sidebar/TypesSection.tsx
+++ b/apps/desktop/src/components/Sidebar/TypesSection.tsx
@@ -77,7 +77,7 @@ export function TypesSection(): JSX.Element {
               <code className="font-mono">.ziba/schema/</code>.
             </p>
           ) : (
-            <ul role="list" className="max-h-[200px] space-y-px overflow-y-auto">
+            <ul role="list" className="space-y-px">
               {types.map((t) => (
                 <TypeRow
                   key={t.id}
@@ -112,7 +112,7 @@ export function TypesSection(): JSX.Element {
               {notesForSelectedType.length === 0 ? (
                 <p className="px-2 py-1 text-xs text-fg-muted">Nessuna nota di questo tipo.</p>
               ) : (
-                <ul role="list" className="max-h-[180px] space-y-px overflow-y-auto">
+                <ul role="list" className="space-y-px">
                   {notesForSelectedType.map((n) => {
                     const active = currentPath === n.path;
                     return (

--- a/apps/desktop/src/components/Sidebar/index.test.tsx
+++ b/apps/desktop/src/components/Sidebar/index.test.tsx
@@ -117,8 +117,10 @@ describe('Sidebar navigation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Organizza' }));
     const tools = screen.getByText('Strumenti').closest('div')?.parentElement?.parentElement;
+    const organizerScroll = document.querySelector('[data-sidebar-organizer-scroll="true"]');
 
     expect(tools).toHaveClass('max-h-[48%]', 'overflow-hidden');
-    expect(screen.getByLabelText('Tipi').parentElement).toHaveClass('overflow-y-auto');
+    expect(organizerScroll).toHaveClass('overflow-y-auto');
+    expect(screen.getByLabelText('Tipi').parentElement).toBe(organizerScroll);
   });
 });

--- a/apps/desktop/src/components/Sidebar/index.tsx
+++ b/apps/desktop/src/components/Sidebar/index.tsx
@@ -600,7 +600,10 @@ export function Sidebar({ onSelectNote }: SidebarProps = {}): JSX.Element {
           </div>
         </div>
         {organizeOpen && (
-          <div className="min-h-0 flex-1 overflow-y-auto border-t border-border bg-bg">
+          <div
+            className="min-h-0 flex-1 overflow-y-auto border-t border-border bg-bg"
+            data-sidebar-organizer-scroll="true"
+          >
             <TypesSection />
             <TagsSection />
           </div>

--- a/apps/desktop/src/components/TopBar.test.tsx
+++ b/apps/desktop/src/components/TopBar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TopBar } from './TopBar';
 import { useEditorStore } from '../stores/editor';
@@ -36,8 +37,11 @@ beforeEach(() => {
 });
 
 describe('TopBar', () => {
+  const renderTopBar = (props: Partial<ComponentProps<typeof TopBar>> = {}) =>
+    render(<TopBar sidebarWidth={320} onChangeVault={vi.fn()} {...props} />);
+
   it('shows vault identity and note tabs without global navigation tabs', () => {
-    render(<TopBar onChangeVault={vi.fn()} />);
+    renderTopBar();
 
     expect(screen.getByText('secondbrain1')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ziba' })).toBeInTheDocument();
@@ -50,7 +54,7 @@ describe('TopBar', () => {
   it('selects a note tab', () => {
     const selectTab = vi.fn();
     useEditorStore.setState({ selectTab });
-    render(<TopBar onChangeVault={vi.fn()} />);
+    renderTopBar();
 
     fireEvent.click(screen.getByRole('button', { name: 'Ziba' }));
 
@@ -58,11 +62,30 @@ describe('TopBar', () => {
   });
 
   it('keeps macOS chrome draggable without covering the vault control', () => {
-    render(<TopBar onChangeVault={vi.fn()} />);
+    renderTopBar();
 
     expect(screen.getByRole('banner')).toHaveClass('app-drag');
     expect(screen.getByRole('banner')).toHaveClass('pl-[86px]');
     expect(screen.getByRole('button', { name: /Cambia vault/ })).toHaveClass('app-no-drag');
     expect(screen.getByRole('button', { name: 'Ziba' })).toHaveClass('app-no-drag');
+  });
+
+  it('aligns the vault cell divider with the sidebar divider below', () => {
+    renderTopBar({ sidebarWidth: 284 });
+
+    expect(screen.getByRole('button', { name: /Cambia vault/ }).parentElement).toHaveStyle({
+      width: '246px',
+    });
+  });
+
+  it('only shows the right-panel toggle in the editor view', () => {
+    const { rerender } = renderTopBar();
+
+    expect(screen.getByRole('button', { name: 'Mostra pannello destro' })).toBeInTheDocument();
+
+    useUiStore.setState({ mainView: 'database' });
+    rerender(<TopBar sidebarWidth={320} onChangeVault={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /pannello destro/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/components/TopBar.tsx
+++ b/apps/desktop/src/components/TopBar.tsx
@@ -7,7 +7,12 @@ import { useVaultStore } from '../stores/vault';
 
 type TopBarProps = {
   onChangeVault: () => void;
+  sidebarWidth: number;
 };
+
+const TITLEBAR_CHROME_INSET = 86;
+const RIBBON_WIDTH = 48;
+const MIN_VAULT_CELL_WIDTH = 120;
 
 function activePaneAndTabs(
   panes: EditorPane[],
@@ -24,7 +29,7 @@ function activePaneAndTabs(
   };
 }
 
-export function TopBar({ onChangeVault }: TopBarProps): JSX.Element {
+export function TopBar({ onChangeVault, sidebarWidth }: TopBarProps): JSX.Element {
   const current = useVaultStore((s) => s.current);
   const indexProgress = useVaultStore((s) => s.indexProgress);
   const workspace = useEditorStore((s) => s.workspace);
@@ -34,11 +39,16 @@ export function TopBar({ onChangeVault }: TopBarProps): JSX.Element {
   const backlinksOpen = useUiStore((s) => s.backlinksOpen);
   const toggleBacklinks = useUiStore((s) => s.toggleBacklinks);
   const setMainView = useUiStore((s) => s.setMainView);
+  const mainView = useUiStore((s) => s.mainView);
   const vaultName = current === null ? 'ziba' : current.name;
   const { pane, tabs } = activePaneAndTabs(
     workspace.panes,
     workspace.activePaneId,
     workspace.tabsById,
+  );
+  const vaultCellWidth = Math.max(
+    MIN_VAULT_CELL_WIDTH,
+    sidebarWidth + RIBBON_WIDTH - TITLEBAR_CHROME_INSET,
   );
 
   const handleNewTab = async (): Promise<void> => {
@@ -52,7 +62,10 @@ export function TopBar({ onChangeVault }: TopBarProps): JSX.Element {
 
   return (
     <header className="app-drag flex h-11 shrink-0 items-stretch border-b border-border/80 bg-bg-subtle/95 pl-[86px] text-sm shadow-[0_1px_0_rgba(30,29,27,0.04)] backdrop-blur-xl">
-      <div className="flex w-[15rem] shrink-0 items-center border-r border-border/70 pr-2">
+      <div
+        style={{ width: `${vaultCellWidth}px` }}
+        className="flex min-w-0 shrink-0 items-center border-r border-border/70 pr-2"
+      >
         <button
           type="button"
           onClick={onChangeVault}
@@ -141,18 +154,20 @@ export function TopBar({ onChangeVault }: TopBarProps): JSX.Element {
       </div>
 
       <div className="app-no-drag flex w-14 shrink-0 items-center justify-end pr-2">
-        <button
-          type="button"
-          onClick={toggleBacklinks}
-          aria-label={backlinksOpen ? 'Nascondi pannello destro' : 'Mostra pannello destro'}
-          aria-pressed={backlinksOpen}
-          title={backlinksOpen ? 'Nascondi pannello destro' : 'Mostra pannello destro'}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-lg transition hover:bg-bg-muted/80 hover:text-fg active:translate-y-px ${
-            backlinksOpen ? 'bg-bg-muted text-fg' : 'text-fg-subtle'
-          }`}
-        >
-          <LinkSimple size={16} aria-hidden="true" />
-        </button>
+        {mainView === 'editor' && (
+          <button
+            type="button"
+            onClick={toggleBacklinks}
+            aria-label={backlinksOpen ? 'Nascondi pannello destro' : 'Mostra pannello destro'}
+            aria-pressed={backlinksOpen}
+            title={backlinksOpen ? 'Nascondi pannello destro' : 'Mostra pannello destro'}
+            className={`inline-flex h-8 w-8 items-center justify-center rounded-lg transition hover:bg-bg-muted/80 hover:text-fg active:translate-y-px ${
+              backlinksOpen ? 'bg-bg-muted text-fg' : 'text-fg-subtle'
+            }`}
+          >
+            <LinkSimple size={16} aria-hidden="true" />
+          </button>
+        )}
       </div>
     </header>
   );

--- a/apps/desktop/src/lib/theme.test.ts
+++ b/apps/desktop/src/lib/theme.test.ts
@@ -6,7 +6,7 @@ describe('theme registry', () => {
     expect(DEFAULT_THEME_ID).toBe('ziba-light');
     expect(THEME_IDS).toEqual([
       'ziba-light',
-      'obsidian-dark',
+      'ziba-dark',
       'warm-paper',
       'graphite',
       'high-contrast',
@@ -14,7 +14,7 @@ describe('theme registry', () => {
   });
 
   it('strictly validates theme ids', () => {
-    expect(isThemeId('obsidian-dark')).toBe(true);
+    expect(isThemeId('ziba-dark')).toBe(true);
     expect(isThemeId('dark')).toBe(false);
     expect(isThemeId('')).toBe(false);
     expect(isThemeId(null)).toBe(false);
@@ -23,7 +23,7 @@ describe('theme registry', () => {
   it('classifies themes that need Tailwind dark variants', () => {
     expect(isDarkTheme('ziba-light')).toBe(false);
     expect(isDarkTheme('warm-paper')).toBe(false);
-    expect(isDarkTheme('obsidian-dark')).toBe(true);
+    expect(isDarkTheme('ziba-dark')).toBe(true);
     expect(isDarkTheme('graphite')).toBe(true);
     expect(isDarkTheme('high-contrast')).toBe(true);
   });

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -1,6 +1,6 @@
 export const THEME_IDS = [
   'ziba-light',
-  'obsidian-dark',
+  'ziba-dark',
   'warm-paper',
   'graphite',
   'high-contrast',
@@ -10,7 +10,7 @@ export type ThemeId = (typeof THEME_IDS)[number];
 
 export const DEFAULT_THEME_ID: ThemeId = 'ziba-light';
 
-export const DARK_THEME_IDS = ['obsidian-dark', 'graphite', 'high-contrast'] as const;
+export const DARK_THEME_IDS = ['ziba-dark', 'graphite', 'high-contrast'] as const;
 
 export type ThemeDefinition = {
   id: ThemeId;
@@ -19,7 +19,7 @@ export type ThemeDefinition = {
 
 export const THEMES: readonly ThemeDefinition[] = [
   { id: 'ziba-light', label: 'Ziba Light' },
-  { id: 'obsidian-dark', label: 'Obsidian Dark' },
+  { id: 'ziba-dark', label: 'Ziba Dark' },
   { id: 'warm-paper', label: 'Warm Paper' },
   { id: 'graphite', label: 'Graphite' },
   { id: 'high-contrast', label: 'High Contrast' },

--- a/apps/desktop/src/stores/ui.test.ts
+++ b/apps/desktop/src/stores/ui.test.ts
@@ -35,15 +35,15 @@ describe('useUiStore — toggles & persistence', () => {
   it('sets the theme, applies it to documentElement, and persists it', async () => {
     const { useUiStore } = await loadUiStore();
 
-    useUiStore.getState().setThemeId('obsidian-dark');
+    useUiStore.getState().setThemeId('ziba-dark');
 
-    expect(useUiStore.getState().themeId).toBe('obsidian-dark');
-    expect(document.documentElement.dataset.theme).toBe('obsidian-dark');
+    expect(useUiStore.getState().themeId).toBe('ziba-dark');
+    expect(document.documentElement.dataset.theme).toBe('ziba-dark');
 
     const persistedRaw = window.localStorage.getItem(STORAGE_KEY);
     expect(persistedRaw).not.toBeNull();
     const persisted = JSON.parse(persistedRaw!);
-    expect(persisted.themeId).toBe('obsidian-dark');
+    expect(persisted.themeId).toBe('ziba-dark');
   });
 
   it('setThemeId same-value is a no-op (no localStorage write)', async () => {
@@ -238,6 +238,20 @@ describe('useUiStore — loadPersisted validator', () => {
 
     expect(useUiStore.getState().themeId).toBe('warm-paper');
     expect(document.documentElement.dataset.theme).toBe('warm-paper');
+  });
+
+  it('migrates the legacy dark theme id to the native dark theme', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        themeId: 'obsidian-dark',
+      }),
+    );
+
+    const { useUiStore } = await loadUiStore();
+
+    expect(useUiStore.getState().themeId).toBe('ziba-dark');
+    expect(document.documentElement.dataset.theme).toBe('ziba-dark');
   });
 
   it('clamps persisted widths into valid range on load', async () => {

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -124,6 +124,11 @@ function isDatabaseViewMode(v: unknown): v is DatabaseViewMode {
   return v === 'table' || v === 'board' || v === 'calendar' || v === 'gallery';
 }
 
+function normalizeThemeId(v: unknown): ThemeId {
+  if (v === 'obsidian-dark') return 'ziba-dark';
+  return isThemeId(v) ? v : DEFAULTS.themeId;
+}
+
 function isFolderIconId(v: unknown): v is FolderIconId {
   return typeof v === 'string' && (FOLDER_ICON_IDS as readonly string[]).includes(v);
 }
@@ -220,7 +225,7 @@ function loadPersisted(): Persisted {
       databaseViewMode: isDatabaseViewMode(p.databaseViewMode)
         ? p.databaseViewMode
         : DEFAULTS.databaseViewMode,
-      themeId: isThemeId(p.themeId) ? p.themeId : DEFAULTS.themeId,
+      themeId: normalizeThemeId(p.themeId),
       folderIconsByVault: loadFolderIconsByVault(p.folderIconsByVault),
     };
   } catch {

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -35,17 +35,17 @@
   --accent-fg: 255 255 255;
 }
 
-:root[data-theme='obsidian-dark'],
+:root[data-theme='ziba-dark'],
 .dark {
-  --bg: 24 24 27;
-  --bg-subtle: 39 39 42;
-  --bg-muted: 52 52 56;
+  --bg: 21 21 24;
+  --bg-subtle: 33 34 37;
+  --bg-muted: 50 51 56;
 
   --fg: 244 244 245;
-  --fg-subtle: 212 212 216;
-  --fg-muted: 161 161 170;
+  --fg-subtle: 220 220 224;
+  --fg-muted: 166 168 176;
 
-  --border: 63 63 70;
+  --border: 75 76 84;
 
   --accent: 148 169 123;
   --accent-fg: 24 24 27;


### PR DESCRIPTION
Summary:
- align the top-bar vault cell with the resizable sidebar/ribbon divider
- show the right-panel toggle only when the editor can render the right pane
- simplify organizer scrolling to one internal scroll region
- rename the bundled dark theme to a Ziba-native id/label and migrate the legacy persisted id

Verification:
- pnpm --filter ziba-desktop test src/components/TopBar.test.tsx src/components/Sidebar/index.test.tsx src/lib/theme.test.ts src/stores/ui.test.ts src/components/GlobalGraph/Canvas.test.tsx
- reviewer pass via subagent: no remaining issues
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test
- pnpm build
- scan for prohibited external-reference name returned no matches