### PR TITLE
feat(ai): semantic search foundation — local embeddings (milestone 1)

### DIFF
--- a/apps/desktop/electron/adapters/index-store-embeddings.test.ts
+++ b/apps/desktop/electron/adapters/index-store-embeddings.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fsp } from 'node:fs';
+import { SqliteIndexStore } from './index-store.sqlite.js';
+
+// Exercises the embedding CRUD through the REAL adapter class (prepared
+// statements, BLOB (de)serialization, joins) against a throwaway on-disk
+// vault. Verifies the little-endian Float32 round-trip survives SQLite.
+
+let store: SqliteIndexStore;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'ziba-emb-'));
+  store = new SqliteIndexStore();
+  await store.init(tmpRoot);
+});
+
+afterEach(async () => {
+  await store.close();
+  await fsp.rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function addNote(p: string, title: string): Promise<void> {
+  await store.upsertNote({ path: p, title, frontmatter: {}, wikilinks: [], mtimeMs: 0, body: '' });
+}
+
+describe('SqliteIndexStore embeddings', () => {
+  it('upserts and reads back a vector exactly (little-endian round-trip)', async () => {
+    await addNote('a.md', 'Alpha');
+    const vec = new Float32Array([0.5, -0.25, 1, 0, -3.14159]);
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'hash-a',
+      modelId: 'fake:hash-32',
+      dim: vec.length,
+      vector: vec,
+      mtimeMs: 123,
+    });
+
+    const all = await store.getAllEmbeddings!();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.sourcePath).toBe('a.md');
+    expect(all[0]!.title).toBe('Alpha');
+    expect(Array.from(all[0]!.vector)).toEqual(Array.from(vec));
+  });
+
+  it('upsert replaces the existing row for a path', async () => {
+    await addNote('a.md', 'Alpha');
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h1',
+      modelId: 'm',
+      dim: 2,
+      vector: new Float32Array([1, 1]),
+      mtimeMs: 1,
+    });
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h2',
+      modelId: 'm',
+      dim: 2,
+      vector: new Float32Array([2, 2]),
+      mtimeMs: 2,
+    });
+    const all = await store.getAllEmbeddings!();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.contentHash).toBe('h2');
+  });
+
+  it('getEmbeddingMeta returns hash+model for the skip check, null when absent', async () => {
+    await addNote('a.md', 'Alpha');
+    expect(await store.getEmbeddingMeta!('a.md')).toBeNull();
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h',
+      modelId: 'ollama:x',
+      dim: 1,
+      vector: new Float32Array([1]),
+      mtimeMs: 0,
+    });
+    expect(await store.getEmbeddingMeta!('a.md')).toEqual({
+      contentHash: 'h',
+      modelId: 'ollama:x',
+    });
+  });
+
+  it('deleteEmbedding removes the row', async () => {
+    await addNote('a.md', 'Alpha');
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h',
+      modelId: 'm',
+      dim: 1,
+      vector: new Float32Array([1]),
+      mtimeMs: 0,
+    });
+    await store.deleteEmbedding!('a.md');
+    expect(await store.getAllEmbeddings!()).toHaveLength(0);
+  });
+
+  it('counts indexed vs total notes', async () => {
+    await addNote('a.md', 'Alpha');
+    await addNote('b.md', 'Beta');
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h',
+      modelId: 'm',
+      dim: 1,
+      vector: new Float32Array([1]),
+      mtimeMs: 0,
+    });
+    expect(await store.getEmbeddingCounts!()).toEqual({ indexed: 1, total: 2 });
+  });
+
+  it('clearEmbeddings drops every row', async () => {
+    await addNote('a.md', 'Alpha');
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h',
+      modelId: 'm',
+      dim: 1,
+      vector: new Float32Array([1]),
+      mtimeMs: 0,
+    });
+    await store.clearEmbeddings!();
+    expect(await store.getEmbeddingCounts!()).toEqual({ indexed: 0, total: 1 });
+  });
+
+  it('orphan embeddings (no notes row) are excluded from getAllEmbeddings', async () => {
+    // Embedding written, then the note deleted out from under it: the INNER
+    // JOIN on notes must drop it from search.
+    await addNote('a.md', 'Alpha');
+    await store.upsertEmbedding!({
+      sourcePath: 'a.md',
+      title: '',
+      contentHash: 'h',
+      modelId: 'm',
+      dim: 1,
+      vector: new Float32Array([1]),
+      mtimeMs: 0,
+    });
+    await store.deleteNote('a.md');
+    expect(await store.getAllEmbeddings!()).toHaveLength(0);
+  });
+});

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -15,11 +15,15 @@ import {
   SCHEMA_SQL,
   EXPECTED_USER_VERSION,
   MIGRATION_DROP_SQL,
+  blobToFloat32,
+  float32ToBlob,
   type DatabaseGroup,
   type DatabaseQuery,
   type DatabaseResult,
   type DatabaseRow,
   type DetectedProperty,
+  type EmbeddingMeta,
+  type EmbeddingStoreRow,
   type FullGraph,
   type FullTextHit,
   type IndexStoreAdapter,
@@ -137,6 +141,13 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     listObjectTypes: Database.Statement;
     getTypeCounts: Database.Statement;
     getTypedPaths: Database.Statement;
+    upsertEmbedding: Database.Statement;
+    deleteEmbedding: Database.Statement;
+    getEmbeddingMeta: Database.Statement;
+    getAllEmbeddings: Database.Statement;
+    countEmbeddings: Database.Statement;
+    countNotes: Database.Statement;
+    clearEmbeddings: Database.Statement;
   } | null = null;
 
   async init(vaultRoot: string): Promise<void> {
@@ -375,6 +386,38 @@ export class SqliteIndexStore implements IndexStoreAdapter {
           AND text_value IS NOT NULL
           AND text_value <> ''
       `),
+      // ---- AI semantic search (milestone 1) ----
+      upsertEmbedding: db.prepare(`
+        INSERT INTO note_embeddings (source_path, content_hash, model_id, dim, vector, mtime)
+        VALUES (@source_path, @content_hash, @model_id, @dim, @vector, @mtime)
+        ON CONFLICT(source_path) DO UPDATE SET
+          content_hash = excluded.content_hash,
+          model_id     = excluded.model_id,
+          dim          = excluded.dim,
+          vector       = excluded.vector,
+          mtime        = excluded.mtime
+      `),
+      deleteEmbedding: db.prepare(`DELETE FROM note_embeddings WHERE source_path = ?`),
+      getEmbeddingMeta: db.prepare(`
+        SELECT content_hash, model_id FROM note_embeddings WHERE source_path = ?
+      `),
+      // Join titles from `notes` so search hits carry a label. LEFT JOIN
+      // would keep embeddings whose note row vanished; INNER JOIN drops
+      // those orphans from search (they'd have no title to show anyway).
+      getAllEmbeddings: db.prepare(`
+        SELECT e.source_path AS source_path,
+               n.title       AS title,
+               e.content_hash AS content_hash,
+               e.model_id     AS model_id,
+               e.dim          AS dim,
+               e.vector       AS vector,
+               e.mtime        AS mtime
+        FROM note_embeddings e
+        JOIN notes n ON n.path = e.source_path
+      `),
+      countEmbeddings: db.prepare(`SELECT COUNT(*) AS c FROM note_embeddings`),
+      countNotes: db.prepare(`SELECT COUNT(*) AS c FROM notes`),
+      clearEmbeddings: db.prepare(`DELETE FROM note_embeddings`),
     };
   }
 
@@ -939,6 +982,74 @@ export class SqliteIndexStore implements IndexStoreAdapter {
     }
 
     return out;
+  }
+
+  // ---- AI semantic search (milestone 1) ---------------------------------
+
+  async upsertEmbedding(row: EmbeddingStoreRow): Promise<void> {
+    const s = this.require();
+    // Store the vector as a Node Buffer so better-sqlite3 binds it as a
+    // BLOB. `float32ToBlob` already gives us little-endian bytes.
+    s.upsertEmbedding.run({
+      source_path: row.sourcePath,
+      content_hash: row.contentHash,
+      model_id: row.modelId,
+      dim: row.dim,
+      vector: Buffer.from(float32ToBlob(row.vector)),
+      mtime: row.mtimeMs,
+    });
+    return Promise.resolve();
+  }
+
+  async deleteEmbedding(sourcePath: NotePath): Promise<void> {
+    const s = this.require();
+    s.deleteEmbedding.run(sourcePath);
+    return Promise.resolve();
+  }
+
+  async getEmbeddingMeta(sourcePath: NotePath): Promise<EmbeddingMeta | null> {
+    const s = this.require();
+    const row = s.getEmbeddingMeta.get(sourcePath) as
+      | { content_hash: string; model_id: string }
+      | undefined;
+    if (!row) return null;
+    return { contentHash: row.content_hash, modelId: row.model_id };
+  }
+
+  async getAllEmbeddings(): Promise<EmbeddingStoreRow[]> {
+    const s = this.require();
+    type Row = {
+      source_path: string;
+      title: string;
+      content_hash: string;
+      model_id: string;
+      dim: number;
+      vector: Buffer;
+      mtime: number;
+    };
+    const rows = s.getAllEmbeddings.all() as Row[];
+    return rows.map((r) => ({
+      sourcePath: r.source_path,
+      title: r.title,
+      contentHash: r.content_hash,
+      modelId: r.model_id,
+      dim: r.dim,
+      vector: blobToFloat32(r.vector),
+      mtimeMs: r.mtime,
+    }));
+  }
+
+  async getEmbeddingCounts(): Promise<{ indexed: number; total: number }> {
+    const s = this.require();
+    const indexed = (s.countEmbeddings.get() as { c: number }).c;
+    const total = (s.countNotes.get() as { c: number }).c;
+    return Promise.resolve({ indexed, total });
+  }
+
+  async clearEmbeddings(): Promise<void> {
+    const s = this.require();
+    s.clearEmbeddings.run();
+    return Promise.resolve();
   }
 }
 

--- a/apps/desktop/electron/adapters/index-store.sqlite.ts
+++ b/apps/desktop/electron/adapters/index-store.sqlite.ts
@@ -415,7 +415,15 @@ export class SqliteIndexStore implements IndexStoreAdapter {
         FROM note_embeddings e
         JOIN notes n ON n.path = e.source_path
       `),
-      countEmbeddings: db.prepare(`SELECT COUNT(*) AS c FROM note_embeddings`),
+      // INNER JOIN notes so the count matches `getAllEmbeddings` (which
+      // drops orphan embeddings whose note row is gone). Otherwise the
+      // "Indicizzate X/Y" status could claim more indexed rows than are
+      // actually searchable.
+      countEmbeddings: db.prepare(`
+        SELECT COUNT(*) AS c
+        FROM note_embeddings e
+        JOIN notes n ON n.path = e.source_path
+      `),
       countNotes: db.prepare(`SELECT COUNT(*) AS c FROM notes`),
       clearEmbeddings: db.prepare(`DELETE FROM note_embeddings`),
     };

--- a/apps/desktop/electron/ai/content-hash.ts
+++ b/apps/desktop/electron/ai/content-hash.ts
@@ -1,0 +1,12 @@
+// SHA-256 content hashing for the embedding skip-if-unchanged check.
+//
+// Lives in the Electron host (not @ziba/core) so core stays free of
+// `node:crypto` and remains bundleable for web + mobile. SHA-256 is
+// collision-resistant enough that an unchanged note reliably skips
+// re-embedding while a single edited byte reliably triggers one.
+
+import { createHash } from 'node:crypto';
+
+export function hashContent(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}

