### PR TITLE
feat(graph): monochrome default + unresolved phantom nodes (Obsidian-like)

### DIFF
--- a/apps/desktop/electron/adapters/index-store.sqlite.test.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.test.ts
@@ -4,8 +4,10 @@ import {
   EXPECTED_USER_VERSION,
   MENTION_EDGE_KIND,
   mergeMentionEdges,
+  mergeUnresolvedNodes,
   PRAGMAS,
   SCHEMA_SQL,
+  unresolvedNodeId,
   type GraphEdge,
   type MentionEdge,
 } from '@ziba/core';
@@ -277,5 +279,60 @@ describe('soft references — FTS mention detection + dedupe', () => {
         kind: MENTION_EDGE_KIND,
       },
     ]);
+  });
+});
+
+describe('graph broken links — unresolved phantom derivation', () => {
+  // Mirrors SqliteIndexStore.graphBrokenLinks: relations with a null
+  // target_path are the broken wikilinks that become gray phantom nodes.
+  function selectBrokenLinks(): Array<{ source: string; targetTitle: string }> {
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT r.source_path AS source, r.target_title AS target_title
+         FROM relations r
+         WHERE r.target_path IS NULL
+           AND r.target_title IS NOT NULL
+           AND TRIM(r.target_title) <> ''`,
+      )
+      .all() as Array<{ source: string; target_title: string }>;
+    return rows.map((r) => ({ source: r.source, targetTitle: r.target_title }));
+  }
+
+  it('surfaces a [[X]] with no backing file as a broken link; a resolved one is excluded', () => {
+    setupNote('a.md');
+    setupNote('b.md');
+    // Resolved wikilink (target_path set) → NOT a broken link.
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, '', 'B', 'b.md')`,
+    ).run('a.md');
+    // Broken wikilink (target_path NULL) → IS a broken link.
+    db.prepare(
+      `INSERT INTO relations (source_path, kind, target_title, target_path)
+       VALUES (?, '', 'Concept', NULL)`,
+    ).run('a.md');
+
+    const broken = selectBrokenLinks();
+    expect(broken).toEqual([{ source: 'a.md', targetTitle: 'Concept' }]);
+
+    // End-to-end: folding through the pure core helper yields one phantom
+    // node + its incoming edge, and leaves the resolved target alone.
+    const graph = {
+      nodes: [
+        { path: 'a.md', title: 'A', type: null, color: null },
+        { path: 'b.md', title: 'B', type: null, color: null },
+      ],
+      edges: [{ source: 'a.md', target: 'b.md', targetTitle: 'B', kind: '' }],
+    };
+    const out = mergeUnresolvedNodes(graph, broken);
+    const phantom = out.nodes.find((n) => n.unresolved === true);
+    expect(phantom?.path).toBe(unresolvedNodeId('Concept'));
+    expect(phantom?.title).toBe('Concept');
+    expect(out.edges).toContainEqual({
+      source: 'a.md',
+      target: unresolvedNodeId('Concept'),
+      targetTitle: 'Concept',
+      kind: '',
+    });
   });
 });

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -15,6 +15,7 @@ import {
   SCHEMA_SQL,
   EXPECTED_USER_VERSION,
   MIGRATION_DROP_SQL,
+  type BrokenLink,
   type DatabaseGroup,
   type DatabaseQuery,
   type DatabaseResult,
@@ -137,6 +138,7 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     listObjectTypes: Database.Statement;
     getTypeCounts: Database.Statement;
     getTypedPaths: Database.Statement;
+    graphBrokenLinks: Database.Statement;
   } | null = null;
 
   async init(vaultRoot: string): Promise<void> {
@@ -333,6 +335,18 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         FROM relations r
         JOIN notes n ON n.path = r.target_path
         WHERE r.target_path IS NOT NULL
+      `),
+      // Broken outgoing wikilinks: relations whose target_title resolves
+      // to no note (target_path IS NULL). Powers the global graph's gray
+      // "unresolved" phantom nodes. DISTINCT so a note linking the same
+      // missing target twice contributes a single row; the pure
+      // `mergeUnresolvedNodes` step dedupes phantom nodes across sources.
+      graphBrokenLinks: db.prepare(`
+        SELECT DISTINCT r.source_path AS source, r.target_title AS target_title
+        FROM relations r
+        WHERE r.target_path IS NULL
+          AND r.target_title IS NOT NULL
+          AND TRIM(r.target_title) <> ''
       `),
       upsertObjectType: db.prepare(`
         INSERT INTO object_types (id, label, icon, color, schema_json, mtime)
@@ -898,6 +912,13 @@ export class SqliteIndexStore implements IndexStoreAdapter {
       kind: r.kind,
     }));
     return Promise.resolve({ nodes, edges });
