### PR TITLE
fix: harden database view menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e
 
 ### Fixed
 
+- Il menu delle viste Database ora si chiude con click esterno/Escape, mostra
+  focus visibile, evita duplicati quando gli eventi arrivano prima della
+  risposta IPC e segnala gli errori di creazione/duplicazione/eliminazione con
+  toast non bloccanti.
+- I controlli nativi rispettano il `color-scheme` del tema e forzano
+  background/testo coerenti, riducendo i casi di dropdown bianco-su-bianco o
+  nero-su-nero in light/dark mode.
 - Topbar e sidebar restano allineate quando la sidebar viene ridimensionata;
   il toggle del pannello destro appare solo nell'editor e la sezione
   Organizza usa un solo scroll interno.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Current state:
 - Frontmatter property editor.
 - Typed property indexing for fast queries.
 - Tags from both frontmatter and inline `#tag` syntax.
-- Saved database views with typed filters, sorting, grouping, limits, and column picking.
+- Saved database views with typed filters, sorting, grouping, limits, column picking, and a compact view menu.
 - Table, board, calendar, and gallery layouts for property-driven workflows.
 - Inline database blocks via `/database`, backed by saved views in the vault.
 

--- a/apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/ColumnPicker.test.tsx
@@ -46,6 +46,20 @@ describe('<ColumnPicker>', () => {
     fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
     expect(screen.getByText('Nessuna proprietà rilevata.')).toBeInTheDocument();
   });
+
+  it('closes the menu on Escape', () => {
+    render(
+      <ColumnPicker
+        availableProperties={['title', 'year']}
+        visibleColumns={[]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colonne/ }));
+    expect(screen.getByLabelText('title')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByLabelText('title')).not.toBeInTheDocument();
+  });
 });
 
 describe('<ColumnPicker> — suggestedKeys', () => {

--- a/apps/desktop/src/components/DatabaseView/ColumnPicker.tsx
+++ b/apps/desktop/src/components/DatabaseView/ColumnPicker.tsx
@@ -46,8 +46,18 @@ export function ColumnPicker({
         setOpen(false);
       }
     };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
     window.addEventListener('mousedown', onMouseDown);
-    return () => window.removeEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
   }, [open]);
 
   const visibleSet = new Set(visibleColumns);