--- a/apps/desktop/electron/ai/embedding-indexer.test.ts
+++ b/apps/desktop/electron/ai/embedding-indexer.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  FakeEmbeddingProvider,
+  type EmbeddingMeta,
+  type EmbeddingProvider,
+  type EmbeddingStoreRow,
+  type IndexStoreAdapter,
+  type NotePath,
+  type SemanticSettings,
+} from '@ziba/core';
+import { EmbeddingIndexer, type NoteBodyLoader } from './embedding-indexer.js';
+
+// Unit tests for the indexer orchestration, with a deterministic
+// FakeEmbeddingProvider and an in-memory store stub — no SQLite, no Ollama,
+// no Electron window. Covers: skip-if-unchanged, debounce coalescing,
+// provider-unreachable abort, the dispose-mid-pass teardown guard, and the
+// four search degradation reasons.
+
+// ---- In-memory store stub ------------------------------------------------
+
+type StubOpts = {
+  /** Throw from upsertEmbedding to simulate a closed DB. */
+  failUpsert?: boolean;
+};
+
+class StubStore {
+  embeddings = new Map<NotePath, EmbeddingStoreRow>();
+  /** Paths that have a `notes` row (for the INNER-JOIN-style count/getAll). */
+  notes = new Set<NotePath>();
+  upsertCalls = 0;
+
+  constructor(private readonly opts: StubOpts = {}) {}
+
+  upsertEmbedding(row: EmbeddingStoreRow): Promise<void> {
+    this.upsertCalls++;
+    if (this.opts.failUpsert) return Promise.reject(new Error('IndexStore not initialized'));
+    this.embeddings.set(row.sourcePath, { ...row });
+    this.notes.add(row.sourcePath);
+    return Promise.resolve();
+  }
+
+  deleteEmbedding(p: NotePath): Promise<void> {
+    this.embeddings.delete(p);
+    return Promise.resolve();
+  }
+
+  getEmbeddingMeta(p: NotePath): Promise<EmbeddingMeta | null> {
+    const row = this.embeddings.get(p);
+    return Promise.resolve(row ? { contentHash: row.contentHash, modelId: row.modelId } : null);
+  }
+
+  getAllEmbeddings(): Promise<EmbeddingStoreRow[]> {
+    // Mirror the adapter's INNER JOIN on notes: only rows with a notes entry.
+    return Promise.resolve(
+      [...this.embeddings.values()].filter((r) => this.notes.has(r.sourcePath)),
+    );
+  }
+
+  getEmbeddingCounts(): Promise<{ indexed: number; total: number }> {
+    const indexed = [...this.embeddings.keys()].filter((p) => this.notes.has(p)).length;
+    return Promise.resolve({ indexed, total: this.notes.size });
+  }
+
+  clearEmbeddings(): Promise<void> {
+    this.embeddings.clear();
+    return Promise.resolve();
+  }
+
+  asAdapter(): IndexStoreAdapter {
+    // The indexer only touches the embedding methods; cast through unknown so
+    // we don't have to stub the entire (large) IndexStoreAdapter surface.
+    return this as unknown as IndexStoreAdapter;
+  }
+}
+
+// ---- Helpers -------------------------------------------------------------
+
+const SETTINGS_ON: SemanticSettings = {
+  enabled: true,
+  baseUrl: 'http://localhost:11434',
+  model: 'fake',
+};
+const SETTINGS_OFF: SemanticSettings = { ...SETTINGS_ON, enabled: false };
+
+function makeLoader(bodies: Record<string, { title: string; body: string }>): NoteBodyLoader {
+  return (p) => Promise.resolve(bodies[p] ?? null);
+}
+
+/** Provider that always rejects — simulates Ollama being down. */
+class DeadProvider implements EmbeddingProvider {
+  readonly id = 'dead:provider';
+  calls = 0;
+  embed(): Promise<Float32Array[]> {
+    this.calls++;
+    return Promise.reject(new Error('ECONNREFUSED'));
+  }
+}
+
+function makeIndexer(
+  store: StubStore,
+  bodies: Record<string, { title: string; body: string }>,
+  settings: SemanticSettings,
+  provider: EmbeddingProvider = new FakeEmbeddingProvider(),
+): EmbeddingIndexer {
+  const paths = Object.keys(bodies);
+  // Register a notes row for each known body so counts/getAll see them.
+  for (const p of paths) store.notes.add(p);
+  return new EmbeddingIndexer(
+    store.asAdapter(),
+    makeLoader(bodies),
+    () => Promise.resolve(paths),
+    () => null, // no window in tests
+    settings,
+    () => provider,
+  );
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---- Tests ---------------------------------------------------------------
+
+describe('EmbeddingIndexer full pass', () => {
+  it('embeds every note on a full pass', async () => {
+    const store = new StubStore();
+    const bodies = {
+      'a.md': { title: 'Alpha', body: 'machine learning' },
+      'b.md': { title: 'Beta', body: 'banana bread' },
+    };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    await idx.runFullPass(false);
+    expect(store.embeddings.size).toBe(2);
+    expect(store.upsertCalls).toBe(2);
+  });
+
+  it('does nothing when the feature is disabled (no provider calls)', async () => {
+    const store = new StubStore();
+    const dead = new DeadProvider();
+    const idx = makeIndexer(store, { 'a.md': { title: 'A', body: 'x' } }, SETTINGS_OFF, dead);
+    await idx.runFullPass(false);
+    expect(dead.calls).toBe(0);
+    expect(store.upsertCalls).toBe(0);
+  });
+
+  it('skips a note whose content_hash + model_id are unchanged', async () => {
+    const store = new StubStore();
+    const bodies = { 'a.md': { title: 'Alpha', body: 'unchanged content' } };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    await idx.runFullPass(false);
+    expect(store.upsertCalls).toBe(1);
+    // Second pass: same content + same model → skipped, no new upsert.
+    await idx.runFullPass(false);
+    expect(store.upsertCalls).toBe(1);
+  });
+
+  it('re-embeds when the note content changes', async () => {
+    const store = new StubStore();
+    const bodies = { 'a.md': { title: 'Alpha', body: 'first version' } };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    await idx.runFullPass(false);
+    expect(store.upsertCalls).toBe(1);
+    bodies['a.md'].body = 'a completely different second version';
+    await idx.runFullPass(false);
+    expect(store.upsertCalls).toBe(2);
+  });
+
+  it('force re-embeds even when content is unchanged', async () => {
+    const store = new StubStore();
+    const bodies = { 'a.md': { title: 'Alpha', body: 'unchanged' } };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    await idx.runFullPass(false);
+    await idx.runFullPass(true); // force
+    expect(store.upsertCalls).toBe(2);
+  });
+
+  it('aborts the pass when the provider is unreachable, without hammering it', async () => {
+    const store = new StubStore();
+    const dead = new DeadProvider();
+    const bodies: Record<string, { title: string; body: string }> = {};
+    // More notes than one batch (BATCH_SIZE=8) so a non-aborting impl would
+    // call embed multiple times.
+    for (let i = 0; i < 20; i++) bodies[`n${i}.md`] = { title: `N${i}`, body: `body ${i}` };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON, dead);
+    await idx.runFullPass(false);
+    // Exactly one embed attempt (the first batch) — the pass aborts on the
+    // first failure instead of retrying every batch.
+    expect(dead.calls).toBe(1);
+    expect(store.embeddings.size).toBe(0);
+  });
+});
+
+describe('EmbeddingIndexer debounce', () => {
+  it('coalesces rapid enqueues into a single pass', async () => {
+    vi.useFakeTimers();
+    const store = new StubStore();
+    const bodies = {
+      'a.md': { title: 'A', body: 'alpha body' },
+      'b.md': { title: 'B', body: 'beta body' },
+    };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    idx.enqueue('a.md');
+    idx.enqueue('b.md');
+    idx.enqueue('a.md'); // duplicate within the window
+    // Nothing should have run yet (still inside the debounce window).
+    expect(store.upsertCalls).toBe(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.runAllTimersAsync();
+    // Both unique paths embedded once; the duplicate 'a.md' coalesced.
+    expect(store.embeddings.size).toBe(2);
+    expect(store.upsertCalls).toBe(2);
+    vi.useRealTimers();
+  });
+});
+
+describe('EmbeddingIndexer dispose / teardown guard', () => {
+  it('dispose() mid-pass settles and prevents writes to a closed store', async () => {
+    // Simulates a vault switch while a full pass is in flight: dispose() is
+    // called (from teardown, a SEPARATE context) while an embed is pending.
+    // The post-embed `disposed` guard must skip the upsert loop so a
+    // closed-DB write (modeled by failUpsert) is never attempted, and the
+    // whole thing settles without an unhandled rejection.
+    const store = new StubStore({ failUpsert: true });
+    const bodies: Record<string, { title: string; body: string }> = {};
+    for (let i = 0; i < 20; i++) bodies[`n${i}.md`] = { title: `N${i}`, body: `body ${i}` };
+
+    // A provider whose first embed blocks on an external deferred, so the
+    // test controls exactly when the "network call" resolves.
+    let releaseEmbed: () => void = () => {};
+    const embedPending = new Promise<void>((resolve) => {
+      releaseEmbed = resolve;
+    });
+    const provider: EmbeddingProvider = {
+      id: 'fake:hash-32',
+      embed: async (texts) => {
+        await embedPending;
+        return texts.map(() => new Float32Array([1, 0, 0]));
+      },
+    };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON, provider);
+
+    // Start the pass; it parks in `embed` awaiting our deferred.
+    const pass = idx.runFullPass(false);
+    // Dispose from the outside (teardown context). dispose() awaits the
+    // in-flight pass — so we kick the embed loose on the next microtask.
+    const disposed = idx.dispose();
+    releaseEmbed();
+
+    await expect(Promise.all([pass, disposed])).resolves.toBeDefined();
+    // The post-embed disposed-guard skipped the loop: no upsert attempted.
+    expect(store.upsertCalls).toBe(0);
+  });
+
+  it('a disposed indexer accepts no new work', () => {
+    const store = new StubStore();
+    const idx = makeIndexer(store, { 'a.md': { title: 'A', body: 'x' } }, SETTINGS_ON);
+    void idx.dispose();
+    idx.enqueue('a.md');
+    expect(store.upsertCalls).toBe(0);
+  });
+});
+
+describe('EmbeddingIndexer search degradation', () => {
+  it('reason "disabled" when the feature is off', async () => {
+    const store = new StubStore();
+    const idx = makeIndexer(store, {}, SETTINGS_OFF);
+    const res = await idx.search('query', 10);
+    expect(res).toEqual({ ok: false, reason: 'disabled', message: expect.any(String) });
+  });
+
+  it('reason "not-indexed" when there are no stored vectors', async () => {
+    const store = new StubStore();
+    const idx = makeIndexer(store, {}, SETTINGS_ON);
+    const res = await idx.search('query', 10);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('not-indexed');
+  });
+
+  it('reason "provider-unreachable" when the query embed fails', async () => {
+    const store = new StubStore();
+    const bodies = { 'a.md': { title: 'A', body: 'alpha' } };
+    // Index first with a working fake provider so the store is non-empty
+    // (otherwise we'd short-circuit on "not-indexed" before touching Ollama).
+    const idx = makeIndexer(store, bodies, SETTINGS_ON, new FakeEmbeddingProvider());
+    await idx.runFullPass(false);
+    expect(store.embeddings.size).toBe(1);
+
+    // A second indexer over the SAME store, but its provider is down — the
+    // query embed throws, so search must report provider-unreachable.
+    const deadIdx = makeIndexer(store, bodies, SETTINGS_ON, new DeadProvider());
+    const res = await deadIdx.search('query', 10);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('provider-unreachable');
+  });
+
+  it('reason "error" when reading the index throws', async () => {
+    const store = new StubStore();
+    store.notes.add('a.md');
+    // Force getAllEmbeddings to throw.
+    vi.spyOn(store, 'getAllEmbeddings').mockRejectedValue(new Error('disk gone'));
+    const idx = makeIndexer(store, { 'a.md': { title: 'A', body: 'x' } }, SETTINGS_ON);
+    const res = await idx.search('query', 10);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('error');
+  });
+
+  it('returns ranked hits with snippets when everything is healthy', async () => {
+    const store = new StubStore();
+    const bodies = {
+      'ml.md': { title: 'ML', body: 'machine learning models and training' },
+      'food.md': { title: 'Food', body: 'banana bread recipe with walnuts' },
+    };
+    const idx = makeIndexer(store, bodies, SETTINGS_ON);
+    await idx.runFullPass(false);
+    const res = await idx.search('machine learning training', 10);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.hits.length).toBeGreaterThan(0);
+      // The ML note should outrank the food note for an ML query.
+      expect(res.hits[0]!.path).toBe('ml.md');
+      expect(res.hits[0]!.snippet.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/desktop/electron/ai/embedding-indexer.ts
+++ b/apps/desktop/electron/ai/embedding-indexer.ts
@@ -13,7 +13,6 @@
 
 import type { BrowserWindow } from 'electron';
 import {
-  hashContent,
   prepareEmbedText,
   rankBySimilarity,
   type EmbeddingProvider,
@@ -24,6 +23,7 @@ import {
   type SemanticSettings,
 } from '@ziba/core';
 import { IpcChannels, type EmbeddingProgressPayload } from '../../shared/ipc.js';
+import { hashContent } from './content-hash.js';
 import { OllamaEmbeddingProvider } from './ollama-embeddings.js';
 
 /** What the indexer needs to read a note's body for embedding. */
@@ -45,6 +45,9 @@ export class EmbeddingIndexer {
   private pendingPaths = new Set<NotePath>();
   private debounceTimer: NodeJS.Timeout | null = null;
   private disposed = false;
+  // Promise for the in-flight pass (full or flush), so dispose() can await
+  // it and the caller (teardown) can safely close the DB afterwards.
+  private activePass: Promise<void> | null = null;
 
   constructor(
     private readonly store: IndexStoreAdapter,
@@ -52,9 +55,12 @@ export class EmbeddingIndexer {
     private readonly listPaths: () => Promise<NotePath[]>,
     private readonly getWindow: () => BrowserWindow | null,
     settings: SemanticSettings,
+    // Seam for tests: swap in a deterministic provider (the production path
+    // always builds an Ollama HTTP provider).
+    private readonly providerFactory: (s: SemanticSettings) => EmbeddingProvider = buildProvider,
   ) {
     this.settings = settings;
-    this.provider = buildProvider(settings);
+    this.provider = providerFactory(settings);
   }
 
   // ---- lifecycle ------------------------------------------------------
@@ -64,11 +70,19 @@ export class EmbeddingIndexer {
    *  re-embedded on the next pass (their meta no longer matches). */
   updateSettings(settings: SemanticSettings): void {
     this.settings = settings;
-    this.provider = buildProvider(settings);
+    this.provider = this.providerFactory(settings);
   }
 
-  /** Cancel any in-flight pass and stop accepting work. */
-  dispose(): void {
+  /**
+   * Cancel any in-flight pass, stop accepting work, and RESOLVE once the
+   * current batch has settled. `teardown()` awaits this BEFORE closing the
+   * DB so an in-flight `embedBatch` can never write to a closed store.
+   *
+   * The batch loop checks `this.disposed` between batches and right after
+   * each `provider.embed`, so awaiting `activePass` is bounded by one
+   * batch (≤ BATCH_SIZE embeds), not the whole vault.
+   */
+  async dispose(): Promise<void> {
     this.disposed = true;
     this.cancelRequested = true;
     if (this.debounceTimer) {
@@ -76,6 +90,14 @@ export class EmbeddingIndexer {
       this.debounceTimer = null;
     }
     this.pendingPaths.clear();
+    const pass = this.activePass;
+    if (pass) {
+      try {
+        await pass;
+      } catch {
+        // The pass swallows its own store errors; this is belt-and-braces.
+      }
+    }
   }
 
   isEnabled(): boolean {
@@ -158,6 +180,17 @@ export class EmbeddingIndexer {
   }
 
   private async embedPaths(paths: NotePath[], force: boolean): Promise<void> {
+    // Track the pass so dispose() can await it before the DB closes.
+    const pass = this.runPass(paths, force);
+    this.activePass = pass;
+    try {
+      await pass;
+    } finally {
+      if (this.activePass === pass) this.activePass = null;
+    }
+  }
+
+  private async runPass(paths: NotePath[], force: boolean): Promise<void> {
     this.running = true;
     this.cancelRequested = false;
     await this.emitProgress();
@@ -174,7 +207,9 @@ export class EmbeddingIndexer {
     } finally {
       this.running = false;
       this.cancelRequested = false;
-      await this.emitProgress();
+      // Skip the progress emit once disposed — the window may be tearing
+      // down and getEmbeddingCounts would hit a closing DB.
+      if (!this.disposed) await this.emitProgress();
     }
   }
 
@@ -218,20 +253,33 @@ export class EmbeddingIndexer {
       return;
     }
 
+    // The embed call is the long await where a vault switch most likely
+    // lands. If we were disposed while it ran, the DB is about to close (or
+    // already has) — bail BEFORE the upsert loop so we don't write to a
+    // closed store.
+    if (this.disposed) return;
+
     if (!this.store.upsertEmbedding) return;
     for (let i = 0; i < toEmbed.length; i++) {
+      if (this.disposed) return;
       const item = toEmbed[i]!;
       const vec = vectors[i];
       if (!vec || vec.length === 0) continue;
-      await this.store.upsertEmbedding({
-        sourcePath: item.path,
-        title: '', // joined from notes on read
-        contentHash: item.hash,
-        modelId: this.provider.id,
-        dim: vec.length,
-        vector: vec,
-        mtimeMs: Date.now(),
-      });
+      try {
+        await this.store.upsertEmbedding({
+          sourcePath: item.path,
+          title: '', // joined from notes on read
+          contentHash: item.hash,
+          modelId: this.provider.id,
+          dim: vec.length,
+          vector: vec,
+          mtimeMs: Date.now(),
+        });
+      } catch {
+        // Best-effort: a closed-DB throw (vault switched out from under us)
+        // or a transient write error just skips this note. The store is a
+        // cache — the next pass re-embeds it.
+      }
     }
   }
 

--- a/apps/desktop/electron/ai/embedding-indexer.ts
+++ b/apps/desktop/electron/ai/embedding-indexer.ts
@@ -1,0 +1,386 @@
+// Background embedding pipeline for the currently-open vault.
+//
+// Responsibilities:
+//   - hold the active EmbeddingProvider (built from the per-app settings),
+//   - (re)embed notes on create/save/rename and drop them on delete,
+//   - run a full pass on demand (enable / reindex) with progress + cancel,
+//   - answer semantic queries by brute-force cosine over stored vectors,
+//   - degrade gracefully when Ollama is unreachable (never throw across IPC).
+//
+// It batches with awaited yields so a large vault never blocks the main
+// thread for long. One instance lives per open vault (created on
+// openVault, torn down on close), mirroring the watcher lifecycle.
+
+import type { BrowserWindow } from 'electron';
+import {
+  hashContent,
+  prepareEmbedText,
+  rankBySimilarity,
+  type EmbeddingProvider,
+  type EmbeddingStatus,
+  type IndexStoreAdapter,
+  type NotePath,
+  type SemanticHit,
+  type SemanticSettings,
+} from '@ziba/core';
+import { IpcChannels, type EmbeddingProgressPayload } from '../../shared/ipc.js';
+import { OllamaEmbeddingProvider } from './ollama-embeddings.js';
+
+/** What the indexer needs to read a note's body for embedding. */
+export type NoteBodyLoader = (path: NotePath) => Promise<{ title: string; body: string } | null>;
+
+/** How many notes to embed before yielding back to the event loop. */
+const BATCH_SIZE = 8;
+/** Debounce window for coalescing rapid single-note (re)embeds after saves. */
+const DEBOUNCE_MS = 800;
+/** Max snippet length shown in a search hit. */
+const SNIPPET_CHARS = 160;
+
+export class EmbeddingIndexer {
+  private provider: EmbeddingProvider;
+  private settings: SemanticSettings;
+  private running = false;
+  private cancelRequested = false;
+  private providerOk = true;
+  private pendingPaths = new Set<NotePath>();
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private disposed = false;
+
+  constructor(
+    private readonly store: IndexStoreAdapter,
+    private readonly loadBody: NoteBodyLoader,
+    private readonly listPaths: () => Promise<NotePath[]>,
+    private readonly getWindow: () => BrowserWindow | null,
+    settings: SemanticSettings,
+  ) {
+    this.settings = settings;
+    this.provider = buildProvider(settings);
+  }
+
+  // ---- lifecycle ------------------------------------------------------
+
+  /** Swap settings at runtime (settings UI). Rebuilds the provider; if the
+   *  model changed, stored vectors with a different model_id will simply be
+   *  re-embedded on the next pass (their meta no longer matches). */
+  updateSettings(settings: SemanticSettings): void {
+    this.settings = settings;
+    this.provider = buildProvider(settings);
+  }
+
+  /** Cancel any in-flight pass and stop accepting work. */
+  dispose(): void {
+    this.disposed = true;
+    this.cancelRequested = true;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.pendingPaths.clear();
+  }
+
+  isEnabled(): boolean {
+    return this.settings.enabled;
+  }
+
+  // ---- change hooks (called from the save/rename/delete pipeline) -----
+
+  /** Enqueue a (re)embed for a note that was created or saved. Debounced. */
+  enqueue(path: NotePath): void {
+    if (this.disposed || !this.settings.enabled) return;
+    this.pendingPaths.add(path);
+    this.scheduleFlush();
+  }
+
+  /** Drop a note's embedding immediately (note deleted). Always safe. */
+  async remove(path: NotePath): Promise<void> {
+    this.pendingPaths.delete(path);
+    if (this.store.deleteEmbedding) {
+      try {
+        await this.store.deleteEmbedding(path);
+      } catch {
+        // The store is a cache; a failed delete just leaves an orphan row
+        // that the INNER JOIN in getAllEmbeddings already filters out.
+      }
+    }
+  }
+
+  /** Move an embedding from one path to another (rename). We re-embed the
+   *  destination on the next flush and drop the source now. */
+  async rename(from: NotePath, to: NotePath): Promise<void> {
+    await this.remove(from);
+    this.enqueue(to);
+  }
+
+  private scheduleFlush(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.flushPending();
+    }, DEBOUNCE_MS);
+  }
+
+  /** Embed everything queued since the last flush. */
+  private async flushPending(): Promise<void> {
+    if (this.disposed || !this.settings.enabled || this.running) {
+      // If a full pass is running it will pick these up via the skip check;
+      // re-arm so we don't lose them.
+      if (this.pendingPaths.size > 0 && !this.disposed) this.scheduleFlush();
+      return;
+    }
+    const paths = [...this.pendingPaths];
+    this.pendingPaths.clear();
+    if (paths.length === 0) return;
+    await this.embedPaths(paths, false);
+  }
+
+  // ---- full / on-demand pass -----------------------------------------
+
+  /**
+   * Full pass over the vault. `force` ignores the unchanged-skip check
+   * (used by reindex after a model change). Emits progress; honors cancel.
+   * Returns silently — callers fire-and-forget; status is observable via
+   * events / getStatus.
+   */
+  async runFullPass(force = false): Promise<void> {
+    if (this.disposed || !this.settings.enabled || this.running) return;
+    let paths: NotePath[];
+    try {
+      paths = await this.listPaths();
+    } catch {
+      return;
+    }
+    await this.embedPaths(paths, force);
+  }
+
+  /** Cancel an in-flight full pass. The loop checks between batches. */
+  cancel(): void {
+    if (this.running) this.cancelRequested = true;
+  }
+
+  private async embedPaths(paths: NotePath[], force: boolean): Promise<void> {
+    this.running = true;
+    this.cancelRequested = false;
+    await this.emitProgress();
+
+    try {
+      for (let i = 0; i < paths.length; i += BATCH_SIZE) {
+        if (this.cancelRequested || this.disposed) break;
+        const batch = paths.slice(i, i + BATCH_SIZE);
+        await this.embedBatch(batch, force);
+        // Yield to the event loop so IPC / UI stays responsive on big vaults.
+        await this.emitProgress();
+        await new Promise((r) => setImmediate(r));
+      }
+    } finally {
+      this.running = false;
+      this.cancelRequested = false;
+      await this.emitProgress();
+    }
+  }
+
+  private async embedBatch(batch: NotePath[], force: boolean): Promise<void> {
+    // Decide which notes actually need embedding (skip unchanged).
+    const toEmbed: Array<{ path: NotePath; title: string; text: string; hash: string }> = [];
+    for (const path of batch) {
+      let loaded: { title: string; body: string } | null;
+      try {
+        loaded = await this.loadBody(path);
+      } catch {
+        continue;
+      }
+      if (!loaded) continue;
+      const text = prepareEmbedText(loaded.title, loaded.body);
+      if (text.trim() === '') {
+        // Empty note: ensure no stale embedding lingers.
+        await this.remove(path);
+        continue;
+      }
+      const hash = hashContent(text);
+      if (!force && this.store.getEmbeddingMeta) {
+        const meta = await this.store.getEmbeddingMeta(path).catch(() => null);
+        if (meta && meta.contentHash === hash && meta.modelId === this.provider.id) {
+          continue; // unchanged content + same model → skip
+        }
+      }
+      toEmbed.push({ path, title: loaded.title, text, hash });
+    }
+    if (toEmbed.length === 0) return;
+
+    let vectors: Float32Array[];
+    try {
+      vectors = await this.provider.embed(toEmbed.map((t) => t.text));
+      this.providerOk = true;
+    } catch {
+      // Provider unreachable: stop the pass (retrying every note would just
+      // hammer a dead daemon). Mark not-ok so the UI can prompt the user.
+      this.providerOk = false;
+      this.cancelRequested = true;
+      return;
+    }
+
+    if (!this.store.upsertEmbedding) return;
+    for (let i = 0; i < toEmbed.length; i++) {
+      const item = toEmbed[i]!;
+      const vec = vectors[i];
+      if (!vec || vec.length === 0) continue;
+      await this.store.upsertEmbedding({
+        sourcePath: item.path,
+        title: '', // joined from notes on read
+        contentHash: item.hash,
+        modelId: this.provider.id,
+        dim: vec.length,
+        vector: vec,
+        mtimeMs: Date.now(),
+      });
+    }
+  }
+
+  // ---- search ---------------------------------------------------------
+
+  /**
+   * Embed the query, brute-force cosine over stored vectors, return top-K
+   * with snippets. Returns a typed degradation reason on every failure path
+   * — never throws across IPC.
+   */
+  async search(
+    query: string,
+    limit: number,
+  ): Promise<
+    | { ok: true; hits: SemanticHit[] }
+    | {
+        ok: false;
+        reason: 'disabled' | 'provider-unreachable' | 'not-indexed' | 'error';
+        message: string;
+      }
+  > {
+    if (!this.settings.enabled) {
+      return { ok: false, reason: 'disabled', message: 'La ricerca semantica è disattivata.' };
+    }
+    if (!this.store.getAllEmbeddings) {
+      return { ok: false, reason: 'error', message: 'Indice embeddings non disponibile.' };
+    }
+    const trimmed = query.trim();
+    if (trimmed === '') return { ok: true, hits: [] };
+
+    let rows;
+    try {
+      rows = await this.store.getAllEmbeddings();
+    } catch {
+      return { ok: false, reason: 'error', message: 'Lettura indice embeddings fallita.' };
+    }
+    if (rows.length === 0) {
+      return {
+        ok: false,
+        reason: 'not-indexed',
+        message: 'Nessuna nota ancora indicizzata. Avvia la reindicizzazione.',
+      };
+    }
+
+    let queryVec: Float32Array;
+    try {
+      const [v] = await this.provider.embed([trimmed]);
+      if (!v) throw new Error('empty embedding');
+      queryVec = v;
+      this.providerOk = true;
+    } catch {
+      this.providerOk = false;
+      return {
+        ok: false,
+        reason: 'provider-unreachable',
+        message: 'Ollama non è raggiungibile. Avvialo per usare la ricerca semantica.',
+      };
+    }
+
+    const embRows = rows.map((r) => ({
+      path: r.sourcePath,
+      title: r.title,
+      contentHash: r.contentHash,
+      modelId: r.modelId,
+      dim: r.dim,
+      vector: r.vector,
+      mtimeMs: r.mtimeMs,
+    }));
+    const ranked = rankBySimilarity(queryVec, embRows, limit);
+    const hits = await this.attachSnippets(ranked);
+    return { ok: true, hits };
+  }
+
+  /** Pull a short body excerpt for each hit. Best-effort; a failed read
+   *  just yields an empty snippet rather than dropping the hit. */
+  private async attachSnippets(hits: SemanticHit[]): Promise<SemanticHit[]> {
+    const out: SemanticHit[] = [];
+    for (const hit of hits) {
+      let snippet = '';
+      try {
+        const loaded = await this.loadBody(hit.path);
+        if (loaded) {
+          const body = loaded.body.replace(/\s+/g, ' ').trim();
+          snippet = body.length > SNIPPET_CHARS ? `${body.slice(0, SNIPPET_CHARS)}…` : body;
+        }
+      } catch {
+        // leave empty
+      }
+      out.push({ ...hit, snippet });
+    }
+    return out;
+  }
+
+  // ---- status ---------------------------------------------------------
+
+  async getStatus(): Promise<EmbeddingStatus> {
+    let indexed = 0;
+    let total = 0;
+    if (this.store.getEmbeddingCounts) {
+      try {
+        const c = await this.store.getEmbeddingCounts();
+        indexed = c.indexed;
+        total = c.total;
+      } catch {
+        // counts are best-effort
+      }
+    }
+    let providerOk = this.providerOk;
+    // Active health check when enabled so the UI reflects reality even
+    // before the first embed call. Cheap (/api/tags); never throws.
+    if (this.settings.enabled && this.provider instanceof OllamaEmbeddingProvider) {
+      providerOk = await this.provider.ping();
+      this.providerOk = providerOk;
+    }
+    return {
+      enabled: this.settings.enabled,
+      indexed,
+      total,
+      running: this.running,
+      providerOk,
+      modelId: this.provider.id,
+    };
+  }
+
+  private async emitProgress(): Promise<void> {
+    const win = this.getWindow();
+    if (!win || win.isDestroyed()) return;
+    let indexed = 0;
+    let total = 0;
+    if (this.store.getEmbeddingCounts) {
+      try {
+        const c = await this.store.getEmbeddingCounts();
+        indexed = c.indexed;
+        total = c.total;
+      } catch {
+        // ignore
+      }
+    }
+    const payload: EmbeddingProgressPayload = {
+      indexed,
+      total,
+      running: this.running,
+      providerOk: this.providerOk,
+    };
+    win.webContents.send(IpcChannels.embeddingProgress, payload);
+  }
+}
+
+/** Build the concrete provider from settings. Currently Ollama-only. */
+function buildProvider(settings: SemanticSettings): EmbeddingProvider {
+  return new OllamaEmbeddingProvider({ baseUrl: settings.baseUrl, model: settings.model });
+}

--- a/apps/desktop/electron/ai/ollama-embeddings.test.ts
+++ b/apps/desktop/electron/ai/ollama-embeddings.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OllamaEmbeddingProvider, OllamaUnavailableError } from './ollama-embeddings.js';
+
+// The provider is the one network-touching piece. These tests stub global
+// `fetch` to prove the two contracts the pipeline relies on: a valid
+// response decodes to a Float32Array, and EVERY failure mode surfaces as a
+// typed OllamaUnavailableError (so the indexer degrades, never crashes).
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('OllamaEmbeddingProvider', () => {
+  it('derives a stable id from the model', () => {
+    const p = new OllamaEmbeddingProvider({
+      baseUrl: 'http://localhost:11434',
+      model: 'nomic-embed-text',
+    });
+    expect(p.id).toBe('ollama:nomic-embed-text');
+  });
+
+  it('decodes a valid embedding response, preserving batch order', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const { prompt } = JSON.parse(init.body) as { prompt: string };
+        calls.push(prompt);
+        // Echo a vector whose first element encodes the prompt length, so
+        // we can assert order is preserved.
+        return {
+          ok: true,
+          json: async () => ({ embedding: [prompt.length, 0.5, -0.5] }),
+        };
+      }),
+    );
+    const p = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    const out = await p.embed(['ab', 'abcd']);
+    expect(out).toHaveLength(2);
+    expect(out[0]![0]).toBe(2);
+    expect(out[1]![0]).toBe(4);
+    expect(calls).toEqual(['ab', 'abcd']);
+  });
+
+  it('throws OllamaUnavailableError when the daemon is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      }),
+    );
+    const p = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    await expect(p.embed(['x'])).rejects.toBeInstanceOf(OllamaUnavailableError);
+  });
+
+  it('throws OllamaUnavailableError on a non-ok status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, text: async () => 'boom' })),
+    );
+    const p = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    await expect(p.embed(['x'])).rejects.toBeInstanceOf(OllamaUnavailableError);
+  });
+
+  it('throws OllamaUnavailableError on an empty / malformed embedding', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ embedding: [] }) })),
+    );
+    const p = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    await expect(p.embed(['x'])).rejects.toBeInstanceOf(OllamaUnavailableError);
+  });
+
+  it('ping returns false when unreachable, true on ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true })),
+    );
+    const up = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    expect(await up.ping()).toBe(true);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('refused');
+      }),
+    );
+    const down = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434', model: 'm' });
+    expect(await down.ping()).toBe(false);
+  });
+
+  it('normalizes a trailing slash in the base URL', async () => {
+    let calledUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calledUrl = url;
+        return { ok: true, json: async () => ({ embedding: [1] }) };
+      }),
+    );
+    const p = new OllamaEmbeddingProvider({ baseUrl: 'http://localhost:11434/', model: 'm' });
+    await p.embed(['x']);
+    expect(calledUrl).toBe('http://localhost:11434/api/embeddings');
+  });
+});