+  }
+
+  async getBrokenLinks(): Promise<BrokenLink[]> {
+    const s = this.require();
+    type R = { source: string; target_title: string };
+    const rows = s.graphBrokenLinks.all() as R[];
+    return Promise.resolve(rows.map((r) => ({ source: r.source, targetTitle: r.target_title })));
   }
 
   async getMentionEdges(perTargetLimit: number, totalLimit: number): Promise<MentionEdge[]> {

--- a/apps/desktop/electron/ipc/file-actions.test.ts
+++ b/apps/desktop/electron/ipc/file-actions.test.ts
@@ -38,6 +38,7 @@ function makeIndexStore(): IndexStoreAdapter {
     runQuery: async () => ({ rows: [], groups: [], totalCount: 0 }),
     getFullGraph: async () => ({ nodes: [], edges: [] }),
     getMentionEdges: async () => [],
+    getBrokenLinks: async () => [],
     replaceRelations: async () => undefined,
     getRelations: async () => [],
     getReverseRelations: async () => [],

--- a/apps/desktop/electron/ipc/graph.ts
+++ b/apps/desktop/electron/ipc/graph.ts
@@ -6,7 +6,7 @@
 // them dashed/dimmed like Obsidian. Wave 2's global graph view reads this
 // once on mount and re-fetches when the index reports a rebuild.
 
-import { mergeMentionEdges, type FullGraph } from '@ziba/core';
+import { mergeMentionEdges, mergeUnresolvedNodes, type FullGraph } from '@ziba/core';
 import { requireIndexStore } from '../state.js';
 
 // Per-target FTS cap — mirrors the per-note MENTION_LIMIT used by
@@ -29,16 +29,28 @@ export async function getFullGraph(): Promise<FullGraph> {
   const store = requireIndexStore();
   const graph = await store.getFullGraph();
 
-  // Skip the (potentially expensive) mention pass on large vaults.
+  // Skip the (potentially expensive) augmentation passes on large vaults:
+  // both the FTS mention scan and the extra phantom nodes/edges are
+  // "nice to have" overlays not worth degrading huge-vault load times.
+  // The renderer already warns past ~1000 nodes (LARGE_GRAPH_WARN).
   if (graph.nodes.length > MENTION_NODE_CEILING) {
     return graph;
   }
 
-  const candidates = await store.getMentionEdges(MENTION_PER_TARGET_LIMIT, MENTION_TOTAL_LIMIT);
-  const knownPaths = new Set(graph.nodes.map((node) => node.path));
-  // Dedupe: explicit links win over mentions for the same pair; drop
-  // self-mentions and dangling endpoints. Pure, unit-tested in core.
-  const edges = mergeMentionEdges(graph.edges, candidates, knownPaths);
+  // Phantom nodes first: broken `[[wikilinks]]` (relations with a null
+  // target_path) become Obsidian-style gray "unresolved" nodes. Reuses
+  // the SAME relation/target-resolution state as the per-note broken-link
+  // detection. Pure merge synthesises the nodes + their incoming edges.
+  const brokenLinks = await store.getBrokenLinks();
+  const withUnresolved = mergeUnresolvedNodes(graph, brokenLinks);
 
-  return { nodes: graph.nodes, edges };
+  const candidates = await store.getMentionEdges(MENTION_PER_TARGET_LIMIT, MENTION_TOTAL_LIMIT);
+  // Mentions only connect real notes — `knownPaths` is the set of REAL
+  // node paths (phantom ids are excluded), so a mention never lands on an
+  // unresolved node. Dedupe: explicit links win over mentions for a pair;
+  // drop self-mentions and dangling endpoints. Pure, unit-tested in core.
+  const knownPaths = new Set(graph.nodes.map((node) => node.path));
+  const edges = mergeMentionEdges(withUnresolved.edges, candidates, knownPaths);
+
+  return { nodes: withUnresolved.nodes, edges };
 }

--- a/apps/desktop/electron/ipc/links.test.ts
+++ b/apps/desktop/electron/ipc/links.test.ts
@@ -45,6 +45,7 @@ function makeIndexStore(): IndexStoreAdapter & {
     runQuery: async () => ({ rows: [], groups: [], totalCount: 0 }),
     getFullGraph: async () => ({ nodes: [], edges: [] }),
     getMentionEdges: async () => [],
+    getBrokenLinks: async () => [],
     replaceRelations: async () => undefined,
     getRelations: async () => [],
     getReverseRelations: async () => [],

--- a/apps/desktop/src/components/GlobalGraph/Canvas.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Canvas.tsx
@@ -34,8 +34,18 @@ export type CanvasNode = {
   degree: number;
   /** v1.0 Phase 5: type slug (null = untyped). */
   type: string | null;
-  /** v1.0 Phase 5: hex color from the type's schema; canvas tints the fill. */
+  /**
+   * Group color (monochrome redesign): hex from a matching user-defined
+   * group rule, or null. When null the node uses the structural node
+   * fill. Type-schema colors NO LONGER feed this — only group rules do.
+   */
   color: string | null;
+  /**
+   * Graph monochrome redesign: true for unresolved phantom nodes
+   * (wikilink targets with no backing file). Rendered gray + dimmer,
+   * smaller (radius set by the parent), and never group-colored.
+   */
+  unresolved?: boolean;
 };
 
 export type CanvasEdge = {
@@ -464,8 +474,9 @@ export const Canvas = memo(
           {showNodes && (
             <g>
               {nodes.map((n) => {
-                const isSelected = selectedId === n.id;
-                const isHovered = hoveredId === n.id;
+                const isUnresolved = n.unresolved === true;
+                const isSelected = !isUnresolved && selectedId === n.id;
+                const isHovered = !isUnresolved && hoveredId === n.id;
                 const isActive = activeId === n.id;
                 const isNeighbor = activeNeighborIds.has(n.id);
                 const matchesFilter = !isFiltered || matchedIds.has(n.id);
@@ -480,16 +491,44 @@ export const Canvas = memo(
                   (hasInteraction && !isActive && !isNeighbor && !isSelected) ||
                   (isFiltered && !matchesFilter) ||
                   !isHighlightedByType;
-                const opacity = dim ? dimOpacity : FULL_OPACITY;
+                // Unresolved nodes always render in the muted gray, and sit
+                // a touch dimmer than real notes even when "lit" so the
+                // hierarchy (real note > phantom) is unmistakable.
+                const opacity = dim
+                  ? dimOpacity
+                  : isUnresolved
+                    ? Math.max(dimOpacity, 0.7)
+                    : FULL_OPACITY;
                 const labelEligible = showText && showLabels && n.degree >= labelDegreeThreshold;
                 const showNodeLabel =
                   showText && (labelEligible || isSelected || isActive || isNeighbor);
                 const radius = Math.max(2.4, n.r * radiusScale);
+                // Phantom nodes are gray regardless of focus/group state.
+                const fill = isUnresolved
+                  ? NODE_FILL_DIM
+                  : dim
+                    ? NODE_FILL_DIM
+                    : isSelected
+                      ? NODE_SELECTED
+                      : n.color !== null
+                        ? n.color
+                        : NODE_FILL;
+                const stroke = isUnresolved
+                  ? NODE_STROKE_DIM
+                  : dim
+                    ? NODE_STROKE_DIM
+                    : isSelected
+                      ? NODE_SELECTED_STROKE
+                      : isHovered
+                        ? HOVER_NODE_STROKE
+                        : NODE_STROKE;
                 return (
                   <g
                     key={n.id}
+                    data-graph-node={n.id}
+                    data-graph-node-unresolved={isUnresolved ? 'true' : undefined}
                     transform={`translate(${n.x},${n.y})`}
-                    className="graph-fade cursor-pointer"
+                    className={`graph-fade ${isUnresolved ? 'cursor-default' : 'cursor-pointer'}`}
                     onClick={(e): void => handleNodeClick(e, n.id)}
                     onDoubleClick={(e): void => handleNodeDoubleClick(e, n.id)}
                     onMouseDown={handleNodeMouseDown}
@@ -521,24 +560,8 @@ export const Canvas = memo(
                     )}
                     <circle
                       r={radius}
-                      fill={
-                        dim
-                          ? NODE_FILL_DIM
-                          : isSelected
-                            ? NODE_SELECTED
-                            : n.color !== null
-                              ? n.color
-                              : NODE_FILL
-                      }
-                      stroke={
-                        dim
-                          ? NODE_STROKE_DIM
-                          : isSelected
-                            ? NODE_SELECTED_STROKE
-                            : isHovered
-                              ? HOVER_NODE_STROKE
-                              : NODE_STROKE
-                      }
+                      fill={fill}
+                      stroke={stroke}
                       strokeWidth={isSelected || isHovered ? 1.8 : 0.9}
                     />
                     {showNodeLabel && (

--- a/apps/desktop/src/components/GlobalGraph/Legend.tsx
+++ b/apps/desktop/src/components/GlobalGraph/Legend.tsx
@@ -1,48 +1,88 @@
 import type { JSX } from 'react';
 import { kindToHsl } from '../../lib/kind-color';
 
+export type LegendGroup = { id: string; label: string; color: string };
+
 type Props = {
-  /** Types currently visible / active in the graph (chips selected → just the one). */
-  visibleTypes: ReadonlyArray<{ id: string; label: string; color: string | null }>;
+  /**
+   * Active user-defined graph groups (query → color). The ONLY source of
+   * node color in the monochrome redesign. Empty → the groups section is
+   * omitted.
+   */
+  groups: ReadonlyArray<LegendGroup>;
+  /** When true, the legend shows the gray "unresolved" phantom-node entry. */
+  hasUnresolved: boolean;
   /** Active relation kinds. Empty array → legend omits the kinds section. */
   visibleKinds: ReadonlyArray<string>;
-  /** When true, the legend shows a soft-reference (mention) entry. */
+  /** When true, the legend shows a soft-reference (mention) edge entry. */
   showMentions: boolean;
 };
 
 /**
- * Top-right floating panel that maps colors to types + relation kinds.
- * Hidden entirely when there's nothing to legend (no types AND no
- * kinds visible).
+ * Top-right floating panel describing the graph's visual language under
+ * the monochrome model:
+ *   - "Nota": real notes render in the bright structural node color.
+ *   - "Non risolte": wikilink targets with no file render gray.
+ *   - then any active group colors (the sole source of node tinting),
+ *   - then relation kinds / soft references for edges.
+ *
+ * The per-type color legend is intentionally gone: types no longer
+ * auto-tint nodes.
  */
-export function Legend({ visibleTypes, visibleKinds, showMentions }: Props): JSX.Element | null {
-  if (visibleTypes.length === 0 && visibleKinds.length === 0 && !showMentions) return null;
+export function Legend({ groups, hasUnresolved, visibleKinds, showMentions }: Props): JSX.Element {
   return (
     <div
       aria-label="Legenda"
       className="pointer-events-none absolute right-4 top-16 z-10 max-w-[200px] rounded-lg border border-graph-edge bg-graph-bg/86 p-2 text-xs text-graph-text shadow-lg shadow-black/20 backdrop-blur"
     >
-      {visibleTypes.length > 0 && (
-        <div>
+      <div>
+        <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-graph-text-muted">
+          Nodi
+        </p>
+        <ul className="flex flex-col gap-0.5">
+          <li className="flex items-center gap-2">
+            <span
+              aria-hidden="true"
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ background: 'rgb(var(--graph-node))' }}
+            />
+            <span className="truncate">Nota</span>
+          </li>
+          {hasUnresolved && (
+            <li className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="inline-block h-2 w-2 shrink-0 rounded-full"
+                style={{ background: 'rgb(var(--graph-node-muted))' }}
+              />
+              <span className="truncate">Non risolte</span>
+            </li>
+          )}
+        </ul>
+      </div>
+
+      {groups.length > 0 && (
+        <div className="mt-2">
           <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-graph-text-muted">
-            Tipi
+            Gruppi
           </p>
           <ul className="flex flex-col gap-0.5">
-            {visibleTypes.map((t) => (
-              <li key={t.id} className="flex items-center gap-2">
+            {groups.map((g) => (
+              <li key={g.id} className="flex items-center gap-2">
                 <span
                   aria-hidden="true"
                   className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ background: t.color ?? 'rgb(99, 102, 241)' }}
+                  style={{ background: g.color }}
                 />
-                <span className="truncate">{t.label}</span>
+                <span className="truncate">{g.label}</span>
               </li>
             ))}
           </ul>
         </div>
       )}
+
       {visibleKinds.length > 0 && (
-        <div className={visibleTypes.length > 0 ? 'mt-2' : ''}>
+        <div className="mt-2">
           <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-graph-text-muted">
             Relazioni
           </p>
@@ -60,8 +100,9 @@ export function Legend({ visibleTypes, visibleKinds, showMentions }: Props): JSX
           </ul>
         </div>
       )}
+
       {showMentions && (
-        <div className={visibleTypes.length > 0 || visibleKinds.length > 0 ? 'mt-2' : ''}>
+        <div className="mt-2">
           <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-graph-text-muted">
             Riferimenti
           </p>

--- a/apps/desktop/src/components/GlobalGraph/index.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.test.tsx
@@ -75,4 +75,83 @@ describe('<GlobalGraph>', () => {
     });
     expect(screen.getByRole('tab', { name: 'Locale' })).toHaveAttribute('aria-pressed', 'true');
   });
+
+  it('does NOT tint a node from its type-schema color (monochrome default)', async () => {
+    const { container } = render(<GlobalGraph />);
+    await waitFor(() => expect(screen.getByText(/4 nodi/)).toBeInTheDocument());
+
+    // Beta carries a type-schema color (#14b8a6) on the wire, but the
+    // monochrome model must NOT use it to tint the node.
+    const beta = container.querySelector('[data-graph-node="Projects/B.md"] circle');
+    expect(beta).not.toBeNull();
+    expect(beta?.getAttribute('fill')).not.toBe('#14b8a6');
+  });
+
+  it('tints a node ONLY from a matching user-defined group rule', async () => {
+    useGraphSettingsStore.setState((prev) => ({
+      ...prev,
+      // Match the mounted vault root so the component's setVaultRoot effect
+      // bails instead of reloading (and re-seeding) persisted settings,
+      // which would clobber the group we set here.
+      vaultRoot: '/vault-a',
+      settings: {
+        ...prev.settings,
+        // groupsSeeded: true keeps the auto folder-group seeding from
+        // injecting competing groups, isolating this assertion to our rule.
+        groupsSeeded: true,
+        groups: [
+          { id: 'g1', name: 'Progetti', query: 'path:Projects', color: '#abcdef', enabled: true },
+        ],
+      },
+    }));
+
+    const { container } = render(<GlobalGraph />);
+    await waitFor(() => expect(screen.getByText(/4 nodi/)).toBeInTheDocument());
+
+    // Beta is in Projects/ → group color applies.
+    const beta = container.querySelector('[data-graph-node="Projects/B.md"] circle');
+    expect(beta?.getAttribute('fill')).toBe('#abcdef');
+    // Alpha is NOT in Projects/ → stays the structural (non-group) fill.
+    const alpha = container.querySelector('[data-graph-node="Inbox/A.md"] circle');
+    expect(alpha?.getAttribute('fill')).not.toBe('#abcdef');
+  });
+});
+
+describe('<GlobalGraph> — unresolved phantom nodes', () => {
+  beforeEach(() => {
+    mock.setHandler(IpcChannels.getFullGraph, async () => ({
+      nodes: [
+        { path: 'Inbox/A.md', title: 'Alpha', type: null, color: null },
+        // Synthetic unresolved node, as produced by the IPC layer's
+        // mergeUnresolvedNodes for a broken [[Missing]] wikilink.
+        {
+          path: 'unresolved:missing',
+          title: 'Missing',
+          type: null,
+          color: null,
+          unresolved: true,
+        },
+      ],
+      edges: [
+        {
+          source: 'Inbox/A.md',
+          target: 'unresolved:missing',
+          targetTitle: 'Missing',
+          kind: '',
+        },
+      ],
+    }));
+  });
+
+  it('renders the phantom node flagged as unresolved (gray, non-interactive)', async () => {
+    const { container } = render(<GlobalGraph />);
+    await waitFor(() => expect(screen.getByText(/2 nodi/)).toBeInTheDocument());
+
+    const phantom = container.querySelector('[data-graph-node="unresolved:missing"]');
+    expect(phantom).not.toBeNull();
+    expect(phantom?.getAttribute('data-graph-node-unresolved')).toBe('true');
+
+    const real = container.querySelector('[data-graph-node="Inbox/A.md"]');
+    expect(real?.getAttribute('data-graph-node-unresolved')).toBeNull();
+  });
 });

--- a/apps/desktop/src/components/GlobalGraph/index.test.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.test.tsx
@@ -91,14 +91,11 @@ describe('<GlobalGraph>', () => {
     useGraphSettingsStore.setState((prev) => ({
       ...prev,
       // Match the mounted vault root so the component's setVaultRoot effect
-      // bails instead of reloading (and re-seeding) persisted settings,
-      // which would clobber the group we set here.
+      // bails instead of reloading persisted settings, which would clobber
+      // the group we set here.
       vaultRoot: '/vault-a',
       settings: {
         ...prev.settings,
-        // groupsSeeded: true keeps the auto folder-group seeding from
-        // injecting competing groups, isolating this assertion to our rule.
-        groupsSeeded: true,
         groups: [
           { id: 'g1', name: 'Progetti', query: 'path:Projects', color: '#abcdef', enabled: true },
         ],

--- a/apps/desktop/src/components/GlobalGraph/index.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.tsx
@@ -125,7 +125,6 @@ export function GlobalGraph(): JSX.Element {
   const addGraphGroup = useGraphSettingsStore((s) => s.addGroup);
   const updateGraphGroup = useGraphSettingsStore((s) => s.updateGroup);
   const removeGraphGroup = useGraphSettingsStore((s) => s.removeGroup);
-  const seedGraphGroups = useGraphSettingsStore((s) => s.seedGroupsFromTopLevelFolders);
   const resetGraphSettings = useGraphSettingsStore((s) => s.resetSettings);
   const search = graphSettings.query.search;
   const selectedType = graphSettings.query.types[0] ?? null;
@@ -183,15 +182,6 @@ export function GlobalGraph(): JSX.Element {
   useEffect(() => {
     setGraphSettingsVaultRoot(currentVaultRoot);
   }, [currentVaultRoot, setGraphSettingsVaultRoot]);
-
-  useEffect(() => {
-    if (load.kind !== 'ready') return;
-    // Exclude synthetic unresolved nodes: their ids aren't real paths and
-    // would seed bogus top-level "folder" groups.
-    seedGraphGroups(
-      load.graph.nodes.filter((node) => node.unresolved !== true).map((node) => node.path),
-    );
-  }, [load, seedGraphGroups]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/apps/desktop/src/components/GlobalGraph/index.tsx
+++ b/apps/desktop/src/components/GlobalGraph/index.tsx
@@ -13,7 +13,7 @@ import {
   Plus,
   X,
 } from '@phosphor-icons/react';
-import { MENTION_EDGE_KIND, type NotePath } from '@ziba/core';
+import { MENTION_EDGE_KIND, UNRESOLVED_NODE_PREFIX, type NotePath } from '@ziba/core';
 import type { FullGraph } from '../../../shared/ipc';
 import { ipc } from '../../lib/ipc';
 import { ipcErrorMessage } from '../../lib/ipc-error';
@@ -31,7 +31,7 @@ import {
 import { computeBounds, initializePositions, runGlobalLayout } from './layout';
 import { TypeChips, type TypeChip } from './TypeChips';
 import { KindFilterDropdown } from './KindFilterDropdown';
-import { Legend } from './Legend';
+import { Legend, type LegendGroup } from './Legend';
 import { useTagsStore } from '../../stores/tags';
 import { useVaultStore } from '../../stores/vault';
 import { useGraphSettingsStore } from '../../stores/graph';
@@ -64,6 +64,10 @@ import { useCameraTween } from '../../lib/graph-camera';
 
 const NODE_R_MIN = 3;
 const NODE_R_MAX = 18;
+// Unresolved phantom nodes render at a fraction of a real note's
+// degree-scaled radius so they read as subordinate "missing concept"
+// discs (Obsidian).
+const UNRESOLVED_RADIUS_SCALE = 0.62;
 
 const ZOOM_STEP = 1.25;
 
@@ -182,7 +186,11 @@ export function GlobalGraph(): JSX.Element {
 
   useEffect(() => {
     if (load.kind !== 'ready') return;
-    seedGraphGroups(load.graph.nodes.map((node) => node.path));
+    // Exclude synthetic unresolved nodes: their ids aren't real paths and
+    // would seed bogus top-level "folder" groups.
+    seedGraphGroups(
+      load.graph.nodes.filter((node) => node.unresolved !== true).map((node) => node.path),
+    );
   }, [load, seedGraphGroups]);
 
   useEffect(() => {
@@ -347,17 +355,33 @@ export function GlobalGraph(): JSX.Element {
   const canvasNodes = useMemo<CanvasNode[]>(() => {
     if (layout === null) return [];
     const maxDegree = Array.from(degreeMap.values()).reduce((acc, v) => (v > acc ? v : acc), 0);
-    const nodeMeta = new Map<NotePath, { type: string | null; color: string | null }>();
+    const nodeMeta = new Map<
+      NotePath,
+      { type: string | null; color: string | null; unresolved: boolean }
+    >();
     for (const n of visibleGraph.nodes) {
       nodeMeta.set(n.path, {
         type: n.type,
-        color: groupColorForNode(n, graphSettings.groups) ?? n.color,
+        // Monochrome redesign: node color comes ONLY from user-defined
+        // group rules. The type-schema color (`n.color`) no longer tints
+        // the node — that produced "too many colors". Phantom (unresolved)
+        // nodes are forced gray and must never take a group color, so we
+        // skip the group lookup for them entirely.
+        color: n.unresolved === true ? null : groupColorForNode(n, graphSettings.groups),
+        unresolved: n.unresolved === true,
       });
     }
     return layout.map((p) => {
       const degree = degreeMap.get(p.id) ?? 0;
-      const r = scaleRadius(degree, maxDegree);
       const meta = nodeMeta.get(p.id);
+      const unresolved = meta?.unresolved ?? false;
+      // Unresolved nodes read as smaller, dimmer "concept without a note"
+      // discs (Obsidian). We shrink their degree-scaled radius so they're
+      // visibly subordinate to real notes even when several links point
+      // at the same missing concept.
+      const r = unresolved
+        ? Math.max(NODE_R_MIN * 0.6, scaleRadius(degree, maxDegree) * UNRESOLVED_RADIUS_SCALE)
+        : scaleRadius(degree, maxDegree);
       return {
         id: p.id,
         x: p.x,
@@ -367,6 +391,7 @@ export function GlobalGraph(): JSX.Element {
         title: titleMap.get(p.id) ?? p.id,
         type: meta?.type ?? null,
         color: meta?.color ?? null,
+        unresolved,
       };
     });
   }, [layout, degreeMap, titleMap, visibleGraph, graphSettings.groups]);
@@ -387,14 +412,28 @@ export function GlobalGraph(): JSX.Element {
     return set ?? EMPTY_SET;
   }, [selectedId, adjacency]);
 
-  // Legend data: when a type chip is active show only that type; otherwise all.
-  const legendTypes = useMemo(() => {
-    if (selectedType === null)
-      return typeChips.map((t) => ({ id: t.id, label: t.label, color: t.color }));
-    const active = typeChips.find((t) => t.id === selectedType);
-    if (active === undefined) return [];
-    return [{ id: active.id, label: active.label, color: active.color }];
-  }, [typeChips, selectedType]);
+  // Legend groups: the active user-defined group rules — the ONLY source
+  // of node color in the monochrome model. We only legend groups that can
+  // actually tint a currently-visible node, so the legend doesn't claim a
+  // color that never appears.
+  const legendGroups = useMemo<LegendGroup[]>(() => {
+    const active = graphSettings.groups.filter((g) => g.enabled);
+    if (active.length === 0) return [];
+    return active
+      .filter((g) =>
+        visibleGraph.nodes.some(
+          (n) => n.unresolved !== true && graphGroupQueryMatchesNode(n, g.query),
+        ),
+      )
+      .map((g) => ({ id: g.id, label: g.name, color: g.color }));
+  }, [graphSettings.groups, visibleGraph]);
+
+  // Whether any unresolved phantom node is currently visible → drives the
+  // gray "Non risolte" legend entry.
+  const hasUnresolved = useMemo<boolean>(
+    () => visibleGraph.nodes.some((n) => n.unresolved === true),
+    [visibleGraph],
+  );
 
   const legendKinds = useMemo(() => {
     if (selectedKinds.size === 0) return [];
@@ -703,6 +742,10 @@ export function GlobalGraph(): JSX.Element {
 
   const handleNodeClick = useCallback(
     (id: NotePath): void => {
+      // Unresolved phantom nodes are not real notes: no selection, no
+      // local-root pivot. Clicking is a deliberate no-op for now (a
+      // future iteration may create+open the missing note Obsidian-style).
+      if (isUnresolvedId(id)) return;
       if (graphScope === 'local') {
         setLocalRootId(id);
         setSelectedId(id);
@@ -715,6 +758,9 @@ export function GlobalGraph(): JSX.Element {
   );
 
   const handleNodeDoubleClick = useCallback((id: NotePath): void => {
+    // No backing file for unresolved phantom nodes — opening would 404.
+    // No-op until create-on-click lands.
+    if (isUnresolvedId(id)) return;
     // Sync the live transform back into React state before opening
     // the editor — otherwise on next mount the canvas would snap
     // back to the last React-tracked view.
@@ -1001,7 +1047,8 @@ export function GlobalGraph(): JSX.Element {
         )}
         {load.kind === 'ready' && nodeCount > 0 && (
           <Legend
-            visibleTypes={legendTypes}
+            groups={legendGroups}
+            hasUnresolved={hasUnresolved}
             visibleKinds={legendKinds}
             showMentions={hasMentionEdges && graphSettings.query.showMentions}
           />
@@ -1010,7 +1057,11 @@ export function GlobalGraph(): JSX.Element {
           <NodeDetailPanel
             node={selectedNode}
             connections={selectedConnections}
-            onSelectConnection={setSelectedId}
+            onSelectConnection={(id): void => {
+              // Don't pivot selection onto a phantom (no backing note).
+              if (isUnresolvedId(id)) return;
+              setSelectedId(id);
+            }}
             onOpen={(): void => {
               void navigateToNote(selectedNode.id);
             }}
@@ -1036,6 +1087,11 @@ function clamp(n: number, lo: number, hi: number): number {
   if (n < lo) return lo;
   if (n > hi) return hi;
   return n;
+}
+
+/** True for synthetic ids of unresolved (phantom) graph nodes. */
+function isUnresolvedId(id: string): boolean {
+  return id.startsWith(UNRESOLVED_NODE_PREFIX);
 }
 
 function isKeyboardInputTarget(target: EventTarget | null): boolean {

--- a/apps/desktop/src/components/MiniGraph/index.tsx
+++ b/apps/desktop/src/components/MiniGraph/index.tsx
@@ -308,7 +308,10 @@ export function MiniGraph({ currentPath, onLoadingChange }: Props): JSX.Element 
                   y2={y2}
                   stroke={
                     isBroken
-                      ? 'rgb(239 68 68 / 0.5)'
+                      ? // Gray (not red): agrees with the global graph's
+                        // unresolved phantom nodes. Dashed keeps the
+                        // "missing target" affordance.
+                        'rgb(var(--graph-node-muted) / 0.7)'
                       : isInbound
                         ? 'rgb(var(--accent))'
                         : isMention
@@ -339,10 +342,12 @@ export function MiniGraph({ currentPath, onLoadingChange }: Props): JSX.Element 
               const isInbound = node.kind === 'inbound';
               const isMention = node.kind === 'mention';
               const r = isSelf ? SELF_R : NODE_R;
+              // Unresolved (broken) nodes are gray to match the global
+              // graph's phantom nodes — no longer red.
               const fill = isSelf
                 ? 'rgb(var(--accent))'
                 : isBroken
-                  ? 'rgb(239 68 68 / 0.12)'
+                  ? 'rgb(var(--graph-node-muted) / 0.18)'
                   : isInbound
                     ? 'rgb(var(--accent) / 0.15)'
                     : isMention
@@ -351,7 +356,7 @@ export function MiniGraph({ currentPath, onLoadingChange }: Props): JSX.Element 
               const stroke = isSelf
                 ? 'rgb(var(--accent))'
                 : isBroken
-                  ? 'rgb(239 68 68 / 0.6)'
+                  ? 'rgb(var(--graph-node-muted) / 0.75)'
                   : isInbound
                     ? 'rgb(var(--accent))'
                     : isMention

--- a/apps/desktop/src/lib/graph-groups.test.ts
+++ b/apps/desktop/src/lib/graph-groups.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  AUTO_GRAPH_GROUP_COLORS,
-  buildAutoGraphGroupsFromFolders,
-  graphGroupQueryMatchesNode,
-  parseGraphGroupQuery,
-} from './graph-groups';
+import { graphGroupQueryMatchesNode, parseGraphGroupQuery } from './graph-groups';
 
 describe('graph group query parser', () => {
   it('parses plain, typed, file, path, folder, quoted, and OR tokens', () => {
@@ -74,83 +69,5 @@ describe('graph group query parser', () => {
         'file:projects',
       ),
     ).toBe(false);
-  });
-});
-
-describe('automatic graph groups', () => {
-  it('builds at most six persistent path queries from top-level folders', () => {
-    const groups = buildAutoGraphGroupsFromFolders([
-      'Projects',
-      'Projects/Archive',
-      'People',
-      'Areas',
-      'Resources',
-      'Archive',
-      'Daily Notes',
-      'Extras',
-      'Loose.md',
-    ]);
-
-    expect(groups).toEqual([
-      {
-        id: 'auto-folder-projects',
-        name: 'Projects',
-        query: 'path:"Projects"',
-        color: AUTO_GRAPH_GROUP_COLORS[0],
-        enabled: true,
-      },
-      {
-        id: 'auto-folder-people',
-        name: 'People',
-        query: 'path:"People"',
-        color: AUTO_GRAPH_GROUP_COLORS[1],
-        enabled: true,
-      },
-      {
-        id: 'auto-folder-areas',
-        name: 'Areas',
-        query: 'path:"Areas"',
-        color: AUTO_GRAPH_GROUP_COLORS[2],
-        enabled: true,
-      },
-      {
-        id: 'auto-folder-resources',
-        name: 'Resources',
-        query: 'path:"Resources"',
-        color: AUTO_GRAPH_GROUP_COLORS[3],
-        enabled: true,
-      },
-      {
-        id: 'auto-folder-archive',
-        name: 'Archive',
-        query: 'path:"Archive"',
-        color: AUTO_GRAPH_GROUP_COLORS[4],
-        enabled: true,
-      },
-      {
-        id: 'auto-folder-daily-notes',
-        name: 'Daily Notes',
-        query: 'path:"Daily Notes"',
-        color: AUTO_GRAPH_GROUP_COLORS[5],
-        enabled: true,
-      },
-    ]);
-    expect(groups.map((group) => group.color)).not.toContain('#14b8a6');
-  });
-
-  it('quotes generated folder queries so folders with punctuation remain parseable', () => {
-    const [group] = buildAutoGraphGroupsFromFolders(['Team "A"/Notes']);
-
-    expect(group).toMatchObject({
-      id: 'auto-folder-team-a',
-      name: 'Team "A"',
-      query: 'path:"Team \\"A\\""',
-    });
-    expect(
-      graphGroupQueryMatchesNode(
-        { path: 'Team "A"/Notes.md', title: 'Notes', type: null },
-        group?.query ?? '',
-      ),
-    ).toBe(true);
   });
 });

--- a/apps/desktop/src/lib/graph-groups.ts
+++ b/apps/desktop/src/lib/graph-groups.ts
@@ -1,5 +1,3 @@
-import type { GraphGroupRule } from './graph-settings';
-
 export type GraphGroupQueryToken =
   | { kind: 'plain'; value: string }
   | { kind: 'type'; value: string }
@@ -16,19 +14,6 @@ export type GraphGroupMatchNode = {
   title: string;
   type: string | null;
 };
-
-export const AUTO_GRAPH_GROUP_LIMIT = 6;
-
-// Muted defaults for automatic folder groups. Green is intentionally absent so
-// semantic/manual green choices keep their visual meaning.
-export const AUTO_GRAPH_GROUP_COLORS = [
-  '#64748b',
-  '#6366f1',
-  '#8b5cf6',
-  '#d97706',
-  '#dc2626',
-  '#2563eb',
-] as const;
 
 type ScannedToken = {
   raw: string;
@@ -164,66 +149,4 @@ export function graphGroupQueryMatchesNode(
   const parsed = typeof query === 'string' ? parseGraphGroupQuery(query) : query;
   if (parsed.clauses.length === 0) return false;
   return parsed.clauses.some((clause) => clause.every((token) => tokenMatchesNode(node, token)));
-}
-
-function topLevelFolder(path: string): string | null {
-  const normalized = path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
-  if (normalized === '') return null;
-
-  const first = normalized.split('/')[0]?.trim() ?? '';
-  if (first === '') return null;
-  if (!normalized.includes('/') && /\.md$/i.test(first)) return null;
-  return first;
-}
-
-function slugForFolder(folder: string, index: number): string {
-  const slug = folder
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug === '' ? `folder-${index + 1}` : slug;
-}
-
-function quotedQueryValue(value: string): string {
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-}
-
-export function buildAutoGraphGroupsFromFolders(folders: readonly string[]): GraphGroupRule[] {
-  const topLevelFolders: string[] = [];
-  const seenFolders = new Set<string>();
-
-  for (const path of folders) {
-    const folder = topLevelFolder(path);
-    if (folder === null) continue;
-
-    const key = normalizePath(folder);
-    if (seenFolders.has(key)) continue;
-
-    seenFolders.add(key);
-    topLevelFolders.push(folder);
-    if (topLevelFolders.length >= AUTO_GRAPH_GROUP_LIMIT) break;
-  }
-
-  const usedIds = new Set<string>();
-  return topLevelFolders.map((folder, index) => {
-    const baseId = `auto-folder-${slugForFolder(folder, index)}`;
-    let id = baseId;
-    let suffix = 2;
-    while (usedIds.has(id)) {
-      id = `${baseId}-${suffix}`;
-      suffix += 1;
-    }
-    usedIds.add(id);
-
-    return {
-      id,
-      name: folder,
-      query: `path:${quotedQueryValue(folder)}`,
-      color:
-        AUTO_GRAPH_GROUP_COLORS[index % AUTO_GRAPH_GROUP_COLORS.length] ??
-        AUTO_GRAPH_GROUP_COLORS[0],
-      enabled: true,
-    };
-  });
 }

--- a/apps/desktop/src/lib/graph-settings.test.ts
+++ b/apps/desktop/src/lib/graph-settings.test.ts
@@ -47,7 +47,6 @@ describe('graph settings defaults', () => {
       linkOpacity: 0.34,
     });
     expect(DEFAULT_GRAPH_SETTINGS.groups).toEqual([]);
-    expect(DEFAULT_GRAPH_SETTINGS.groupsSeeded).toBe(false);
   });
 });
 
@@ -111,6 +110,8 @@ describe('graph settings storage', () => {
             nodeDistance: Number.NaN,
             linkOpacity: 0.7,
           },
+          // Legacy field from the old auto-seed era — must be tolerated and
+          // dropped, without disturbing the user's persisted groups.
           groupsSeeded: 'yes',
           groups: [
             { id: 'ok', name: 'People', enabled: true, query: 'type:person', color: '#ef4444' },
@@ -152,7 +153,8 @@ describe('graph settings storage', () => {
     expect(settings.groups).toEqual([
       { id: 'ok', name: 'People', enabled: true, query: 'type:person', color: '#ef4444' },
     ]);
-    expect(settings.groupsSeeded).toBe(false);
+    // The legacy `groupsSeeded` key is no longer part of the schema.
+    expect('groupsSeeded' in settings).toBe(false);
   });
 
   it('migrates old persisted settings by filling newly added fields', async () => {
@@ -189,6 +191,5 @@ describe('graph settings storage', () => {
       showGrid: false,
     });
     expect(settings.forces.linkOpacity).toBe(0.32);
-    expect(settings.groupsSeeded).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/graph-settings.ts
+++ b/apps/desktop/src/lib/graph-settings.ts
@@ -52,7 +52,6 @@ export type GraphSettings = {
   display: GraphDisplaySettings;
   forces: GraphForceSettings;
   groups: GraphGroupRule[];
-  groupsSeeded: boolean;
 };
 
 export const GRAPH_SETTINGS_STORAGE_KEY = 'ziba.graph-settings.v1';
@@ -91,8 +90,9 @@ export const DEFAULT_GRAPH_SETTINGS: GraphSettings = {
     nodeDistance: 48,
     linkOpacity: 0.34,
   },
+  // Monochrome by default: no color groups until the user creates one
+  // (matches Obsidian — there is no auto-seeding from folders).
   groups: [],
-  groupsSeeded: false,
 };
 
 const DISPLAY_LIMITS = {
@@ -124,7 +124,6 @@ function cloneDefaults(): GraphSettings {
     display: { ...DEFAULT_GRAPH_SETTINGS.display },
     forces: { ...DEFAULT_GRAPH_SETTINGS.forces },
     groups: [],
-    groupsSeeded: DEFAULT_GRAPH_SETTINGS.groupsSeeded,
   };
 }
 
@@ -266,7 +265,6 @@ export function validateGraphSettings(raw: unknown): GraphSettings {
       ),
     },
     groups,
-    groupsSeeded: bool(raw.groupsSeeded, defaults.groupsSeeded),
   };
 }
 

--- a/apps/desktop/src/stores/graph.test.ts
+++ b/apps/desktop/src/stores/graph.test.ts
@@ -43,7 +43,6 @@ describe('useGraphSettingsStore', () => {
     expect(useGraphSettingsStore.getState().settings.groups).toEqual([
       { id: groupId, name: 'People', query: 'type:person', color: '#14b8a6', enabled: false },
     ]);
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(true);
 
     useGraphSettingsStore.getState().removeGroup(groupId);
     expect(useGraphSettingsStore.getState().settings.groups).toEqual([]);
@@ -53,67 +52,66 @@ describe('useGraphSettingsStore', () => {
     expect(useGraphSettingsStore.getState().settings).toEqual(DEFAULT_GRAPH_SETTINGS);
   });
 
-  it('does not add automatic groups after a manual group has been created', async () => {
+  it('starts monochrome with no groups and never auto-seeds folder groups', async () => {
+    const { DEFAULT_GRAPH_SETTINGS, useGraphSettingsStore } = await loadGraphStore();
+
+    // Default state for a fresh vault: zero color groups (Obsidian-like).
+    expect(DEFAULT_GRAPH_SETTINGS.groups).toEqual([]);
+
+    useGraphSettingsStore.getState().setVaultRoot('/vault-a');
+    expect(useGraphSettingsStore.getState().settings.groups).toEqual([]);
+
+    // No mounting / folder data should ever inject groups: the store has no
+    // seeding action anymore. The graph stays monochrome until the user
+    // creates a group manually.
+    expect(
+      (useGraphSettingsStore.getState() as Record<string, unknown>).seedGroupsFromTopLevelFolders,
+    ).toBeUndefined();
+
+    // Nothing got persisted for this vault yet (no settings changes).
+    const persistedRaw = window.localStorage.getItem(STORAGE_KEY);
+    expect(persistedRaw === null || JSON.parse(persistedRaw)['/vault-a'] === undefined).toBe(true);
+  });
+
+  it('keeps manually-created groups and persists them per vault', async () => {
     const { useGraphSettingsStore } = await loadGraphStore();
 
     useGraphSettingsStore.getState().setVaultRoot('/vault-a');
-    useGraphSettingsStore.getState().addGroup({
-      name: 'Manuale',
-      query: 'type:idea',
-      color: '#64748b',
+    const id = useGraphSettingsStore.getState().addGroup({
+      name: 'Persone',
+      query: 'type:person',
+      color: '#14b8a6',
     });
-    useGraphSettingsStore.getState().seedGroupsFromTopLevelFolders(['Projects', 'People']);
 
-    expect(useGraphSettingsStore.getState().settings.groups.map((group) => group.name)).toEqual([
-      'Manuale',
-    ]);
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(true);
-  });
-
-  it('seeds automatic folder groups once and does not regenerate after deletion', async () => {
-    const { useGraphSettingsStore } = await loadGraphStore();
-
-    useGraphSettingsStore.getState().setVaultRoot('/vault-a');
-    useGraphSettingsStore
-      .getState()
-      .seedGroupsFromTopLevelFolders(['Projects', 'People', 'Areas', 'Resources']);
-
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(true);
-    expect(useGraphSettingsStore.getState().settings.groups.map((group) => group.name)).toEqual([
-      'Projects',
-      'People',
-      'Areas',
-      'Resources',
+    expect(useGraphSettingsStore.getState().settings.groups).toEqual([
+      { id, name: 'Persone', query: 'type:person', color: '#14b8a6', enabled: true },
     ]);
 
-    for (const group of useGraphSettingsStore.getState().settings.groups) {
-      useGraphSettingsStore.getState().removeGroup(group.id);
-    }
-
-    useGraphSettingsStore.getState().seedGroupsFromTopLevelFolders(['Projects', 'People']);
-
-    expect(useGraphSettingsStore.getState().settings.groups).toEqual([]);
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(true);
-
+    // Persisted for /vault-a only.
     const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
-    expect(persisted['/vault-a'].groupsSeeded).toBe(true);
-    expect(persisted['/vault-a'].groups).toEqual([]);
+    expect(persisted['/vault-a'].groups).toEqual([
+      { id, name: 'Persone', query: 'type:person', color: '#14b8a6', enabled: true },
+    ]);
   });
 
-  it('does not burn the automatic seed flag when there are no folders yet', async () => {
+  it('reloads persisted user groups when returning to a vault', async () => {
     const { useGraphSettingsStore } = await loadGraphStore();
 
     useGraphSettingsStore.getState().setVaultRoot('/vault-a');
-    useGraphSettingsStore.getState().seedGroupsFromTopLevelFolders([]);
+    const id = useGraphSettingsStore.getState().addGroup({
+      name: 'Progetti',
+      query: 'path:Projects',
+      color: '#6366f1',
+    });
 
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(false);
+    // Switch away and back: the group must survive the round-trip through
+    // localStorage (the persistence path, not in-memory state).
+    useGraphSettingsStore.getState().setVaultRoot('/vault-b');
     expect(useGraphSettingsStore.getState().settings.groups).toEqual([]);
 
-    useGraphSettingsStore.getState().seedGroupsFromTopLevelFolders(['Projects']);
-
-    expect(useGraphSettingsStore.getState().settings.groups.map((group) => group.name)).toEqual([
-      'Projects',
+    useGraphSettingsStore.getState().setVaultRoot('/vault-a');
+    expect(useGraphSettingsStore.getState().settings.groups).toEqual([
+      { id, name: 'Progetti', query: 'path:Projects', color: '#6366f1', enabled: true },
     ]);
-    expect(useGraphSettingsStore.getState().settings.groupsSeeded).toBe(true);
   });
 });

--- a/apps/desktop/src/stores/graph.ts
+++ b/apps/desktop/src/stores/graph.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { buildAutoGraphGroupsFromFolders } from '../lib/graph-groups';
 import {
   DEFAULT_GRAPH_SETTINGS,
   loadGraphSettingsForVault,
@@ -35,7 +34,6 @@ type GraphSettingsState = {
   addGroup(group: NewGroupRule): string;
   updateGroup(id: string, patch: Partial<Omit<GraphGroupRule, 'id'>>): void;
   removeGroup(id: string): void;
-  seedGroupsFromTopLevelFolders(folders: readonly string[]): void;
   resetSettings(): void;
 };
 
@@ -52,7 +50,6 @@ function cloneSettings(settings: GraphSettings): GraphSettings {
     display: { ...settings.display },
     forces: { ...settings.forces },
     groups: settings.groups.map((g) => ({ ...g })),
-    groupsSeeded: settings.groupsSeeded,
   };
 }
 
@@ -113,7 +110,6 @@ export const useGraphSettingsStore = create<GraphSettingsState>((set, get) => {
             enabled: group.enabled ?? true,
           },
         ],
-        groupsSeeded: true,
       };
       setAndPersist(settings);
       return id;
@@ -133,22 +129,6 @@ export const useGraphSettingsStore = create<GraphSettingsState>((set, get) => {
         groups: get().settings.groups.filter((group) => group.id !== id),
       };
       setAndPersist(settings);
-    },
-    seedGroupsFromTopLevelFolders(folders) {
-      const current = get().settings;
-      if (current.groupsSeeded || current.groups.length > 0) return;
-
-      const existingIds = new Set(current.groups.map((group) => group.id));
-      const generatedGroups = buildAutoGraphGroupsFromFolders(folders).filter(
-        (group) => !existingIds.has(group.id),
-      );
-      if (generatedGroups.length === 0) return;
-
-      setAndPersist({
-        ...current,
-        groups: [...current.groups, ...generatedGroups],
-        groupsSeeded: true,
-      });
     },
     resetSettings() {
       setAndPersist(cloneSettings(DEFAULT_GRAPH_SETTINGS));

--- a/packages/core/src/adapters/index-store.ts
+++ b/packages/core/src/adapters/index-store.ts
@@ -1,5 +1,6 @@
 import type { Note, NotePath, NoteSummary } from '../types/note.js';
 import type {
+  BrokenLink,
   DatabaseQuery,
   DatabaseResult,
   DetectedProperty,
@@ -194,6 +195,17 @@ export interface IndexStoreAdapter {
    * `mergeMentionEdges`) so this method stays a thin query.
    */
   getMentionEdges(perTargetLimit: number, totalLimit: number): Promise<MentionEdge[]>;
+
+  /**
+   * Broken outgoing wikilinks for the GLOBAL graph: relation rows whose
+   * `target_path IS NULL` (the `[[targetTitle]]` resolves to no note).
+   * These power Obsidian-style gray "unresolved" phantom nodes. Reuses
+   * the same resolution state the backlinks/broken-link detection relies
+   * on (`relations.target_path`), so the global graph agrees with the
+   * per-note broken-link view. Dedupe + phantom-node synthesis is the
+   * CALLER's job (see `mergeUnresolvedNodes`).
+   */
+  getBrokenLinks(): Promise<BrokenLink[]>;
 
   /**
    * v1.0: replace all relations originating from `sourcePath`. The

--- a/packages/core/src/query/index.test.ts
+++ b/packages/core/src/query/index.test.ts
@@ -3,10 +3,16 @@ import {
   detectProperty,
   extractProperties,
   mergeMentionEdges,
+  mergeUnresolvedNodes,
+  unresolvedNodeId,
+  UNRESOLVED_NODE_PREFIX,
   MENTION_EDGE_KIND,
+  type BrokenLink,
   type DatabaseQuery,
   type DetectedProperty,
+  type FullGraph,
   type GraphEdge,
+  type GraphNode,
   type MentionEdge,
   type ScalarFilter,
 } from './index.js';
@@ -288,5 +294,96 @@ describe('mergeMentionEdges', () => {
   it('drops mentions whose endpoints are not both known nodes', () => {
     const merged = mergeMentionEdges([], [mention(A, 'ghost.md'), mention('ghost.md', B)], known);
     expect(merged).toEqual([]);
+  });
+});
+
+describe('unresolvedNodeId', () => {
+  it('prefixes and lowercases the trimmed title so casing/whitespace collapse', () => {
+    expect(unresolvedNodeId('Concept')).toBe(`${UNRESOLVED_NODE_PREFIX}concept`);
+    expect(unresolvedNodeId('  Concept  ')).toBe(unresolvedNodeId('concept'));
+  });
+});
+
+describe('mergeUnresolvedNodes', () => {
+  const A = 'A.md';
+  const B = 'B.md';
+
+  function node(path: string, title: string): GraphNode {
+    return { path, title, type: null, color: null };
+  }
+
+  function graph(nodes: GraphNode[], edges: GraphEdge[] = []): FullGraph {
+    return { nodes, edges };
+  }
+
+  function broken(source: string, targetTitle: string): BrokenLink {
+    return { source, targetTitle };
+  }
+
+  it('adds an unresolved phantom node + edge for a wikilink with no backing file', () => {
+    const base = graph([node(A, 'A')]);
+    const out = mergeUnresolvedNodes(base, [broken(A, 'Concept')]);
+
+    const phantomId = unresolvedNodeId('Concept');
+    const phantom = out.nodes.find((n) => n.path === phantomId);
+    expect(phantom).toEqual({
+      path: phantomId,
+      title: 'Concept',
+      type: null,
+      color: null,
+      unresolved: true,
+    });
+    expect(out.edges).toContainEqual({
+      source: A,
+      target: phantomId,
+      targetTitle: 'Concept',
+      kind: '',
+    });
+    // Original node untouched and not flagged unresolved.
+    expect(out.nodes.find((n) => n.path === A)?.unresolved).toBeUndefined();
+  });
+
+  it('does NOT create a phantom when the target resolves to an existing note (case-insensitive)', () => {
+    // B.md exists with title "Concept"; a broken link to "concept" must
+    // not spawn a phantom (the target is real, casing differs).
+    const base = graph([node(A, 'A'), node(B, 'Concept')]);
+    const out = mergeUnresolvedNodes(base, [broken(A, 'concept')]);
+
+    expect(out.nodes.some((n) => n.unresolved === true)).toBe(false);
+    expect(out.nodes).toHaveLength(2);
+    expect(out.edges).toHaveLength(0);
+  });
+
+  it('dedupes phantom nodes across sources but keeps one edge per source', () => {
+    const base = graph([node(A, 'A'), node(B, 'B')]);
+    const out = mergeUnresolvedNodes(base, [
+      broken(A, 'Concept'),
+      broken(B, 'concept'), // same phantom, different casing
+    ]);
+
+    const phantomId = unresolvedNodeId('Concept');
+    expect(out.nodes.filter((n) => n.path === phantomId)).toHaveLength(1);
+    expect(out.edges.filter((e) => e.target === phantomId)).toHaveLength(2);
+  });
+
+  it('collapses duplicate broken links from the same source into one edge', () => {
+    const base = graph([node(A, 'A')]);
+    const out = mergeUnresolvedNodes(base, [broken(A, 'Concept'), broken(A, 'Concept')]);
+    const phantomId = unresolvedNodeId('Concept');
+    expect(out.edges.filter((e) => e.target === phantomId)).toHaveLength(1);
+  });
+
+  it('drops broken links whose source is not a known node, and empty titles', () => {
+    const base = graph([node(A, 'A')]);
+    const out = mergeUnresolvedNodes(base, [broken('ghost.md', 'Concept'), broken(A, '   ')]);
+    expect(out.nodes).toHaveLength(1);
+    expect(out.edges).toHaveLength(0);
+  });
+
+  it('returns the original graph unchanged when there are no broken links', () => {
+    const base = graph([node(A, 'A')], [{ source: A, target: A, targetTitle: 'A', kind: '' }]);
+    const out = mergeUnresolvedNodes(base, []);
+    expect(out.nodes).toEqual(base.nodes);
+    expect(out.edges).toEqual(base.edges);
   });
 });

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -196,9 +196,31 @@ export type GraphNode = {
    * the type slug and a matching `object_types` row with a non-null
    * `color` exist. Null otherwise (no schema, or schema with no color
    * declared).
+   *
+   * NOTE (graph monochrome redesign): the renderer no longer auto-tints
+   * nodes from this schema color. It is kept on the wire because the
+   * type-filter chips still surface it; node tinting now comes ONLY from
+   * user-defined graph groups.
    */
   color: string | null;
+  /**
+   * Graph monochrome redesign: marks a "phantom" node — a wikilink
+   * target (`[[Concept]]`) that has no backing note file. Rendered gray,
+   * smaller and dimmer (Obsidian's unresolved nodes). Absent/false for
+   * every real note. The `path` of an unresolved node is the synthetic
+   * `UNRESOLVED_NODE_PREFIX + lower(title)` id, never a real file path.
+   */
+  unresolved?: boolean;
 };
+
+/**
+ * Synthetic id prefix for unresolved (phantom) graph nodes. Chosen so it
+ * can never collide with a real vault-relative path: real `NotePath`s are
+ * POSIX paths ending in `.md`, and the `:` after the prefix is not a path
+ * separator we emit. Mirrors the MiniGraph `broken:` convention but is
+ * distinct so the two id-spaces never overlap if ever merged.
+ */
+export const UNRESOLVED_NODE_PREFIX = 'unresolved:';
 
 /**
  * Distinct sentinel `kind` for soft references (unlinked mentions): a
@@ -287,4 +309,93 @@ export function mergeMentionEdges(
   }
 
   return merged;
+}
+
+/**
+ * A broken outgoing wikilink: `source` links to `targetTitle` via
+ * `[[targetTitle]]` but no note resolves to that title (its row in the
+ * `relations` table has `target_path IS NULL`). The adapter surfaces
+ * these so the global graph can render the missing target as an
+ * Obsidian-style gray "unresolved" phantom node.
+ */
+export type BrokenLink = {
+  source: NotePath;
+  targetTitle: string;
+};
+
+/**
+ * Stable synthetic id for an unresolved node, derived from its title.
+ * Case-insensitive (Obsidian title resolution is case-insensitive), so
+ * `[[Concept]]` and `[[concept]]` from different notes collapse onto ONE
+ * phantom node. Whitespace is trimmed; the original casing is preserved
+ * for display in the returned node's `title`.
+ */
+export function unresolvedNodeId(title: string): NotePath {
+  return `${UNRESOLVED_NODE_PREFIX}${title.trim().toLowerCase()}`;
+}
+
+/**
+ * Fold broken wikilinks into a base graph as unresolved phantom nodes +
+ * their incoming edges. Pure & unit-tested so the SQLite adapter stays a
+ * thin query.
+ *
+ * Rules:
+ *   - A broken link whose `targetTitle` already resolves to a real node
+ *     (case-insensitive title match against an existing node) is DROPPED:
+ *     the target exists, so it isn't a phantom. (Defensive — the adapter
+ *     only passes genuinely unresolved targets, but a title can match a
+ *     real note via casing differences the SQL `target_path` join missed.)
+ *   - Phantom nodes dedupe by synthetic id (case-insensitive title), so
+ *     many `[[Concept]]` links across notes share one gray node.
+ *   - One edge per (source → phantom) pair; duplicate links collapse.
+ *   - Links whose `source` isn't a known real node are dropped (dangling).
+ *
+ * Returns a NEW graph: original nodes/edges first (stable order), then the
+ * phantom nodes, then the phantom edges. Edge `kind` is `''` (generic
+ * wikilink) so the renderer styles the connector like any other link.
+ */
+export function mergeUnresolvedNodes(
+  graph: FullGraph,
+  brokenLinks: readonly BrokenLink[],
+): FullGraph {
+  const knownPaths = new Set<NotePath>();
+  const knownTitlesLower = new Set<string>();
+  for (const node of graph.nodes) {
+    knownPaths.add(node.path);
+    knownTitlesLower.add(node.title.trim().toLowerCase());
+  }
+
+  const phantomNodes = new Map<NotePath, GraphNode>();
+  const phantomEdges: GraphEdge[] = [];
+  const seenEdgePairs = new Set<string>();
+
+  for (const link of brokenLinks) {
+    const title = link.targetTitle.trim();
+    if (title === '') continue;
+    // Source must be a real node, else the edge dangles.
+    if (!knownPaths.has(link.source)) continue;
+    // Target resolves to a real note after all → not a phantom.
+    if (knownTitlesLower.has(title.toLowerCase())) continue;
+
+    const id = unresolvedNodeId(title);
+    if (!phantomNodes.has(id)) {
+      phantomNodes.set(id, {
+        path: id,
+        title,
+        type: null,
+        color: null,
+        unresolved: true,
+      });
+    }
+
+    const pairKey = `${link.source} ${id}`;
+    if (seenEdgePairs.has(pairKey)) continue;
+    seenEdgePairs.add(pairKey);
+    phantomEdges.push({ source: link.source, target: id, targetTitle: title, kind: '' });
+  }
+
+  return {
+    nodes: [...graph.nodes, ...phantomNodes.values()],
+    edges: [...graph.edges, ...phantomEdges],
+  };
 }


### PR DESCRIPTION
Makes the knowledge graph read like Obsidian's: monochrome by default, colors only from user-defined groups.

## What
- **Monochrome default** — existing notes render bright (`--graph-node`); the type-schema color no longer auto-tints nodes (that was the "too many colors" problem). Node color now comes **only** from user group rules.
- **Unresolved phantom nodes** — `[[Concept]]` links with no backing file now appear in the global graph as **gray**, smaller, dimmer nodes (like Obsidian's "concept without a note"). New `unresolved` flag on `GraphNode`; derived from `relations WHERE target_path IS NULL` (the same resolution the per-note broken-link detection uses). Clicking a phantom is a guarded no-op (create-on-click deferred).
- **MiniGraph** — broken-link nodes changed from red to the same muted gray, for consistency.
- **Legend** — rewritten to the monochrome model: Note (bright) / Non risolte (gray) / active group colors / relation kinds / soft references. Dropped the per-type color legend.
- Node size still scales with degree; edges stay subtle; mentions stay dashed/dim. All theme-aware via `--graph-*` tokens (5 themes + light), no hardcoded hex.

## Verification
- typecheck + lint green; `packages/core` 181 tests + build green; desktop graph/Legend/MiniGraph suites + new tests green (536 desktop tests). Reviewed: APPROVED.

## Notes
- Phantom create-on-click is intentionally a no-op for now (documented) — a nice Obsidian-style "click to create the note" is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)