@@ -82,13 +92,13 @@ export function ColumnPicker({
     return (
       <label
         key={key}
-        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted"
+        className="flex min-h-7 cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted focus-within:bg-bg-muted focus-within:text-fg"
       >
         <input
           type="checkbox"
           checked={checked}
           onChange={(): void => toggle(key)}
-          className="h-3 w-3"
+          className="h-3 w-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         />
         <span className="truncate">{key}</span>
       </label>
@@ -102,7 +112,7 @@ export function ColumnPicker({
         onClick={(): void => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="menu"
-        className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+        className="min-h-7 rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       >
         Colonne ({visibleColumns.length})
       </button>
@@ -114,7 +124,7 @@ export function ColumnPicker({
         >
           {suggested.length > 0 && (
             <>
-              <p className="px-2 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-fg-muted">
+              <p className="px-2 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-fg-subtle">
                 Suggerite
               </p>
               {suggested.map((k) => renderRow(k))}

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.test.tsx
@@ -63,6 +63,14 @@ describe('<TypeFilterDropdown>', () => {
     expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
   });
 
+  it('closes on Escape', () => {
+    render(<TypeFilterDropdown types={TYPES} selectedType={null} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));
+    expect(screen.getByRole('menuitemradio', { name: /Tutti/i })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('menuitemradio', { name: /Tutti/i })).not.toBeInTheDocument();
+  });
+
   it('shows the empty-state hint when no types are available', () => {
     render(<TypeFilterDropdown types={[]} selectedType={null} onChange={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /Tipo:/ }));

--- a/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
+++ b/apps/desktop/src/components/DatabaseView/TypeFilterDropdown.tsx
@@ -40,8 +40,18 @@ export function TypeFilterDropdown({ types, selectedType, onChange }: Props): JS
         setOpen(false);
       }
     };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
     window.addEventListener('mousedown', onMouseDown);
-    return (): void => window.removeEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return (): void => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
   }, [open]);
 
   const activeOption =
@@ -66,7 +76,7 @@ export function TypeFilterDropdown({ types, selectedType, onChange }: Props): JS
         onClick={(): void => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="menu"
-        className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+        className="min-h-7 max-w-52 truncate rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       >
         {buttonLabel}
       </button>
@@ -82,8 +92,10 @@ export function TypeFilterDropdown({ types, selectedType, onChange }: Props): JS
             aria-checked={selectedType === null}
             onClick={(): void => choose(null)}
             className={[
-              'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
-              selectedType === null ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+              'flex min-h-7 w-full items-center gap-2 rounded px-2 py-1 text-left text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent',
+              selectedType === null
+                ? 'bg-accent/10 text-fg'
+                : 'text-fg-subtle hover:bg-bg-muted focus-visible:bg-bg-muted focus-visible:text-fg',
             ].join(' ')}
           >
             <span className="flex-1 truncate">Tutti</span>
@@ -102,12 +114,14 @@ export function TypeFilterDropdown({ types, selectedType, onChange }: Props): JS
                 aria-checked={isActive}
                 onClick={(): void => choose(t.id)}
                 className={[
-                  'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs',
-                  isActive ? 'bg-accent/10 text-fg' : 'text-fg-subtle hover:bg-bg-muted',
+                  'flex min-h-7 w-full items-center gap-2 rounded px-2 py-1 text-left text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent',
+                  isActive
+                    ? 'bg-accent/10 text-fg'
+                    : 'text-fg-subtle hover:bg-bg-muted focus-visible:bg-bg-muted focus-visible:text-fg',
                 ].join(' ')}
               >
                 <span className="flex-1 truncate">{`${iconPrefix}${t.label}`}</span>
-                <span className="tabular-nums text-fg-muted">{`(${t.count})`}</span>
+                <span className="tabular-nums text-fg-subtle">{`(${t.count})`}</span>
               </button>
             );
           })}

--- a/apps/desktop/src/components/DatabaseView/index.test.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.test.tsx
@@ -9,6 +9,7 @@ import {
 import { installMockIpc, type MockController } from '../../test/mock-ipc';
 import { useDatabaseStore } from '../../stores/database';
 import { useTagsStore } from '../../stores/tags';
+import { useToastStore } from '../../stores/toast';
 import { useUiStore } from '../../stores/ui';
 import { useVaultStore } from '../../stores/vault';
 import { DatabaseView } from './index';
@@ -44,6 +45,20 @@ function makeRows(): DatabaseResult {
     groups: [],
     totalCount: 1,
   };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason?: unknown): void;
+} {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 beforeEach(() => {
@@ -84,6 +99,7 @@ beforeEach(() => {
   });
   useTagsStore.setState({ types: [], objectTypeSchemas: [] });
   useUiStore.setState({ databaseViewMode: 'table' });
+  useToastStore.getState().clear();
   useDatabaseStore.setState({
     query: { filters: [], limit: 1000 },
     result: null,
@@ -172,5 +188,121 @@ describe('<DatabaseView>', () => {
         frontmatter: { status: 'done' },
       });
     });
+  });
+
+  it('opens and closes the saved-view menu with outside click and Escape', async () => {
+    render(<DatabaseView />);
+
+    const trigger = await screen.findByRole('button', { name: 'Vista' });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('disables saved-view actions while duplicate is pending and applies the returned copy', async () => {
+    const copy = makeView({ id: 'projects-copy', name: 'Projects copia' });
+    const pending = deferred<DatabaseViewDefinition>();
+    mock.setHandler(IpcChannels.duplicateDatabaseView, async () => pending.promise);
+
+    render(<DatabaseView />);
+
+    await screen.findByRole('tab', { name: 'Tutte' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Projects' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Vista' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Duplica' }));
+
+    expect(mock.getSpy(IpcChannels.duplicateDatabaseView)).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Vista' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vista' }));
+    expect(mock.getSpy(IpcChannels.duplicateDatabaseView)).toHaveBeenCalledTimes(1);
+
+    pending.resolve(copy);
+
+    expect(await screen.findByRole('tab', { name: 'Projects copia' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Vista' })).not.toBeDisabled();
+  });
+
+  it('keeps one tab when a duplicate event arrives before the duplicate request resolves', async () => {
+    const copy = makeView({ id: 'projects-copy', name: 'Projects copia' });
+    const pending = deferred<DatabaseViewDefinition>();
+    mock.setHandler(IpcChannels.duplicateDatabaseView, async () => pending.promise);
+
+    render(<DatabaseView />);
+
+    await screen.findByRole('tab', { name: 'Tutte' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Projects' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Vista' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Duplica' }));
+
+    mock.triggerDatabaseViewsChanged({
+      version: 1,
+      activeViewId: copy.id,
+      views: [
+        makeView({ id: 'default', name: 'Tutte' }),
+        makeView({ id: 'projects', name: 'Projects' }),
+        copy,
+      ],
+    });
+    pending.resolve(copy);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab', { name: 'Projects copia' })).toHaveLength(1);
+    });
+  });
+
+  it('shows a toast and preserves the active view when duplicate fails', async () => {
+    mock.setHandler(IpcChannels.duplicateDatabaseView, async () => {
+      throw new Error('[INTERNAL] disco pieno');
+    });
+
+    render(<DatabaseView />);
+
+    await screen.findByRole('tab', { name: 'Tutte' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Projects' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Vista' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Duplica' }));
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.at(-1)).toMatchObject({
+        kind: 'error',
+        title: 'Impossibile duplicare la vista',
+        message: 'disco pieno',
+      });
+    });
+    expect(screen.queryByRole('tab', { name: /copia/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Projects' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does not delete the final saved view', async () => {
+    const singleViewFile: DatabaseViewsFile = {
+      version: 1,
+      activeViewId: 'default',
+      views: [makeView({ id: 'default', name: 'Tutte' })],
+    };
+    mock.setHandler(IpcChannels.listDatabaseViews, async () => singleViewFile);
+
+    render(<DatabaseView />);
+
+    await screen.findByRole('tab', { name: 'Tutte' });
+    fireEvent.click(screen.getByRole('button', { name: 'Vista' }));
+
+    const deleteButton = screen.getByRole('menuitem', { name: 'Elimina' });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.click(deleteButton);
+    expect(mock.getSpy(IpcChannels.deleteDatabaseView)).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/DatabaseView/index.tsx
+++ b/apps/desktop/src/components/DatabaseView/index.tsx
@@ -33,6 +33,12 @@ import { Table, type DatabaseCellCommit } from './Table';
  */
 const DEFAULT_VISIBLE_COLUMN_COUNT = 5;
 const DEFAULT_QUERY_LIMIT = 1000;
+const MENU_TRIGGER_CLASS =
+  'min-h-7 rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+const MENU_ITEM_CLASS =
+  'block min-h-7 w-full rounded px-2 py-1 text-left text-fg-subtle hover:bg-bg-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 focus-visible:bg-bg-muted focus-visible:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent';
+const DANGER_MENU_ITEM_CLASS =
+  'block min-h-7 w-full rounded px-2 py-1 text-left text-red-600 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-400 focus-visible:bg-red-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-500';
 
 // Frozen empty fallbacks — see BoardView/CalendarView for the same
 // reasoning (avoid per-render `[]` allocations driving downstream
@@ -58,6 +64,21 @@ export type DatabaseViewProps = {
 
 function createViewId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `view-${Date.now().toString(36)}`;
+}
+
+function upsertViewInFile(
+  current: DatabaseViewsFile | null,
+  view: DatabaseViewDefinition,
+): DatabaseViewsFile {
+  if (current === null) return { version: 1, activeViewId: view.id, views: [view] };
+  const exists = current.views.some((item) => item.id === view.id);
+  return {
+    ...current,
+    activeViewId: view.id,
+    views: exists
+      ? current.views.map((item) => (item.id === view.id ? view : item))
+      : [...current.views, view],
+  };
 }
 
 function coerceCellValue(type: PropertyType | null, value: string | boolean): unknown {
@@ -131,6 +152,10 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
   const [viewsFile, setViewsFile] = useState<DatabaseViewsFile | null>(null);
   const [activeViewId, setActiveViewId] = useState<string | null>(null);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
+  const [viewActionPending, setViewActionPending] = useState<
+    'create' | 'duplicate' | 'delete' | null
+  >(null);
+  const viewMenuRef = useRef<HTMLDivElement | null>(null);
   const seededRef = useRef(false);
 
   const activeView = useMemo<DatabaseViewDefinition | null>(() => {
@@ -193,6 +218,29 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
     seededRef.current = true;
     setVisibleColumns(availableProperties.slice(0, DEFAULT_VISIBLE_COLUMN_COUNT));
   }, [availableProperties]);
+
+  useEffect(() => {
+    if (!viewMenuOpen) return;
+    const onMouseDown = (e: MouseEvent): void => {
+      const node = viewMenuRef.current;
+      if (node === null) return;
+      if (e.target instanceof Node && !node.contains(e.target)) {
+        setViewMenuOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setViewMenuOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return (): void => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [viewMenuOpen]);
 
   // Drop seeded columns that no longer exist (e.g. user removed the
   // frontmatter key from every note). We don't auto-add new keys — the
@@ -257,10 +305,12 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
   );
 
   const handleSelectView = (view: DatabaseViewDefinition): void => {
+    setViewMenuOpen(false);
     applyDatabaseView(view);
   };
 
-  const handleCreateView = (): void => {
+  const handleCreateView = async (): Promise<void> => {
+    if (viewActionPending !== null) return;
     const timestamp = Date.now();
     const view: DatabaseViewDefinition = {
       id: createViewId(),
@@ -273,36 +323,58 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
       updatedAt: timestamp,
     };
     setViewMenuOpen(false);
-    setViewsFile((current) =>
-      current === null
-        ? { version: 1, activeViewId: view.id, views: [view] }
-        : { ...current, activeViewId: view.id, views: [...current.views, view] },
-    );
+    setViewActionPending('create');
+    setViewsFile((current) => upsertViewInFile(current, view));
     applyDatabaseView(view);
-    void ipc.upsertDatabaseView({ view });
+    try {
+      const saved = await ipc.upsertDatabaseView({ view });
+      setViewsFile((current) => upsertViewInFile(current, saved));
+      applyDatabaseView(saved);
+    } catch (err: unknown) {
+      toast.error(ipcErrorMessage(err), 'Impossibile creare la vista');
+      try {
+        const file = await ipc.listDatabaseViews();
+        setViewsFile(file);
+        const next = file.views.find((item) => item.id === file.activeViewId) ?? file.views[0];
+        if (next !== undefined) applyDatabaseView(next);
+      } catch {
+        // Keep the optimistic view visible if recovery also fails.
+      }
+    } finally {
+      setViewActionPending(null);
+    }
   };
 
-  const handleDuplicateView = (): void => {
-    if (activeView === null) return;
+  const handleDuplicateView = async (): Promise<void> => {
+    if (activeView === null || viewActionPending !== null) return;
     setViewMenuOpen(false);
-    void ipc.duplicateDatabaseView({ id: activeView.id }).then((copy) => {
-      setViewsFile((current) =>
-        current === null
-          ? { version: 1, activeViewId: copy.id, views: [copy] }
-          : { ...current, activeViewId: copy.id, views: [...current.views, copy] },
-      );
+    setViewActionPending('duplicate');
+    try {
+      const copy = await ipc.duplicateDatabaseView({ id: activeView.id });
+      setViewsFile((current) => upsertViewInFile(current, copy));
       applyDatabaseView(copy);
-    });
+    } catch (err: unknown) {
+      toast.error(ipcErrorMessage(err), 'Impossibile duplicare la vista');
+    } finally {
+      setViewActionPending(null);
+    }
   };
 
-  const handleDeleteView = (): void => {
-    if (activeView === null) return;
+  const handleDeleteView = async (): Promise<void> => {
+    if (activeView === null || viewActionPending !== null) return;
+    if ((viewsFile?.views.length ?? 0) <= 1) return;
     setViewMenuOpen(false);
-    void ipc.deleteDatabaseView({ id: activeView.id }).then((file) => {
+    setViewActionPending('delete');
+    try {
+      const file = await ipc.deleteDatabaseView({ id: activeView.id });
       setViewsFile(file);
       const next = file.views.find((view) => view.id === file.activeViewId) ?? file.views[0];
       if (next !== undefined) applyDatabaseView(next);
-    });
+    } catch (err: unknown) {
+      toast.error(ipcErrorMessage(err), 'Impossibile eliminare la vista');
+    } finally {
+      setViewActionPending(null);
+    }
   };
 
   const handleVisibleColumnsChange = (columns: string[]): void => {
@@ -400,6 +472,10 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
 
   const lastUpdatedLabel =
     lastUpdatedAt === null ? null : TIME_FORMATTER.format(new Date(lastUpdatedAt));
+  const viewActionBusy = viewActionPending !== null;
+  const canDuplicateView = activeView !== null && !viewActionBusy;
+  const canDeleteView =
+    activeView !== null && (viewsFile?.views.length ?? 0) > 1 && !viewActionBusy;
 
   // Clear-all-filters helper used by the empty state CTA.
   const clearAllFilters = (): void => {
@@ -543,8 +619,8 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
                   onClick={(): void => handleSelectView(view)}
                   className={
                     active
-                      ? 'rounded bg-bg-muted px-2 py-1 text-xs font-medium text-fg'
-                      : 'rounded px-2 py-1 text-xs font-medium text-fg-subtle hover:bg-bg-muted hover:text-fg'
+                      ? 'min-h-7 max-w-40 truncate rounded bg-bg-muted px-2 py-1 text-xs font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
+                      : 'min-h-7 max-w-40 truncate rounded px-2 py-1 text-xs font-medium text-fg-subtle hover:bg-bg-muted hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
                   }
                 >
                   {view.name}
@@ -552,42 +628,53 @@ export function DatabaseView(props: DatabaseViewProps = {}): JSX.Element {
               );
             })}
           </div>
-          <div className="relative">
+          <div ref={viewMenuRef} className="relative">
             <button
               type="button"
               aria-haspopup="menu"
               aria-expanded={viewMenuOpen}
+              aria-busy={viewActionBusy}
+              disabled={viewActionBusy}
               onClick={(): void => setViewMenuOpen((open) => !open)}
-              className="rounded border border-border bg-bg-subtle px-2 py-1 text-xs text-fg-subtle hover:bg-bg-muted hover:text-fg"
+              className={MENU_TRIGGER_CLASS}
             >
               Vista
             </button>
             {viewMenuOpen && (
               <div
                 role="menu"
-                className="absolute right-0 z-20 mt-1 w-40 rounded border border-border bg-bg p-1 text-xs shadow-lg"
+                className="absolute right-0 z-20 mt-1 w-48 rounded border border-border bg-bg p-1 text-xs shadow-lg"
               >
                 <button
                   type="button"
                   role="menuitem"
-                  onClick={handleCreateView}
-                  className="block w-full rounded px-2 py-1 text-left text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                  disabled={viewActionBusy}
+                  onClick={(): void => {
+                    void handleCreateView();
+                  }}
+                  className={MENU_ITEM_CLASS}
                 >
                   Nuova vista
                 </button>
                 <button
                   type="button"
                   role="menuitem"
-                  onClick={handleDuplicateView}
-                  className="block w-full rounded px-2 py-1 text-left text-fg-subtle hover:bg-bg-muted hover:text-fg"
+                  disabled={!canDuplicateView}
+                  onClick={(): void => {
+                    void handleDuplicateView();
+                  }}
+                  className={MENU_ITEM_CLASS}
                 >
                   Duplica
                 </button>
                 <button
                   type="button"
                   role="menuitem"
-                  onClick={handleDeleteView}
-                  className="block w-full rounded px-2 py-1 text-left text-red-600 hover:bg-red-500/10"
+                  disabled={!canDeleteView}
+                  onClick={(): void => {
+                    void handleDeleteView();
+                  }}
+                  className={DANGER_MENU_ITEM_CLASS}
                 >
                   Elimina
                 </button>

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -21,6 +21,8 @@
  */
 :root,
 :root[data-theme='ziba-light'] {
+  color-scheme: light;
+
   --bg: 253 252 249;
   --bg-subtle: 248 247 244;
   --bg-muted: 239 238 233;
@@ -37,6 +39,8 @@
 
 :root[data-theme='ziba-dark'],
 .dark {
+  color-scheme: dark;
+
   --bg: 21 21 24;
   --bg-subtle: 33 34 37;
   --bg-muted: 50 51 56;
@@ -52,6 +56,8 @@
 }
 
 :root[data-theme='warm-paper'] {
+  color-scheme: light;
+
   --bg: 252 248 239;
   --bg-subtle: 246 239 226;
   --bg-muted: 232 221 203;
@@ -67,6 +73,8 @@
 }
 
 :root[data-theme='graphite'] {
+  color-scheme: dark;
+
   --bg: 31 32 32;
   --bg-subtle: 43 45 45;
   --bg-muted: 60 62 62;
@@ -82,6 +90,8 @@
 }
 
 :root[data-theme='high-contrast'] {
+  color-scheme: dark;
+
   --bg: 0 0 0;
   --bg-subtle: 16 16 16;
   --bg-muted: 38 38 38;
@@ -112,6 +122,12 @@ body {
   color: rgb(var(--fg));
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+select,
+option {
+  background-color: rgb(var(--bg));
+  color: rgb(var(--fg));
 }
 
 .app-drag {


### PR DESCRIPTION
## Summary
- harden the Database saved-view menu with outside-click/Escape close, pending states, disabled invalid actions, and toast errors
- de-duplicate saved-view updates when database view change events race duplicate responses
- improve Database dropdown focus/contrast and native select color-scheme handling across themes
- update README and changelog for the shipped Database view polish

## Test plan
- pnpm --filter ziba-desktop test src/components/DatabaseView/index.test.tsx src/components/DatabaseView/ColumnPicker.test.tsx src/components/DatabaseView/TypeFilterDropdown.test.tsx
- pnpm typecheck && pnpm lint && pnpm format:check && pnpm test && pnpm build

## Notes
- One full combined gate initially hit unrelated transient timeouts in search/tags store tests; both files passed in isolation, and the full test command passed on rerun.