--- a/apps/desktop/electron/ai/ollama-embeddings.ts
+++ b/apps/desktop/electron/ai/ollama-embeddings.ts
@@ -1,0 +1,118 @@
+// Ollama embedding provider (v1 backend for semantic search).
+//
+// Talks to a locally-running Ollama daemon over HTTP — no native deps, no
+// cloud, notes never leave the machine. Ollama's embeddings endpoint takes
+// ONE prompt per call, so a batch is issued sequentially. Every network
+// path is defensive: a timeout and a clear error so the indexing pipeline
+// can degrade (mark provider unreachable) rather than crash.
+
+import type { EmbeddingProvider } from '@ziba/core';
+
+export type OllamaConfig = {
+  baseUrl: string;
+  model: string;
+  /** Per-request timeout in ms. Generous: first call may load the model. */
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Thrown when Ollama is unreachable or returns an error. Carries a
+ *  user-facing Italian message so the IPC layer can surface it directly. */
+export class OllamaUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OllamaUnavailableError';
+  }
+}
+
+type EmbeddingsResponse = {
+  embedding?: number[];
+};
+
+export class OllamaEmbeddingProvider implements EmbeddingProvider {
+  readonly id: string;
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly timeoutMs: number;
+
+  constructor(config: OllamaConfig) {
+    // Normalize: drop a trailing slash so `${baseUrl}/api/...` is clean.
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.model = config.model;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.id = `ollama:${this.model}`;
+  }
+
+  /**
+   * Embed each text with a sequential round-trip. Order + length are
+   * preserved (one output vector per input). Any failure (network,
+   * timeout, bad status, malformed body) throws `OllamaUnavailableError`
+   * so the caller can degrade gracefully.
+   */
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    const out: Float32Array[] = [];
+    for (const text of texts) {
+      out.push(await this.embedOne(text));
+    }
+    return out;
+  }
+
+  private async embedOne(prompt: string): Promise<Float32Array> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${this.baseUrl}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: this.model, prompt }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new OllamaUnavailableError(
+          `Ollama ha risposto con stato ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ''}.`,
+        );
+      }
+      const data = (await res.json()) as EmbeddingsResponse;
+      if (!Array.isArray(data.embedding) || data.embedding.length === 0) {
+        throw new OllamaUnavailableError(
+          `Ollama non ha restituito un embedding valido per il modello "${this.model}". Verifica che il modello sia installato (ollama pull ${this.model}).`,
+        );
+      }
+      return Float32Array.from(data.embedding);
+    } catch (err) {
+      if (err instanceof OllamaUnavailableError) throw err;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new OllamaUnavailableError(
+          `Timeout dopo ${this.timeoutMs} ms contattando Ollama su ${this.baseUrl}.`,
+        );
+      }
+      // ECONNREFUSED / DNS / TypeError("fetch failed"): Ollama is not
+      // running or the URL is wrong. Give an actionable hint.
+      throw new OllamaUnavailableError(
+        `Impossibile contattare Ollama su ${this.baseUrl}. Avvia Ollama (ollama serve) e riprova.`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Lightweight health check for the status surface. Returns true if the
+   * daemon answers `/api/tags` (cheaper than an embed; doesn't require the
+   * model to be pulled). Never throws.
+   */
+  async ping(): Promise<boolean> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5_000);
+    try {
+      const res = await fetch(`${this.baseUrl}/api/tags`, { signal: controller.signal });
+      return res.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/apps/desktop/electron/ipc/ai.ts
+++ b/apps/desktop/electron/ipc/ai.ts
@@ -1,0 +1,81 @@
+// IPC handlers for semantic search (milestone 1).
+//
+// Every handler degrades gracefully: when the feature is off, no vault is
+// open, or Ollama is down, they return a typed "not ok" / default status
+// rather than throwing — so the renderer never has to catch to stay alive.
+
+import type { EmbeddingStatus, SemanticSettings } from '@ziba/core';
+import type { SemanticSearchResult } from '../../shared/ipc.js';
+import { getEmbeddingIndexer } from '../state.js';
+import { getSemanticSettings, setSemanticSettings } from './settings.js';
+
+const SEARCH_LIMIT_DEFAULT = 20;
+const SEARCH_LIMIT_MAX = 50;
+
+export async function semanticSearch(args: {
+  query: string;
+  limit?: number;
+}): Promise<SemanticSearchResult> {
+  const indexer = getEmbeddingIndexer();
+  if (!indexer) {
+    return { ok: false, reason: 'disabled', message: 'Nessun vault aperto.' };
+  }
+  const limit = Math.max(1, Math.min(args.limit ?? SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX));
+  return indexer.search(args.query, limit);
+}
+
+export async function getEmbeddingStatus(): Promise<EmbeddingStatus> {
+  const indexer = getEmbeddingIndexer();
+  if (!indexer) {
+    // No vault open: report a safe disabled snapshot.
+    const settings = await getSemanticSettings();
+    return {
+      enabled: settings.enabled,
+      indexed: 0,
+      total: 0,
+      running: false,
+      providerOk: false,
+      modelId: `ollama:${settings.model}`,
+    };
+  }
+  return indexer.getStatus();
+}
+
+export async function reindexEmbeddings(): Promise<{ started: boolean }> {
+  const indexer = getEmbeddingIndexer();
+  if (!indexer || !indexer.isEnabled()) return { started: false };
+  // Force a full rebuild (ignore the unchanged-skip), fire-and-forget so the
+  // IPC call returns immediately; progress streams over `embeddingProgress`.
+  void indexer.runFullPass(true);
+  return { started: true };
+}
+
+export async function getSemanticSettingsHandler(): Promise<SemanticSettings> {
+  return getSemanticSettings();
+}
+
+/**
+ * Persist new provider settings and reconfigure the live indexer. Toggling
+ * `enabled` on kicks off a full pass; toggling off cancels any in-flight
+ * pass. Returns the merged, validated settings.
+ */
+export async function setSemanticSettingsHandler(args: {
+  settings: Partial<SemanticSettings>;
+}): Promise<SemanticSettings> {
+  const before = await getSemanticSettings();
+  const next = await setSemanticSettings(args.settings ?? {});
+  const indexer = getEmbeddingIndexer();
+  if (indexer) {
+    indexer.updateSettings(next);
+    const turnedOn = !before.enabled && next.enabled;
+    const modelChanged = before.model !== next.model || before.baseUrl !== next.baseUrl;
+    if (!next.enabled) {
+      indexer.cancel();
+    } else if (turnedOn || modelChanged) {
+      // New model/URL means stored vectors may be stale (different model_id)
+      // — a full pass re-embeds what's changed and skips what isn't.
+      void indexer.runFullPass(modelChanged);
+    }
+  }
+  return next;
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -51,6 +51,13 @@ import {
   getRelationsByTarget,
 } from './types.js';
 import { getRecentVaults } from './settings.js';
+import {
+  semanticSearch,
+  getEmbeddingStatus,
+  reindexEmbeddings,
+  getSemanticSettingsHandler,
+  setSemanticSettingsHandler,
+} from './ai.js';
 
 type Handler<C extends keyof IpcRequests> = (
   args: IpcRequests[C],
@@ -138,6 +145,13 @@ export function registerIpcHandlers(win: BrowserWindow): void {
 
   // Settings
   handle(IpcChannels.getRecentVaults, () => getRecentVaults());
+
+  // AI semantic search (milestone 1)
+  handle(IpcChannels.semanticSearch, (args) => semanticSearch(args));
+  handle(IpcChannels.getEmbeddingStatus, () => getEmbeddingStatus());
+  handle(IpcChannels.reindexEmbeddings, () => reindexEmbeddings());
+  handle(IpcChannels.getSemanticSettings, () => getSemanticSettingsHandler());
+  handle(IpcChannels.setSemanticSettings, (args) => setSemanticSettingsHandler(args));
 }
 
 /**

--- a/apps/desktop/electron/ipc/notes.ts
+++ b/apps/desktop/electron/ipc/notes.ts
@@ -29,7 +29,7 @@ import {
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { IpcChannels, type VaultEventPayload } from '../../shared/ipc.js';
 import { assertResolvedWithinVault, assertVaultRelative, IpcError } from '../security.js';
-import { markSelfWrite, requireIndexStore, requireVault } from '../state.js';
+import { getEmbeddingIndexer, markSelfWrite, requireIndexStore, requireVault } from '../state.js';
 
 /**
  * Push a synthetic 'change' vault event to the renderer after a
@@ -151,6 +151,10 @@ export async function saveNote(args: {
   // typedPaths, tags, and the database store.
   pushSyntheticChangeEvent(args.path, st.mtimeMs);
 
+  // AI: queue a (re)embed for this note. Debounced + skipped if the
+  // content hash is unchanged. No-op when the feature is disabled.
+  getEmbeddingIndexer()?.enqueue(args.path);
+
   return { mtimeMs: st.mtimeMs };
 }
 
@@ -182,6 +186,9 @@ export async function createNote(args: { path: NotePath; initialBody?: string })
   // Watcher echo suppressed for this write. Push a synthetic add/change
   // event so the renderer learns about the new file immediately.
   pushSyntheticChangeEvent(args.path, st.mtimeMs);
+
+  // AI: queue an embed for the new note. No-op when disabled.
+  getEmbeddingIndexer()?.enqueue(args.path);
 
   const title = parseMarkdown(body).headingTitle ?? deriveTitleFromPath(args.path);
 
@@ -258,6 +265,9 @@ export async function renameNote(args: {
   // the renamed note.
   await store.reresolveStaleWikilinks(args.from);
 
+  // AI: drop the old path's embedding and queue a re-embed at the new path.
+  await getEmbeddingIndexer()?.rename(args.from, args.to);
+
   return { newPath: args.to };
 }
 
@@ -273,6 +283,9 @@ export async function deleteNote(args: { path: NotePath }): Promise<void> {
   markSelfWrite(args.path);
   await fs.deleteFile(abs);
   await store.deleteNote(args.path);
+
+  // AI: drop this note's embedding too. No-op when disabled / absent.
+  await getEmbeddingIndexer()?.remove(args.path);
 }
 
 export async function searchByTitle(args: {

--- a/apps/desktop/electron/ipc/settings.ts
+++ b/apps/desktop/electron/ipc/settings.ts
@@ -7,13 +7,19 @@
 import { app } from 'electron';
 import path from 'node:path';
 import { promises as fsp } from 'node:fs';
+import { DEFAULT_SEMANTIC_SETTINGS, type SemanticSettings } from '@ziba/core';
 import type { VaultInfo } from '../../shared/ipc.js';
 
 const FILENAME = 'recent-vaults.json';
 const MAX_RECENT = 10;
+const SEMANTIC_FILENAME = 'semantic-settings.json';
 
 function filePath(): string {
   return path.join(app.getPath('userData'), FILENAME);
+}
+
+function semanticFilePath(): string {
+  return path.join(app.getPath('userData'), SEMANTIC_FILENAME);
 }
 
 export async function getRecentVaults(): Promise<VaultInfo[]> {
@@ -56,4 +62,53 @@ export async function pushRecentVault(v: VaultInfo): Promise<void> {
   const fp = filePath();
   await fsp.mkdir(path.dirname(fp), { recursive: true });
   await fsp.writeFile(fp, JSON.stringify(next, null, 2), 'utf8');
+}
+
+// ---- Semantic-search settings (per-app, not per-vault) ------------------
+//
+// Provider config (enabled / baseUrl / model) is a machine-level choice —
+// the same Ollama daemon serves every vault — so it lives in userData
+// alongside recent-vaults. The embeddings themselves are per-vault in
+// `<vault>/.ziba/index.db`.
+
+function coerceSemanticSettings(raw: unknown): SemanticSettings {
+  if (typeof raw !== 'object' || raw === null) return { ...DEFAULT_SEMANTIC_SETTINGS };
+  const r = raw as Partial<SemanticSettings>;
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : DEFAULT_SEMANTIC_SETTINGS.enabled,
+    baseUrl:
+      typeof r.baseUrl === 'string' && r.baseUrl.trim() !== ''
+        ? r.baseUrl.trim()
+        : DEFAULT_SEMANTIC_SETTINGS.baseUrl,
+    model:
+      typeof r.model === 'string' && r.model.trim() !== ''
+        ? r.model.trim()
+        : DEFAULT_SEMANTIC_SETTINGS.model,
+  };
+}
+
+export async function getSemanticSettings(): Promise<SemanticSettings> {
+  try {
+    const raw = await fsp.readFile(semanticFilePath(), 'utf8');
+    return coerceSemanticSettings(JSON.parse(raw));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ...DEFAULT_SEMANTIC_SETTINGS };
+    }
+    // Corrupt / unreadable: log and fall back to defaults (feature OFF) so
+    // the app never breaks over a bad settings file.
+    console.error('[settings] semantic-settings.json unreadable, using defaults:', err);
+    return { ...DEFAULT_SEMANTIC_SETTINGS };
+  }
+}
+
+export async function setSemanticSettings(
+  patch: Partial<SemanticSettings>,
+): Promise<SemanticSettings> {
+  const current = await getSemanticSettings();
+  const next = coerceSemanticSettings({ ...current, ...patch });
+  const fp = semanticFilePath();
+  await fsp.mkdir(path.dirname(fp), { recursive: true });
+  await fsp.writeFile(fp, JSON.stringify(next, null, 2), 'utf8');
+  return next;
 }

--- a/apps/desktop/electron/ipc/vault.ts
+++ b/apps/desktop/electron/ipc/vault.ts
@@ -61,12 +61,14 @@ export async function pickVaultFolder(args: {
  * (so we never leak the previous vault's watcher / DB handle).
  */
 async function teardown(): Promise<void> {
-  // Stop the embedding pass first so it doesn't write to a DB we're about
-  // to close. dispose() cancels any in-flight pass and clears the queue.
+  // Stop the embedding pass FIRST and AWAIT it so it doesn't write to a DB
+  // we're about to close. dispose() cancels the in-flight pass and resolves
+  // once the current batch has settled — bounded by one batch, not the
+  // whole vault. This must complete before `s.close()` below.
   const emb = getEmbeddingIndexer();
   if (emb) {
     try {
-      emb.dispose();
+      await emb.dispose();
     } catch {
       // best effort
     }

--- a/apps/desktop/electron/ipc/vault.ts
+++ b/apps/desktop/electron/ipc/vault.ts
@@ -7,27 +7,38 @@
 import { dialog, BrowserWindow } from 'electron';
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
-import { indexVault } from '@ziba/core';
+import {
+  deriveTitleFromPath,
+  getFrontmatterTitle,
+  indexVault,
+  loadNote as coreLoadNote,
+  parseMarkdown,
+  scanVault,
+  type NotePath,
+} from '@ziba/core';
 import { IpcChannels, type VaultInfo } from '../../shared/ipc.js';
 import { getFilesystemAdapter } from '../adapters/filesystem.electron.js';
 import { SqliteIndexStore } from '../adapters/index-store.sqlite.js';
 import { ChokidarWatcher } from '../adapters/watcher.chokidar.js';
+import { EmbeddingIndexer } from '../ai/embedding-indexer.js';
 import { bootstrapSchemas, watchSchemas } from '../schema-loader.js';
 import { IpcError } from '../security.js';
 import {
   consumeIfSelfWrite,
   getCurrentVault,
+  getEmbeddingIndexer,
   getIndexStore,
   getSchemaWatcher,
   getWatcher,
   requireIndexStore,
   setCurrentVault,
+  setEmbeddingIndexer,
   setFilesystem,
   setIndexStore,
   setSchemaWatcher,
   setWatcher,
 } from '../state.js';
-import { pushRecentVault } from './settings.js';
+import { getSemanticSettings, pushRecentVault } from './settings.js';
 
 export async function pickVaultFolder(args: {
   defaultPath?: string;
@@ -50,6 +61,17 @@ export async function pickVaultFolder(args: {
  * (so we never leak the previous vault's watcher / DB handle).
  */
 async function teardown(): Promise<void> {
+  // Stop the embedding pass first so it doesn't write to a DB we're about
+  // to close. dispose() cancels any in-flight pass and clears the queue.
+  const emb = getEmbeddingIndexer();
+  if (emb) {
+    try {
+      emb.dispose();
+    } catch {
+      // best effort
+    }
+    setEmbeddingIndexer(null);
+  }
   const w = getWatcher();
   if (w) {
     try {
@@ -159,6 +181,24 @@ export async function openVault(win: BrowserWindow, args: { root: string }): Pro
   });
   setWatcher(watcher);
 
+  // AI semantic search (milestone 1). Build the embedding indexer for this
+  // vault. It is gated behind the per-app "enabled" setting — when OFF, the
+  // indexer is still constructed (so toggling on later works) but does ZERO
+  // work and makes ZERO Ollama calls. The initial full pass runs in the
+  // background (fire-and-forget) so it never blocks vault open.
+  const semanticSettings = await getSemanticSettings();
+  const embedder = new EmbeddingIndexer(
+    indexStore,
+    makeBodyLoader(root),
+    () => listVaultNotePaths(root),
+    () => (win.isDestroyed() ? null : win),
+    semanticSettings,
+  );
+  setEmbeddingIndexer(embedder);
+  if (semanticSettings.enabled) {
+    void embedder.runFullPass(false);
+  }
+
   const info: VaultInfo = {
     root,
     name: path.basename(root) || root,
@@ -168,6 +208,37 @@ export async function openVault(win: BrowserWindow, args: { root: string }): Pro
   await pushRecentVault(info);
 
   return info;
+}
+
+/**
+ * Build a NoteBodyLoader bound to a vault root. Reads a note's title +
+ * body from disk for embedding. Returns null when the file is gone so the
+ * indexer can skip it without throwing.
+ */
+function makeBodyLoader(
+  root: string,
+): (p: NotePath) => Promise<{ title: string; body: string } | null> {
+  const fs = getFilesystemAdapter();
+  return async (notePath: NotePath) => {
+    try {
+      const note = await coreLoadNote(fs, root, notePath);
+      const title =
+        getFrontmatterTitle(note.frontmatter) ??
+        parseMarkdown(note.content).headingTitle ??
+        deriveTitleFromPath(notePath);
+      return { title, body: note.content };
+    } catch {
+      return null;
+    }
+  };
+}
+
+/** List every `.md` note path in the vault (vault-relative) for a full pass. */
+async function listVaultNotePaths(root: string): Promise<NotePath[]> {
+  const fs = getFilesystemAdapter();
+  const out: NotePath[] = [];
+  for await (const p of scanVault(fs, root)) out.push(p);
+  return out;
 }
 
 export async function closeVault(): Promise<void> {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -11,6 +11,7 @@ import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import {
   IpcChannels,
   type DatabaseViewsChangedPayload,
+  type EmbeddingProgressPayload,
   type IndexProgressPayload,
   type IpcRequests,
   type IpcResponses,
@@ -46,6 +47,16 @@ const api: ZibaApi = {
     ipcRenderer.on(IpcChannels.indexProgress, wrapped);
     return () => {
       ipcRenderer.off(IpcChannels.indexProgress, wrapped);
+    };
+  },
+
+  onEmbeddingProgress(listener: (payload: EmbeddingProgressPayload) => void): () => void {
+    const wrapped = (_e: IpcRendererEvent, payload: EmbeddingProgressPayload): void => {
+      listener(payload);
+    };
+    ipcRenderer.on(IpcChannels.embeddingProgress, wrapped);
+    return () => {
+      ipcRenderer.off(IpcChannels.embeddingProgress, wrapped);
     };
   },
 

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -7,6 +7,7 @@
 
 import type { FilesystemAdapter, IndexStoreAdapter, NotePath, WatcherAdapter } from '@ziba/core';
 import type { VaultInfo } from '../shared/ipc.js';
+import type { EmbeddingIndexer } from './ai/embedding-indexer.js';
 import { IpcError } from './security.js';
 
 let currentVault: VaultInfo | null = null;
@@ -14,6 +15,7 @@ let indexStore: IndexStoreAdapter | null = null;
 let watcher: WatcherAdapter | null = null;
 let filesystem: FilesystemAdapter | null = null;
 let schemaWatcher: { stop: () => Promise<void> } | null = null;
+let embeddingIndexer: EmbeddingIndexer | null = null;
 
 // Paths we just wrote ourselves, with an expiry timestamp. The watcher
 // uses this to skip echoes of our own writes (chokidar's awaitWriteFinish
@@ -60,6 +62,14 @@ export function getSchemaWatcher(): { stop: () => Promise<void> } | null {
 
 export function setSchemaWatcher(w: { stop: () => Promise<void> } | null): void {
   schemaWatcher = w;
+}
+
+export function getEmbeddingIndexer(): EmbeddingIndexer | null {
+  return embeddingIndexer;
+}
+
+export function setEmbeddingIndexer(e: EmbeddingIndexer | null): void {
+  embeddingIndexer = e;
 }
 
 /**

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -11,6 +11,7 @@ import type {
   DatabaseViewLayout,
   DatabaseViewsFile,
   DetectedProperty,
+  EmbeddingStatus,
   Frontmatter,
   FullGraph,
   GraphEdge,
@@ -22,6 +23,8 @@ import type {
   PropertyType,
   RelationRow,
   ScalarFilter,
+  SemanticHit,
+  SemanticSettings,
   TypeCountRow,
 } from '@ziba/core';
 
@@ -37,6 +40,7 @@ export type {
   DatabaseViewLayout,
   DatabaseViewsFile,
   DetectedProperty,
+  EmbeddingStatus,
   FullGraph,
   GraphEdge,
   GraphNode,
@@ -44,6 +48,8 @@ export type {
   PropertyType,
   RelationRow,
   ScalarFilter,
+  SemanticHit,
+  SemanticSettings,
   TypeCountRow,
 };
 
@@ -105,9 +111,17 @@ export const IpcChannels = {
   // Settings / persisted state
   getRecentVaults: 'settings:recentVaults',
 
+  // AI semantic search (milestone 1)
+  semanticSearch: 'ai:semanticSearch',
+  getEmbeddingStatus: 'ai:embeddingStatus',
+  reindexEmbeddings: 'ai:reindexEmbeddings',
+  getSemanticSettings: 'ai:getSettings',
+  setSemanticSettings: 'ai:setSettings',
+
   // Watcher push events (main → renderer)
   vaultEvent: 'watcher:event',
   indexProgress: 'index:progress',
+  embeddingProgress: 'ai:embeddingProgress',
   databaseViewsChanged: 'database:viewsChanged',
 } as const;
 
@@ -202,6 +216,13 @@ export type IpcRequests = {
   [IpcChannels.getRelationsByTarget]: { targetPath: NotePath; kind?: string };
 
   [IpcChannels.getRecentVaults]: void;
+
+  // AI
+  [IpcChannels.semanticSearch]: { query: string; limit?: number };
+  [IpcChannels.getEmbeddingStatus]: void;
+  [IpcChannels.reindexEmbeddings]: void;
+  [IpcChannels.getSemanticSettings]: void;
+  [IpcChannels.setSemanticSettings]: { settings: Partial<SemanticSettings> };
 };
 
 export type Backlink = {
@@ -225,6 +246,19 @@ export type LinkReferencesResult = {
 };
 
 export type DatabaseViewsChangedPayload = DatabaseViewsFile;
+
+/**
+ * Result of a semantic search. A discriminated union so the renderer can
+ * distinguish "feature off", "provider down", and "ok with hits" WITHOUT
+ * parsing an error string — every degradation path is typed, never a crash.
+ */
+export type SemanticSearchResult =
+  | { ok: true; hits: SemanticHit[] }
+  | {
+      ok: false;
+      reason: 'disabled' | 'provider-unreachable' | 'not-indexed' | 'error';
+      message: string;
+    };
 
 /** A single full-text-search hit returned to the renderer. */
 export type SearchHit = {
@@ -294,6 +328,13 @@ export type IpcResponses = {
   [IpcChannels.getRelationsByTarget]: RelationRow[];
 
   [IpcChannels.getRecentVaults]: VaultInfo[];
+
+  // AI
+  [IpcChannels.semanticSearch]: SemanticSearchResult;
+  [IpcChannels.getEmbeddingStatus]: EmbeddingStatus;
+  [IpcChannels.reindexEmbeddings]: { started: boolean };
+  [IpcChannels.getSemanticSettings]: SemanticSettings;
+  [IpcChannels.setSemanticSettings]: SemanticSettings;
 };
 
 // ---- Push events (main → renderer, no response) ----
@@ -310,6 +351,18 @@ export type VaultEventPayload =
 
 export type IndexProgressPayload = { processed: number; total: number | null };
 
+/**
+ * Embedding-pass progress (main → renderer). `running` flips false when the
+ * pass finishes or is cancelled; `providerOk` lets the UI flag an Ollama
+ * outage without a separate status poll.
+ */
+export type EmbeddingProgressPayload = {
+  indexed: number;
+  total: number;
+  running: boolean;
+  providerOk: boolean;
+};
+
 // ---- API surface exposed via contextBridge to window.ziba ----
 
 export interface ZibaApi {
@@ -320,6 +373,7 @@ export interface ZibaApi {
 
   onVaultEvent(listener: (payload: VaultEventPayload) => void): () => void;
   onIndexProgress(listener: (payload: IndexProgressPayload) => void): () => void;
+  onEmbeddingProgress(listener: (payload: EmbeddingProgressPayload) => void): () => void;
   onDatabaseViewsChanged(listener: (payload: DatabaseViewsChangedPayload) => void): () => void;
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState } from 'react';
 import { EmptyState } from './components/EmptyState';
 import { Layout } from './components/Layout';
 import { SearchPalette } from './components/SearchPalette';
+import { SettingsPanel } from './components/SettingsPanel';
 import { ToastStack } from './components/ToastStack';
 import { useEditorStore } from './stores/editor';
 import { useSearchStore } from './stores/search';
+import { useSemanticStore } from './stores/semantic';
 import { useTagsStore } from './stores/tags';
 import { useUiStore } from './stores/ui';
 import { useVaultStore } from './stores/vault';
@@ -55,10 +57,16 @@ export function App(): JSX.Element {
       setIndexProgress(p);
     });
 
+    // AI: keep the semantic-settings panel's status live during a pass.
+    const offEmbeddingProgress = ipc.onEmbeddingProgress((p) => {
+      useSemanticStore.getState().applyProgress(p);
+    });
+
     return () => {
       active = false;
       offVaultEvent();
       offIndexProgress();
+      offEmbeddingProgress();
     };
   }, [hydrateFromMain, applyVaultEvent, applyExternalChange, setIndexProgress]);
 
@@ -172,6 +180,7 @@ export function App(): JSX.Element {
     <>
       <Layout />
       <SearchPalette />
+      <SettingsPanel />
       <ToastStack />
     </>
   );

--- a/apps/desktop/src/components/Ribbon.tsx
+++ b/apps/desktop/src/components/Ribbon.tsx
@@ -9,6 +9,7 @@ import {
 } from '@phosphor-icons/react';
 import type { JSX } from 'react';
 import { useSearchStore } from '../stores/search';
+import { useSemanticStore } from '../stores/semantic';
 import { THEMES, THEME_IDS, type ThemeId } from '../lib/theme';
 import { useUiStore } from '../stores/ui';
 import { Tooltip } from './ui/Tooltip';
@@ -24,6 +25,7 @@ function themeLabel(id: ThemeId): string {
 
 export function Ribbon(): JSX.Element {
   const openPalette = useSearchStore((s) => s.openPalette);
+  const openSettings = useSemanticStore((s) => s.openPanel);
   const mainView = useUiStore((s) => s.mainView);
   const setMainView = useUiStore((s) => s.setMainView);
   const themeId = useUiStore((s) => s.themeId);
@@ -73,8 +75,7 @@ export function Ribbon(): JSX.Element {
         />
         <RibbonButton
           label="Impostazioni"
-          disabled
-          tooltip="Impostazioni in arrivo nel pannello dedicato"
+          onClick={openSettings}
           icon={<Gear size={20} aria-hidden="true" />}
         />
       </div>

--- a/apps/desktop/src/components/SettingsPanel/index.tsx
+++ b/apps/desktop/src/components/SettingsPanel/index.tsx
@@ -1,0 +1,266 @@
+import { ArrowsClockwise, X } from '@phosphor-icons/react';
+import { useEffect, useRef, useState, type JSX } from 'react';
+import { createPortal } from 'react-dom';
+import { useSemanticStore } from '../../stores/semantic';
+
+/**
+ * Minimal, token-based settings surface. Milestone 1 ships a single
+ * section — AI semantic search (Ricerca semantica) — letting the user
+ * enable the feature, point at their Ollama daemon, see status
+ * (reachable? indexed/total, indexing progress) and force a reindex.
+ *
+ * Mounted unconditionally near the App root; renders via portal only when
+ * `useSemanticStore.open`. Escape and the backdrop both close it.
+ */
+export function SettingsPanel(): JSX.Element | null {
+  const open = useSemanticStore((s) => s.open);
+  const settings = useSemanticStore((s) => s.settings);
+  const status = useSemanticStore((s) => s.status);
+  const loading = useSemanticStore((s) => s.loading);
+  const saving = useSemanticStore((s) => s.saving);
+  const error = useSemanticStore((s) => s.error);
+  const closePanel = useSemanticStore((s) => s.closePanel);
+  const save = useSemanticStore((s) => s.save);
+  const reindex = useSemanticStore((s) => s.reindex);
+
+  // Local draft for the text inputs so typing doesn't round-trip to disk on
+  // every keystroke; committed on blur / Enter.
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (settings) {
+      setBaseUrl(settings.baseUrl);
+      setModel(settings.model);
+    }
+  }, [settings]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        closePanel();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    // Move focus into the dialog for keyboard + screen-reader users.
+    dialogRef.current?.focus();
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, closePanel]);
+
+  if (!open) return null;
+
+  const enabled = settings?.enabled ?? false;
+  const pct = status.total > 0 ? Math.round((status.indexed / status.total) * 100) : 0;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={closePanel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Impostazioni"
+        tabIndex={-1}
+        onClick={(e): void => e.stopPropagation()}
+        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl outline-none"
+      >
+        <header className="flex items-center justify-between border-b border-border px-5 py-3.5">
+          <h2 className="text-sm font-semibold text-fg">Impostazioni</h2>
+          <button
+            type="button"
+            onClick={closePanel}
+            aria-label="Chiudi impostazioni"
+            className="grid size-7 place-items-center rounded-md text-fg-muted transition hover:bg-bg-muted hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+          <section aria-labelledby="semantic-heading" className="space-y-4">
+            <div>
+              <h3 id="semantic-heading" className="text-[13px] font-semibold text-fg">
+                Ricerca semantica
+              </h3>
+              <p className="mt-1 text-[12px] leading-5 text-fg-muted">
+                Trova le note per significato, non solo per parole chiave. Gli embedding sono
+                calcolati in locale tramite Ollama: le tue note non lasciano il computer.
+              </p>
+            </div>
+
+            {error !== null && (
+              <p
+                role="alert"
+                className="rounded-md border border-border bg-bg-subtle px-3 py-2 text-[12px] text-fg"
+              >
+                {error}
+              </p>
+            )}
+
+            {/* Enable toggle */}
+            <label className="flex items-center justify-between gap-3 rounded-md border border-border bg-bg-subtle px-3 py-2.5">
+              <span className="min-w-0">
+                <span className="block text-[13px] font-medium text-fg">Attiva</span>
+                <span className="block text-[11px] text-fg-muted">
+                  Quando disattivata, nessun dato viene inviato a Ollama.
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                role="switch"
+                aria-label="Attiva ricerca semantica"
+                checked={enabled}
+                disabled={loading || saving}
+                onChange={(e): void => void save({ enabled: e.target.checked })}
+                className="size-4 shrink-0 accent-accent"
+              />
+            </label>
+
+            {/* Provider config */}
+            <div className="space-y-3" aria-disabled={!enabled}>
+              <Field
+                id="ollama-base-url"
+                label="URL Ollama"
+                value={baseUrl}
+                placeholder="http://localhost:11434"
+                disabled={saving}
+                onChange={setBaseUrl}
+                onCommit={(): void => {
+                  if (settings && baseUrl !== settings.baseUrl) void save({ baseUrl });
+                }}
+              />
+              <Field
+                id="ollama-model"
+                label="Modello"
+                value={model}
+                placeholder="nomic-embed-text"
+                disabled={saving}
+                onChange={setModel}
+                onCommit={(): void => {
+                  if (settings && model !== settings.model) void save({ model });
+                }}
+              />
+            </div>
+
+            {/* Status */}
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 rounded-md border border-border bg-bg-subtle px-3 py-3 text-[12px]">
+              <Stat label="Provider">
+                <StatusDot ok={status.providerOk} />
+                <span className="text-fg">
+                  {status.providerOk ? 'Raggiungibile' : 'Non raggiungibile'}
+                </span>
+              </Stat>
+              <Stat label="Indicizzate">
+                <span className="font-mono tabular-nums text-fg">
+                  {status.indexed} / {status.total}
+                </span>
+              </Stat>
+              <Stat label="Modello">
+                <span className="truncate font-mono text-[11px] text-fg-muted">
+                  {status.modelId || '—'}
+                </span>
+              </Stat>
+              <Stat label="Stato">
+                <span className="text-fg">
+                  {status.running ? `In corso (${pct}%)` : 'Inattivo'}
+                </span>
+              </Stat>
+            </dl>
+
+            {status.running && (
+              <div
+                className="h-1.5 w-full overflow-hidden rounded-full bg-bg-muted"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={pct}
+                aria-label="Avanzamento indicizzazione"
+              >
+                <div
+                  className="h-full bg-accent transition-[width] duration-300"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={(): void => void reindex()}
+              disabled={!enabled || status.running}
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-bg-subtle px-3 py-1.5 text-[12px] font-medium text-fg transition hover:bg-bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            >
+              <ArrowsClockwise size={14} aria-hidden="true" />
+              Reindicizza
+            </button>
+          </section>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function Field({
+  id,
+  label,
+  value,
+  placeholder,
+  disabled,
+  onChange,
+  onCommit,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onChange(v: string): void;
+  onCommit(): void;
+}): JSX.Element {
+  return (
+    <label htmlFor={id} className="block space-y-1">
+      <span className="block text-[12px] font-medium text-fg-muted">{label}</span>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        spellCheck={false}
+        autoComplete="off"
+        onChange={(e): void => onChange(e.target.value)}
+        onBlur={onCommit}
+        onKeyDown={(e): void => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            onCommit();
+          }
+        }}
+        className="h-8 w-full rounded-md border border-border bg-bg px-2.5 text-[12px] text-fg outline-none transition placeholder:text-fg-subtle focus:border-accent focus:ring-2 focus:ring-accent/25 disabled:opacity-50"
+      />
+    </label>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-[11px] text-fg-subtle">{label}</dt>
+      <dd className="flex items-center gap-1.5">{children}</dd>
+    </div>
+  );
+}
+
+function StatusDot({ ok }: { ok: boolean }): JSX.Element {
+  return (
+    <span
+      aria-hidden="true"
+      className={`size-2 shrink-0 rounded-full ${ok ? 'bg-emerald-500' : 'bg-rose-500'}`}
+    />
+  );
+}

--- a/apps/desktop/src/components/SettingsPanel/index.tsx
+++ b/apps/desktop/src/components/SettingsPanel/index.tsx
@@ -121,8 +121,10 @@ export function SettingsPanel(): JSX.Element | null {
               />
             </label>
 
-            {/* Provider config */}
-            <div className="space-y-3" aria-disabled={!enabled}>
+            {/* Provider config. Editable even when the feature is OFF —
+                configure-before-enable is a valid flow — so no disabled
+                signal on the group. */}
+            <div className="space-y-3">
               <Field
                 id="ollama-base-url"
                 label="URL Ollama"

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -3,6 +3,7 @@
 // keep the IPC contract enforced by the shared types.
 
 import type { Frontmatter, Note, NotePath, NoteSummary } from '@ziba/core';
+import type { EmbeddingStatus, SemanticSettings } from '@ziba/core';
 import type {
   Backlink,
   DatabaseQuery,
@@ -10,12 +11,14 @@ import type {
   DatabaseViewDefinition,
   DatabaseViewsChangedPayload,
   DatabaseViewsFile,
+  EmbeddingProgressPayload,
   FullGraph,
   IndexProgressPayload,
   LinkReferencesResult,
   ObjectTypeRow,
   RelationRow,
   SearchHit,
+  SemanticSearchResult,
   TagSummary,
   TypeCountRow,
   VaultEventPayload,
@@ -169,12 +172,32 @@ export const ipc = {
     return api().invoke(IpcChannels.getRecentVaults);
   },
 
+  // AI semantic search (milestone 1)
+  semanticSearch(args: { query: string; limit?: number }): Promise<SemanticSearchResult> {
+    return api().invoke(IpcChannels.semanticSearch, args);
+  },
+  getEmbeddingStatus(): Promise<EmbeddingStatus> {
+    return api().invoke(IpcChannels.getEmbeddingStatus);
+  },
+  reindexEmbeddings(): Promise<{ started: boolean }> {
+    return api().invoke(IpcChannels.reindexEmbeddings);
+  },
+  getSemanticSettings(): Promise<SemanticSettings> {
+    return api().invoke(IpcChannels.getSemanticSettings);
+  },
+  setSemanticSettings(args: { settings: Partial<SemanticSettings> }): Promise<SemanticSettings> {
+    return api().invoke(IpcChannels.setSemanticSettings, args);
+  },
+
   // Push subscriptions — return an unsubscribe function.
   onVaultEvent(listener: (payload: VaultEventPayload) => void): () => void {
     return api().onVaultEvent(listener);
   },
   onIndexProgress(listener: (payload: IndexProgressPayload) => void): () => void {
     return api().onIndexProgress(listener);
+  },
+  onEmbeddingProgress(listener: (payload: EmbeddingProgressPayload) => void): () => void {
+    return api().onEmbeddingProgress(listener);
   },
   onDatabaseViewsChanged(listener: (payload: DatabaseViewsChangedPayload) => void): () => void {
     return api().onDatabaseViewsChanged(listener);

--- a/apps/desktop/src/stores/semantic.ts
+++ b/apps/desktop/src/stores/semantic.ts
@@ -1,0 +1,102 @@
+import { create } from 'zustand';
+import type { EmbeddingStatus, SemanticSettings } from '@ziba/core';
+import type { EmbeddingProgressPayload } from '../../shared/ipc';
+import { ipc } from '../lib/ipc';
+import { ipcErrorMessage } from '../lib/ipc-error';
+
+// Renderer-side state for the semantic-search settings panel: the persisted
+// provider config + a live status snapshot (indexed/total, providerOk,
+// running). Status is refreshed on open and kept current by the
+// `embeddingProgress` push stream wired in App.tsx.
+
+const DEFAULT_STATUS: EmbeddingStatus = {
+  enabled: false,
+  indexed: 0,
+  total: 0,
+  running: false,
+  providerOk: false,
+  modelId: '',
+};
+
+type SemanticState = {
+  open: boolean;
+  settings: SemanticSettings | null;
+  status: EmbeddingStatus;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+
+  openPanel(): void;
+  closePanel(): void;
+  refresh(): Promise<void>;
+  save(patch: Partial<SemanticSettings>): Promise<void>;
+  reindex(): Promise<void>;
+  applyProgress(p: EmbeddingProgressPayload): void;
+};
+
+export const useSemanticStore = create<SemanticState>((set, get) => ({
+  open: false,
+  settings: null,
+  status: DEFAULT_STATUS,
+  loading: false,
+  saving: false,
+  error: null,
+
+  openPanel() {
+    set({ open: true, error: null });
+    void get().refresh();
+  },
+
+  closePanel() {
+    set({ open: false });
+  },
+
+  async refresh() {
+    set({ loading: true, error: null });
+    try {
+      const [settings, status] = await Promise.all([
+        ipc.getSemanticSettings(),
+        ipc.getEmbeddingStatus(),
+      ]);
+      set({ settings, status, loading: false });
+    } catch (err: unknown) {
+      set({ loading: false, error: ipcErrorMessage(err) });
+    }
+  },
+
+  async save(patch) {
+    set({ saving: true, error: null });
+    try {
+      const settings = await ipc.setSemanticSettings({ settings: patch });
+      set({ settings, saving: false });
+      // Pull a fresh status: toggling on triggers a pass / health check.
+      const status = await ipc.getEmbeddingStatus();
+      set({ status });
+    } catch (err: unknown) {
+      set({ saving: false, error: ipcErrorMessage(err) });
+    }
+  },
+
+  async reindex() {
+    set({ error: null });
+    try {
+      await ipc.reindexEmbeddings();
+      const status = await ipc.getEmbeddingStatus();
+      set({ status });
+    } catch (err: unknown) {
+      set({ error: ipcErrorMessage(err) });
+    }
+  },
+
+  applyProgress(p) {
+    set((s) => ({
+      status: {
+        ...s.status,
+        indexed: p.indexed,
+        total: p.total,
+        running: p.running,
+        providerOk: p.providerOk,
+      },
+    }));
+  },
+}));

--- a/apps/desktop/src/test/mock-ipc.ts
+++ b/apps/desktop/src/test/mock-ipc.ts
@@ -257,6 +257,9 @@ export function installMockIpc(overrides: MockHandlers = {}): MockController {
     }) as ZibaApi['invoke'],
     onVaultEvent: onVaultEventSpy as unknown as ZibaApi['onVaultEvent'],
     onIndexProgress: onIndexProgressSpy as unknown as ZibaApi['onIndexProgress'],
+    // No-op subscription: tests that need embedding progress can extend the
+    // mock; the default just registers and immediately unsubscribes.
+    onEmbeddingProgress: (() => () => {}) as ZibaApi['onEmbeddingProgress'],
     onDatabaseViewsChanged:
       onDatabaseViewsChangedSpy as unknown as ZibaApi['onDatabaseViewsChanged'],
   };

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -29,6 +29,7 @@ function makeFailingApi(): ZibaApi {
     invoke: ((channel: string) => fail(`invoke('${channel}')`)) as ZibaApi['invoke'],
     onVaultEvent: () => fail('onVaultEvent'),
     onIndexProgress: () => fail('onIndexProgress'),
+    onEmbeddingProgress: () => fail('onEmbeddingProgress'),
     onDatabaseViewsChanged: () => fail('onDatabaseViewsChanged'),
   };
 }

--- a/docs/superpowers/specs/2026-06-09-ai-semantic-search.md
+++ b/docs/superpowers/specs/2026-06-09-ai-semantic-search.md
@@ -1,0 +1,70 @@
+# Spec — Semantic Search (AI-native, milestone 1)
+
+## Context
+
+Ziba's differentiator vs Obsidian is **local-first + open-source + AI-native**: a second brain that reasons with you. Milestone 1 is **semantic search** — find notes by meaning, not keywords. It is the foundation for later milestones (ask-your-notes/RAG, AI-suggested links & properties).
+
+**Stance (decided with the user):** *Hybrid.* Embeddings are computed **locally** (notes never leave the machine); the heavy LLM layer (later milestones) is BYO-key. For embeddings v1 we use a **provider interface** so the concrete backend is swappable.
+
+- **v1 provider:** local **Ollama** embeddings endpoint (`POST {baseUrl}/api/embeddings`, default `http://localhost:11434`, model e.g. `nomic-embed-text` / `bge-m3`). HTTP-only, no native deps, fully local/private, easy to test.
+- **Next provider (separate follow-up):** bundled `transformers.js` (ONNX) local model for zero-setup — isolates the heavy electron-builder native-binary integration.
+
+## Architecture
+
+### Storage (`packages/core` schema + electron adapter)
+New table in `<vault>/.ziba/index.db`:
+```
+note_embeddings(
+  source_path TEXT PRIMARY KEY,
+  content_hash TEXT NOT NULL,   -- skip re-embed when unchanged
+  model_id TEXT NOT NULL,       -- provider+model; reindex on change
+  dim INTEGER NOT NULL,
+  vector BLOB NOT NULL,         -- Float32 little-endian
+  mtime INTEGER NOT NULL
+)
+```
+Keep `packages/core` pure TS: put the vector math (cosine, blob<->Float32) and the provider interface there; the SQLite adapter + Ollama HTTP live in `apps/desktop/electron`.
+
+### Provider interface (pure core)
+```
+interface EmbeddingProvider {
+  readonly id: string;            // e.g. "ollama:nomic-embed-text"
+  embed(texts: string[]): Promise<Float32Array[]>;
+}
+```
+- Core exports `cosineSimilarity`, `float32ToBlob`/`blobToFloat32`, `hashContent`, and a deterministic **fake provider** for tests.
+
+### Indexing pipeline (electron main)
+- On note create/save/rename/delete (same hooks as the existing indexer in `electron/adapters/index-store.sqlite.ts` + `reindexVault`), enqueue (re)embedding. Skip when `content_hash` + `model_id` unchanged. Delete embedding on note delete.
+- Debounced, batched, background; emit progress events (`{indexed, total, running}`) to the renderer.
+- For v1, embed a **truncated** note (title + first ~2k chars) — chunking is a RAG-milestone concern.
+- Initial full pass on vault open / on enabling the feature, with progress + cancellation.
+
+### IPC
+- `semanticSearch({query, limit}) -> [{path, title, score, snippet}]` — embed query, brute-force cosine over stored vectors (fine for thousands of notes), top-K.
+- `getEmbeddingStatus() -> {enabled, indexed, total, running, providerOk, modelId}`.
+- `reindexEmbeddings()` — force full rebuild.
+- Settings: enable/disable, provider base URL + model, status/progress, reindex button.
+
+### Search UI
+- Extend the existing palette (`stores/search.ts` `runSearch` → `ipc.searchFullText`): add a **semantic mode** (toggle, or a blended keyword+semantic ranking). Show score + snippet. Reuse `SearchPalette` UI + `EmptyView`/no-results.
+- Clear states: feature disabled, provider unreachable (Ollama not running) → actionable message, indexing in progress.
+
+## Edge cases
+- Provider unreachable / Ollama down → graceful, actionable error; never crash; degrade to keyword search.
+- Large vault → batch + progress + cancel; don't block UI (main-process batching with yields; worker thread optional later).
+- Multilingual (Italian) → choose a multilingual model in defaults.
+- Empty/huge notes → truncate; skip empty.
+- Vault switch → embeddings live in that vault's `.ziba`; reset in-memory state.
+- Model change → `model_id` mismatch triggers reindex.
+- First run / offline → no model download in v1 (Ollama path), clear setup hint.
+
+## Milestones
+1. **(this PR) Foundation, no fancy UI:** schema + core vector utils + provider interface + Ollama provider + indexing pipeline + IPC + status + minimal settings + tests (deterministic fake provider).
+2. **Palette semantic mode + settings polish.**
+3. **(follow-up) Bundled transformers.js provider** (zero-setup local model).
+Later milestones: ask-your-notes (RAG), AI-suggested links/properties.
+
+## Verification
+- `pnpm -C packages/core test` (vector math, hashing, fake-provider search ranking) + `pnpm -C apps/desktop typecheck/lint/test`.
+- Manual: run Ollama locally, enable feature, index the demo vault, search by meaning, confirm semantically-related notes rank above keyword matches; confirm graceful behavior with Ollama stopped.

--- a/packages/core/src/adapters/index-store.ts
+++ b/packages/core/src/adapters/index-store.ts
@@ -241,7 +241,60 @@ export interface IndexStoreAdapter {
   deleteObjectType(id: string): Promise<void>;
 
   clear(): Promise<void>;
+
+  // ---- AI semantic search (milestone 1) -------------------------------
+  //
+  // These are OPTIONAL on the interface so non-SQLite / in-memory adapters
+  // (and existing tests) don't have to implement embeddings. Callers in the
+  // embedding pipeline guard with `'upsertEmbedding' in store` /
+  // optional-chaining before use.
+
+  /** Insert or replace a note's embedding row. */
+  upsertEmbedding?(row: EmbeddingStoreRow): Promise<void>;
+
+  /** Delete a note's embedding. No-op when absent. */
+  deleteEmbedding?(sourcePath: NotePath): Promise<void>;
+
+  /**
+   * Fingerprint for the skip-if-unchanged check: returns the stored
+   * content_hash + model_id for a path, or null if no embedding exists.
+   */
+  getEmbeddingMeta?(sourcePath: NotePath): Promise<EmbeddingMeta | null>;
+
+  /**
+   * All embeddings as decoded rows (path, title, vector, …) for the
+   * brute-force cosine scan. Title is joined from `notes` so the search
+   * result can show a label without a second round-trip.
+   */
+  getAllEmbeddings?(): Promise<EmbeddingStoreRow[]>;
+
+  /** Counts for the status surface: how many notes have an embedding, and total notes. */
+  getEmbeddingCounts?(): Promise<{ indexed: number; total: number }>;
+
+  /** Drop every embedding row (used by reindex / disable). */
+  clearEmbeddings?(): Promise<void>;
 }
+
+/**
+ * Row shape exchanged with the embedding store. `vector` is decoded
+ * (Float32Array); the SQLite layer (de)serializes the BLOB. `title` is
+ * empty on write (joined on read).
+ */
+export type EmbeddingStoreRow = {
+  sourcePath: NotePath;
+  title: string;
+  contentHash: string;
+  modelId: string;
+  dim: number;
+  vector: Float32Array;
+  mtimeMs: number;
+};
+
+/** Just enough to decide whether a note needs re-embedding. */
+export type EmbeddingMeta = {
+  contentHash: string;
+  modelId: string;
+};
 
 // Re-export the entry shape so callers can import it from this module.
 export type { RelationEntry };

--- a/packages/core/src/ai/fake-provider.test.ts
+++ b/packages/core/src/ai/fake-provider.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { FakeEmbeddingProvider } from './fake-provider.js';
+import { cosineSimilarity } from './vector.js';
+
+describe('FakeEmbeddingProvider', () => {
+  it('is deterministic: same input → same vector', async () => {
+    const p = new FakeEmbeddingProvider();
+    const [a] = await p.embed(['ciao mondo']);
+    const [b] = await p.embed(['ciao mondo']);
+    expect(Array.from(a!)).toEqual(Array.from(b!));
+  });
+
+  it('different inputs → different vectors', async () => {
+    const p = new FakeEmbeddingProvider();
+    const [a] = await p.embed(['gatto']);
+    const [b] = await p.embed(['quantistica']);
+    expect(Array.from(a!)).not.toEqual(Array.from(b!));
+  });
+
+  it('returns one vector per input, in order, all of the fixed dim', async () => {
+    const p = new FakeEmbeddingProvider(16);
+    const out = await p.embed(['x', 'y', 'z']);
+    expect(out).toHaveLength(3);
+    for (const v of out) expect(v.length).toBe(16);
+  });
+
+  it('produces unit-norm vectors so cosine ranking is well-behaved', async () => {
+    const p = new FakeEmbeddingProvider();
+    const [v] = await p.embed(['qualcosa']);
+    expect(cosineSimilarity(v!, v!)).toBeCloseTo(1, 5);
+  });
+
+  it('ranks similar strings closer than dissimilar ones', async () => {
+    // Shared-token strings should land nearer each other than an unrelated
+    // string — enough signal to test ranking order end-to-end.
+    const p = new FakeEmbeddingProvider();
+    const [base, near, far] = await p.embed([
+      'machine learning models',
+      'machine learning training',
+      'banana bread recipe',
+    ]);
+    const simNear = cosineSimilarity(base!, near!);
+    const simFar = cosineSimilarity(base!, far!);
+    expect(simNear).toBeGreaterThan(simFar);
+  });
+
+  it('has a stable id', () => {
+    expect(new FakeEmbeddingProvider().id).toBe('fake:hash-32');
+  });
+
+  it('handles empty string without throwing', async () => {
+    const p = new FakeEmbeddingProvider();
+    const [v] = await p.embed(['']);
+    expect(v!.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/ai/fake-provider.ts
+++ b/packages/core/src/ai/fake-provider.ts
@@ -8,10 +8,24 @@
 //   2. Token overlap → higher cosine similarity, so ranking order is
 //      testable without standing up Ollama.
 
-import { hashContent } from './vector.js';
 import type { EmbeddingProvider } from './types.js';
 
 const DEFAULT_DIM = 32;
+
+/**
+ * Tiny pure-JS FNV-1a hash → unsigned 32-bit int. NOT cryptographic — the
+ * fake provider only needs determinism + reasonable token spread, and core
+ * must stay free of the crypto builtin. Same input always yields the same value.
+ */
+function fnv1a(text: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    // h *= 16777619, kept in 32-bit range via Math.imul.
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
 
 export class FakeEmbeddingProvider implements EmbeddingProvider {
   readonly id: string;
@@ -33,16 +47,15 @@ export class FakeEmbeddingProvider implements EmbeddingProvider {
     // Empty input still needs a non-zero vector (cosine of a zero vector is
     // undefined); seed one dimension from the raw text hash.
     if (tokens.length === 0) {
-      const h = parseInt(hashContent(text).slice(0, 8), 16);
-      vec[h % this.dim] = 1;
+      vec[fnv1a(text) % this.dim] = 1;
       return vec;
     }
     for (const tok of tokens) {
-      // Two independent hash slices: one picks the bucket, one the sign,
-      // so distinct tokens spread across dimensions rather than piling up.
-      const h = hashContent(tok);
-      const bucket = parseInt(h.slice(0, 8), 16) % this.dim;
-      const sign = (parseInt(h.slice(8, 10), 16) & 1) === 0 ? 1 : -1;
+      // Two independent hashes (the token, and the token salted) so the
+      // bucket and the sign are uncorrelated — distinct tokens spread
+      // across dimensions rather than piling up on one.
+      const bucket = fnv1a(tok) % this.dim;
+      const sign = (fnv1a(`${tok}#sign`) & 1) === 0 ? 1 : -1;
       vec[bucket] = (vec[bucket] ?? 0) + sign;
     }
     // L2-normalize so every vector is unit length → cosine == dot product
@@ -57,8 +70,7 @@ export class FakeEmbeddingProvider implements EmbeddingProvider {
       for (let i = 0; i < this.dim; i++) vec[i] = (vec[i] ?? 0) / norm;
     } else {
       // Degenerate (e.g. tokens cancelled out); fall back to a hash seed.
-      const h = parseInt(hashContent(text).slice(0, 8), 16);
-      vec[h % this.dim] = 1;
+      vec[fnv1a(text) % this.dim] = 1;
     }
     return vec;
   }

--- a/packages/core/src/ai/fake-provider.ts
+++ b/packages/core/src/ai/fake-provider.ts
@@ -1,0 +1,65 @@
+// Deterministic, dependency-free embedding provider for tests.
+//
+// It is NOT a real semantic model — it's a hashed bag-of-words: each
+// whitespace token is hashed into a dimension and accumulated, then the
+// vector is L2-normalized. This gives the two properties our tests (and
+// the ranking pipeline) need:
+//   1. Determinism — same text always yields the same vector.
+//   2. Token overlap → higher cosine similarity, so ranking order is
+//      testable without standing up Ollama.
+
+import { hashContent } from './vector.js';
+import type { EmbeddingProvider } from './types.js';
+
+const DEFAULT_DIM = 32;
+
+export class FakeEmbeddingProvider implements EmbeddingProvider {
+  readonly id: string;
+  private readonly dim: number;
+
+  constructor(dim: number = DEFAULT_DIM) {
+    this.dim = dim;
+    this.id = `fake:hash-${dim}`;
+  }
+
+  embed(texts: string[]): Promise<Float32Array[]> {
+    return Promise.resolve(texts.map((t) => this.embedOne(t)));
+  }
+
+  private embedOne(text: string): Float32Array {
+    const vec = new Float32Array(this.dim);
+    // Tokenize loosely; lowercase so casing doesn't fragment the bag.
+    const tokens = text.toLowerCase().split(/\W+/).filter(Boolean);
+    // Empty input still needs a non-zero vector (cosine of a zero vector is
+    // undefined); seed one dimension from the raw text hash.
+    if (tokens.length === 0) {
+      const h = parseInt(hashContent(text).slice(0, 8), 16);
+      vec[h % this.dim] = 1;
+      return vec;
+    }
+    for (const tok of tokens) {
+      // Two independent hash slices: one picks the bucket, one the sign,
+      // so distinct tokens spread across dimensions rather than piling up.
+      const h = hashContent(tok);
+      const bucket = parseInt(h.slice(0, 8), 16) % this.dim;
+      const sign = (parseInt(h.slice(8, 10), 16) & 1) === 0 ? 1 : -1;
+      vec[bucket] = (vec[bucket] ?? 0) + sign;
+    }
+    // L2-normalize so every vector is unit length → cosine == dot product
+    // and self-similarity is exactly 1.
+    let norm = 0;
+    for (let i = 0; i < this.dim; i++) {
+      const x = vec[i] ?? 0;
+      norm += x * x;
+    }
+    norm = Math.sqrt(norm);
+    if (norm > 0) {
+      for (let i = 0; i < this.dim; i++) vec[i] = (vec[i] ?? 0) / norm;
+    } else {
+      // Degenerate (e.g. tokens cancelled out); fall back to a hash seed.
+      const h = parseInt(hashContent(text).slice(0, 8), 16);
+      vec[h % this.dim] = 1;
+    }
+    return vec;
+  }
+}

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './vector.js';
+export * from './rank.js';
+export * from './fake-provider.js';

--- a/packages/core/src/ai/rank.test.ts
+++ b/packages/core/src/ai/rank.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { rankBySimilarity } from './rank.js';
+import type { EmbeddingRow } from './types.js';
+
+function row(path: string, vector: number[]): EmbeddingRow {
+  return {
+    path,
+    title: path,
+    contentHash: 'h',
+    modelId: 'fake',
+    dim: vector.length,
+    vector: new Float32Array(vector),
+    mtimeMs: 0,
+  };
+}
+
+describe('rankBySimilarity', () => {
+  const rows: EmbeddingRow[] = [
+    row('a.md', [1, 0, 0]),
+    row('b.md', [0.9, 0.1, 0]),
+    row('c.md', [0, 1, 0]),
+    row('d.md', [-1, 0, 0]),
+  ];
+
+  it('orders by descending cosine similarity', () => {
+    const query = new Float32Array([1, 0, 0]);
+    const out = rankBySimilarity(query, rows, 10);
+    expect(out.map((r) => r.path)).toEqual(['a.md', 'b.md', 'c.md', 'd.md']);
+    expect(out[0]!.score).toBeGreaterThan(out[1]!.score);
+  });
+
+  it('respects the limit (top-K)', () => {
+    const query = new Float32Array([1, 0, 0]);
+    const out = rankBySimilarity(query, rows, 2);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.path)).toEqual(['a.md', 'b.md']);
+  });
+
+  it('returns each hit with path, title and score', () => {
+    const out = rankBySimilarity(new Float32Array([1, 0, 0]), rows, 1);
+    expect(out[0]).toMatchObject({ path: 'a.md', title: 'a.md' });
+    expect(typeof out[0]!.score).toBe('number');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(rankBySimilarity(new Float32Array([1, 0, 0]), [], 5)).toEqual([]);
+  });
+
+  it('skips rows whose dim does not match the query (stale model)', () => {
+    const mixed = [...rows, row('wrong.md', [1, 0])];
+    const out = rankBySimilarity(new Float32Array([1, 0, 0]), mixed, 10);
+    expect(out.map((r) => r.path)).not.toContain('wrong.md');
+  });
+
+  it('clamps a non-positive limit to at least one result', () => {
+    const out = rankBySimilarity(new Float32Array([1, 0, 0]), rows, 0);
+    expect(out.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/core/src/ai/rank.ts
+++ b/packages/core/src/ai/rank.ts
@@ -1,0 +1,33 @@
+// Pure top-K ranking by cosine similarity. The brute-force scan is fine
+// for thousands of notes (the spec's target); a vector index is a later
+// optimization if vaults grow into the tens of thousands.
+
+import { cosineSimilarity } from './vector.js';
+import type { EmbeddingRow, SemanticHit } from './types.js';
+
+/**
+ * Score every row against `queryVec`, return the top `limit` as
+ * `SemanticHit`s (without snippet — the caller fills that from note
+ * content). Rows whose `dim` differs from the query are skipped: they were
+ * embedded by a different model and aren't comparable (cosineSimilarity
+ * would return 0 anyway, but skipping is clearer and slightly cheaper).
+ */
+export function rankBySimilarity(
+  queryVec: Float32Array,
+  rows: readonly EmbeddingRow[],
+  limit: number,
+): SemanticHit[] {
+  const safeLimit = Math.max(1, Math.floor(limit) || 1);
+  const scored: SemanticHit[] = [];
+  for (const r of rows) {
+    if (r.vector.length !== queryVec.length) continue;
+    scored.push({
+      path: r.path,
+      title: r.title,
+      score: cosineSimilarity(queryVec, r.vector),
+      snippet: '',
+    });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, safeLimit);
+}

--- a/packages/core/src/ai/types.ts
+++ b/packages/core/src/ai/types.ts
@@ -1,0 +1,96 @@
+// Pure-TS types + interfaces for the semantic-search foundation.
+//
+// This module is driver-agnostic: no SQLite, no Electron, no `fetch`
+// implementation. The Electron adapter (`apps/desktop/electron/ai/`) and
+// the SQLite store provide the concrete I/O; this file only describes the
+// shapes that cross those boundaries so both sides type-check against one
+// source of truth.
+
+import type { NotePath } from '../types/note.js';
+
+/**
+ * Pluggable embedding backend. v1's concrete implementation is the Ollama
+ * HTTP provider; tests use a deterministic fake. Keeping this an interface
+ * (not a class) lets us swap in bundled transformers.js later without
+ * touching the indexing pipeline.
+ */
+export interface EmbeddingProvider {
+  /**
+   * Stable identifier combining provider + model, e.g.
+   * `"ollama:nomic-embed-text"`. Persisted alongside each vector as
+   * `model_id`; a mismatch on read triggers a re-embed (vectors from
+   * different models aren't comparable).
+   */
+  readonly id: string;
+
+  /**
+   * Embed a batch of texts. Returns one Float32Array per input, in order.
+   * Implementations MUST preserve order and length (`out.length === texts.length`).
+   * May reject if the backend is unreachable — callers degrade gracefully.
+   */
+  embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+/**
+ * A persisted embedding row, mirroring the `note_embeddings` table. The
+ * `vector` is the decoded Float32Array (the SQLite layer stores it as a
+ * little-endian BLOB and decodes on read).
+ */
+export type EmbeddingRow = {
+  path: NotePath;
+  title: string;
+  contentHash: string;
+  modelId: string;
+  dim: number;
+  vector: Float32Array;
+  mtimeMs: number;
+};
+
+/** A single semantic-search result returned to the renderer. */
+export type SemanticHit = {
+  path: NotePath;
+  title: string;
+  /** Cosine similarity in [-1, 1]; higher is more similar. */
+  score: number;
+  /** Short body excerpt for display. Plain text, no highlight markup. */
+  snippet: string;
+};
+
+/**
+ * Status snapshot for the settings UI + search palette. `providerOk`
+ * reflects the last health check; `running` is true while a full/batch
+ * pass is in flight.
+ */
+export type EmbeddingStatus = {
+  enabled: boolean;
+  indexed: number;
+  total: number;
+  running: boolean;
+  providerOk: boolean;
+  modelId: string;
+};
+
+/**
+ * Per-app (not per-vault) provider configuration. Persisted in userData
+ * the same way recent-vaults is; the embeddings themselves live per-vault
+ * in `<vault>/.ziba/index.db`.
+ */
+export type SemanticSettings = {
+  enabled: boolean;
+  baseUrl: string;
+  model: string;
+};
+
+/** Built-in defaults. Multilingual model so Italian notes embed sensibly. */
+export const DEFAULT_SEMANTIC_SETTINGS: SemanticSettings = {
+  enabled: false,
+  baseUrl: 'http://localhost:11434',
+  model: 'nomic-embed-text',
+};
+
+/**
+ * Max characters of (title + body) we feed the embedder in v1. Chunking is
+ * a later RAG-milestone concern; for "find by meaning" a truncated head is
+ * plenty and keeps embedding cost bounded.
+ */
+export const EMBED_TEXT_MAX_CHARS = 2000;

--- a/packages/core/src/ai/vector.test.ts
+++ b/packages/core/src/ai/vector.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  blobToFloat32,
-  cosineSimilarity,
-  float32ToBlob,
-  hashContent,
-  prepareEmbedText,
-} from './vector.js';
+import { blobToFloat32, cosineSimilarity, float32ToBlob, prepareEmbedText } from './vector.js';
 
 describe('cosineSimilarity', () => {
   it('returns 1 for identical vectors (identity)', () => {
@@ -72,20 +66,6 @@ describe('float32ToBlob / blobToFloat32', () => {
   it('round-trips an empty vector', () => {
     const back = blobToFloat32(float32ToBlob(new Float32Array([])));
     expect(back.length).toBe(0);
-  });
-});
-
-describe('hashContent', () => {
-  it('is stable: same input → same hash', () => {
-    expect(hashContent('ciao mondo')).toBe(hashContent('ciao mondo'));
-  });
-
-  it('differs for different input', () => {
-    expect(hashContent('a')).not.toBe(hashContent('b'));
-  });
-
-  it('returns a hex string', () => {
-    expect(hashContent('x')).toMatch(/^[0-9a-f]+$/);
   });
 });
 

--- a/packages/core/src/ai/vector.test.ts
+++ b/packages/core/src/ai/vector.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blobToFloat32,
+  cosineSimilarity,
+  float32ToBlob,
+  hashContent,
+  prepareEmbedText,
+} from './vector.js';
+
+describe('cosineSimilarity', () => {
+  it('returns 1 for identical vectors (identity)', () => {
+    const a = new Float32Array([1, 2, 3, 4]);
+    expect(cosineSimilarity(a, a)).toBeCloseTo(1, 6);
+  });
+
+  it('is symmetric: cos(a,b) === cos(b,a)', () => {
+    const a = new Float32Array([0.2, -0.5, 0.9, 0.1]);
+    const b = new Float32Array([0.7, 0.3, -0.2, 0.8]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(cosineSimilarity(b, a), 6);
+  });
+
+  it('returns 0 for orthogonal vectors', () => {
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([0, 1]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0, 6);
+  });
+
+  it('returns -1 for opposite vectors', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const b = new Float32Array([-1, -2, -3]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1, 6);
+  });
+
+  it('is scale-invariant', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const b = new Float32Array([2, 4, 6]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(1, 6);
+  });
+
+  it('returns 0 when either vector is all-zero (avoids NaN)', () => {
+    const a = new Float32Array([0, 0, 0]);
+    const b = new Float32Array([1, 2, 3]);
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  it('returns 0 on length mismatch rather than throwing', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const b = new Float32Array([1, 2]);
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+});
+
+describe('float32ToBlob / blobToFloat32', () => {
+  it('round-trips a vector exactly', () => {
+    const v = new Float32Array([0, 1, -1, 0.5, -0.25, 3.14159, 1e-7, -2e8]);
+    const blob = float32ToBlob(v);
+    const back = blobToFloat32(blob);
+    expect(Array.from(back)).toEqual(Array.from(v));
+  });
+
+  it('produces a little-endian byte layout', () => {
+    // 1.0 in IEEE-754 little-endian is 00 00 80 3F.
+    const blob = float32ToBlob(new Float32Array([1]));
+    expect(Array.from(blob)).toEqual([0x00, 0x00, 0x80, 0x3f]);
+  });
+
+  it('blob length is 4 bytes per element', () => {
+    const v = new Float32Array([1, 2, 3, 4, 5]);
+    expect(float32ToBlob(v).length).toBe(20);
+  });
+
+  it('round-trips an empty vector', () => {
+    const back = blobToFloat32(float32ToBlob(new Float32Array([])));
+    expect(back.length).toBe(0);
+  });
+});
+
+describe('hashContent', () => {
+  it('is stable: same input → same hash', () => {
+    expect(hashContent('ciao mondo')).toBe(hashContent('ciao mondo'));
+  });
+
+  it('differs for different input', () => {
+    expect(hashContent('a')).not.toBe(hashContent('b'));
+  });
+
+  it('returns a hex string', () => {
+    expect(hashContent('x')).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe('prepareEmbedText', () => {
+  it('combines title and body', () => {
+    expect(prepareEmbedText('Titolo', 'corpo')).toContain('Titolo');
+    expect(prepareEmbedText('Titolo', 'corpo')).toContain('corpo');
+  });
+
+  it('truncates to the max length', () => {
+    const long = 'x'.repeat(5000);
+    expect(prepareEmbedText('T', long).length).toBeLessThanOrEqual(2000);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(prepareEmbedText('  T  ', '  body  ')).toBe('T\n\nbody');
+  });
+});

--- a/packages/core/src/ai/vector.ts
+++ b/packages/core/src/ai/vector.ts
@@ -1,0 +1,85 @@
+// Pure vector math + (de)serialization for embeddings. No driver, no
+// Electron — just numbers and bytes, so it's trivially unit-testable and
+// reusable from either process.
+//
+// `node:crypto` is the one Node builtin we lean on (for a stable content
+// hash). It's available everywhere this package runs (main process, tests)
+// and avoids pulling a hashing dependency into core.
+
+import { createHash } from 'node:crypto';
+import { EMBED_TEXT_MAX_CHARS } from './types.js';
+
+/**
+ * Cosine similarity of two equal-length vectors, in [-1, 1].
+ *
+ * Defensive returns of `0` (rather than throwing / NaN) for the two
+ * degenerate cases — a zero-magnitude vector or a length mismatch — so the
+ * brute-force ranking loop never has to special-case them. A length
+ * mismatch shouldn't happen (all vectors share a model's `dim`), but a
+ * model change mid-index could leave stale rows; returning 0 ranks them
+ * last instead of crashing the search.
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!;
+    const y = b[i]!;
+    dot += x * y;
+    normA += x * x;
+    normB += y * y;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Serialize a Float32Array to a little-endian byte buffer for BLOB storage.
+ * We force little-endian explicitly (rather than relying on the platform's
+ * native order via `.buffer`) so a vault is portable across architectures.
+ */
+export function float32ToBlob(vec: Float32Array): Uint8Array {
+  const out = new Uint8Array(vec.length * 4);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < vec.length; i++) {
+    view.setFloat32(i * 4, vec[i]!, true /* little-endian */);
+  }
+  return out;
+}
+
+/**
+ * Decode a little-endian BLOB back into a Float32Array. Accepts any
+ * ArrayBuffer-view-like input (better-sqlite3 hands back a `Buffer`).
+ */
+export function blobToFloat32(blob: Uint8Array): Float32Array {
+  const count = Math.floor(blob.byteLength / 4);
+  const view = new DataView(blob.buffer, blob.byteOffset, count * 4);
+  const out = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    out[i] = view.getFloat32(i * 4, true /* little-endian */);
+  }
+  return out;
+}
+
+/**
+ * Stable content hash. SHA-256 hex — collision-resistant enough that an
+ * unchanged note reliably skips re-embedding, and a single edited byte
+ * reliably triggers one.
+ */
+export function hashContent(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+/**
+ * Build the text we actually embed for a note: title + body, truncated to
+ * `EMBED_TEXT_MAX_CHARS`. Title leads so it dominates short-note
+ * similarity; the body fills the rest. Whitespace-trimmed on both pieces.
+ */
+export function prepareEmbedText(title: string, body: string): string {
+  const combined = `${title.trim()}\n\n${body.trim()}`.trim();
+  return combined.length > EMBED_TEXT_MAX_CHARS
+    ? combined.slice(0, EMBED_TEXT_MAX_CHARS)
+    : combined;
+}

--- a/packages/core/src/ai/vector.ts
+++ b/packages/core/src/ai/vector.ts
@@ -1,12 +1,10 @@
 // Pure vector math + (de)serialization for embeddings. No driver, no
-// Electron — just numbers and bytes, so it's trivially unit-testable and
-// reusable from either process.
+// Electron, NO Node builtins — just numbers and bytes, so this package
+// stays bundleable for web + mobile reuse and is trivially unit-testable.
 //
-// `node:crypto` is the one Node builtin we lean on (for a stable content
-// hash). It's available everywhere this package runs (main process, tests)
-// and avoids pulling a hashing dependency into core.
+// Content hashing (SHA-256) lives in the Electron host, not here, to keep
+// core free of the crypto builtin. The fake provider uses its own pure-JS hash.
 
-import { createHash } from 'node:crypto';
 import { EMBED_TEXT_MAX_CHARS } from './types.js';
 
 /**
@@ -61,15 +59,6 @@ export function blobToFloat32(blob: Uint8Array): Float32Array {
     out[i] = view.getFloat32(i * 4, true /* little-endian */);
   }
   return out;
-}
-
-/**
- * Stable content hash. SHA-256 hex — collision-resistant enough that an
- * unchanged note reliably skips re-embedding, and a single edited byte
- * reliably triggers one.
- */
-export function hashContent(text: string): string {
-  return createHash('sha256').update(text, 'utf8').digest('hex');
 }
 
 /**

--- a/packages/core/src/index-store/schema.ts
+++ b/packages/core/src/index-store/schema.ts
@@ -117,6 +117,25 @@ CREATE INDEX IF NOT EXISTS idx_note_props_key    ON note_properties(prop_key);
 CREATE INDEX IF NOT EXISTS idx_note_props_text   ON note_properties(prop_key, text_value);
 CREATE INDEX IF NOT EXISTS idx_note_props_number ON note_properties(prop_key, number_value);
 CREATE INDEX IF NOT EXISTS idx_note_props_date   ON note_properties(prop_key, date_value);
+
+-- AI semantic search (milestone 1). One embedding vector per note.
+-- \`content_hash\` + \`model_id\` let the indexer skip a note whose body and
+-- embedding model are both unchanged. \`vector\` is a Float32 little-endian
+-- BLOB (see \`float32ToBlob\` in core/ai). This table is additive — a new
+-- table needs no \`user_version\` bump (IF NOT EXISTS handles fresh + upgraded
+-- vaults). The data is a pure cache: deleting it just forces a re-embed.
+--
+-- No FK to \`notes\`: embeddings are written by an async background pass that
+-- can lag the notes upsert, and we don't want a missing-parent race to throw.
+-- The pipeline deletes the embedding explicitly on note delete instead.
+CREATE TABLE IF NOT EXISTS note_embeddings (
+  source_path  TEXT PRIMARY KEY,
+  content_hash TEXT NOT NULL,
+  model_id     TEXT NOT NULL,
+  dim          INTEGER NOT NULL,
+  vector       BLOB NOT NULL,
+  mtime        INTEGER NOT NULL
+);
 `.trim();
 
 /**
@@ -154,6 +173,7 @@ DROP TABLE IF EXISTS relations;
 DROP TABLE IF EXISTS object_types;
 DROP TABLE IF EXISTS notes_fts;
 DROP TABLE IF EXISTS note_properties;
+DROP TABLE IF EXISTS note_embeddings;
 DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS notes;
 `.trim();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from './adapters/index.js';
 export * from './markdown/index.js';
 export * from './vault/index.js';
 export * from './index-store/index.js';
+export * from './ai/index.js';
 export { SEED_SCHEMAS, SEED_SCHEMA_IDS, type SeedSchemaId } from './seed-schemas/index.js';
 export { EXPECTED_USER_VERSION, MIGRATION_DROP_SQL } from './index-store/schema.js';
 export type {


### PR DESCRIPTION
First step of the **AI-native** direction: local-first semantic search. Spec: `docs/superpowers/specs/2026-06-09-ai-semantic-search.md`. This is the **foundation** (no palette UI yet — milestone 2).

## What
- **Local embeddings, hybrid stance** — notes never leave the machine. Provider behind an interface; v1 concrete = **local Ollama** (`/api/embeddings`, default `localhost:11434` / `nomic-embed-text`). Bundled zero-setup transformers.js model is the next provider.
- **Storage** — `note_embeddings` table in the per-vault `.ziba/index.db` (Float32 blob + content-hash + model-id to skip unchanged).
- **Indexing** — background, debounced (800ms) + batched, hooked into the existing save/create/rename/delete pipeline; skip-if-unchanged; per-vault lifecycle; progress events mirroring the existing index-progress.
- **IPC** — `semanticSearch` / `getEmbeddingStatus` / `reindexEmbeddings` / settings get-set, wired through every layer. `semanticSearch` returns a typed `{ok:false, reason}` union — never throws across the bridge.
- **Settings panel** (from the Ribbon gear) — enable toggle, Ollama baseUrl/model, provider-reachable status, indexed/total + progress, "Reindicizza".
- **Default OFF** — zero Ollama calls / zero indexing until you opt in; degrades gracefully when Ollama is down.

## Pure core
`packages/core/src/ai` stays pure TS (no Node builtins — verified): cosine, blob<->Float32 (little-endian), ranking, provider interface, deterministic FakeEmbeddingProvider for tests.

## Verification
- core 201 tests + desktop typecheck/lint + 560 desktop tests green. Reviewed (NEEDS CHANGES → fixed): core-purity (node:crypto moved out), teardown race (vault switch mid-pass can't write to a closed DB), + 14 new EmbeddingIndexer tests.

## Try it
Run Ollama (`ollama pull nomic-embed-text`), open Settings → enable, let it index, then (milestone 2) search by meaning in the palette.

## Next
Milestone 2: palette "semantic mode". Follow-up: bundled transformers.js provider (zero-setup). Then RAG (ask-your-notes) + AI-suggested links/properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)